### PR TITLE
fix(patterns): match imperatives behind markdown list markers

### DIFF
--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -48,8 +48,12 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Efficiency patterns
 # ---------------------------------------------------------------------------
+# Leading list marker: numbered ("1. ", "12. ") OR bullet ("- ", "* ", "+ ").
+# Applied as an optional prefix so bare imperatives still match.
+_LIST_MARKER = r"(?:\d+\.\s*|[-*+]\s+)?"
+
 _RE_ACTIONABLE_LINES = re.compile(
-    r"^(?:\d+\.\s*)?(?:Read|Run|Check|Create|Add|Remove|Move|Use|Set|"
+    r"^" + _LIST_MARKER + r"(?:Read|Run|Check|Create|Add|Remove|Move|Use|Set|"
     r"Install|Configure|Deploy|Test|Verify|Build|Start|Stop|Open|Save|"
     r"Copy|Delete|Write|Edit|Update|Generate|Execute|Validate|Parse|"
     r"Extract|Transform|Import|Export|Send|Fetch|Call|Return|"
@@ -90,7 +94,7 @@ _RE_AMBIGUOUS_PRONOUN = re.compile(
     r"^\s*(It|This|That)\s+(is|does|will|can|should|has|was|means)\b"
 )
 _RE_RUN_PATTERN = re.compile(
-    r"^\s*(?:\d+\.\s*)?(?:Run|Execute|Install|Configure)\s+(.+)", re.IGNORECASE
+    r"^\s*" + _LIST_MARKER + r"(?:Run|Execute|Install|Configure)\s+(.+)", re.IGNORECASE
 )
 _RE_CONCEPTUAL = re.compile(
     r"(?i)(baseline|all\s+\d+|VERIFY|evolution|"
@@ -198,7 +202,7 @@ _RE_SEC_BOUNDARY_VIOLATION = re.compile(
 # Diff patterns
 # ---------------------------------------------------------------------------
 _RE_DIFF_SIGNAL = re.compile(
-    r"^(?:\d+\.\s*)?(?:Read|Run|Check|Create|Add|Remove|Move|Use|Set|"
+    r"^" + _LIST_MARKER + r"(?:Read|Run|Check|Create|Add|Remove|Move|Use|Set|"
     r"Install|Configure|Deploy|Test|Verify|Build|Start|Stop|Open|Save|"
     r"Copy|Delete|Write|Edit|Update|Generate|Execute|Validate|Parse|"
     r"Extract|Transform|Import|Export|Send|Fetch|Call|Return)\b",
@@ -218,7 +222,7 @@ _RE_DIFF_NOISE = re.compile(
 # Coherence patterns
 # ---------------------------------------------------------------------------
 _RE_IMPERATIVE_INSTRUCTION = re.compile(
-    r"^\s*(?:\d+\.\s*)?(?:Run|Create|Add|Check|Remove|Move|Use|Set|Install|"
+    r"^\s*" + _LIST_MARKER + r"(?:Run|Create|Add|Check|Remove|Move|Use|Set|Install|"
     r"Configure|Deploy|Test|Verify|Build|Start|Stop|Open|Save|Copy|Delete|"
     r"Write|Edit|Update|Generate|Execute|Validate|Parse|Extract|Transform|"
     r"Import|Export|Send|Fetch|Call|Return)\b(.+)",

--- a/skills/schliff/tests/unit/test_patterns.py
+++ b/skills/schliff/tests/unit/test_patterns.py
@@ -511,3 +511,89 @@ class TestEfficiencyDedup:
         content = "Run the build\nRUN the build\nrun the build\n"
         # All match 'Run'/'RUN'/'run', lowercase[:60] -> all 'run'
         assert self._count_actionable(content) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. List-marker support in _RE_ACTIONABLE_LINES
+# ---------------------------------------------------------------------------
+
+class TestListMarkerSupport:
+    """Tests for leading markdown list-marker support in _RE_ACTIONABLE_LINES.
+
+    Markdown documents commonly list actionable steps as bullet items
+    (`- Install X`, `* Use Y`) or numbered items (`1. Run Z`). The pattern
+    must match both styles so imperatives aren't silently dropped for
+    files that prefer bullets over numbers.
+
+    These tests exercise the production per-line match loop from
+    efficiency.py (line 50), which differs from the dedup helper above
+    in that it matches against `line.strip()` and dedups on full-line
+    content rather than on the captured verb token.
+    """
+
+    def _count_actionable_via_match(self, content: str) -> int:
+        """Replicate efficiency.py's production per-line match loop."""
+        seen = set()
+        for line in content.split("\n"):
+            if _RE_ACTIONABLE_LINES.match(line.strip()):
+                seen.add(line.strip().lower()[:80])
+        return len(seen)
+
+    # --- Supported list markers ---
+
+    def test_numbered_list_imperatives_match(self):
+        content = "1. Run the build\n2. Install deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    def test_dash_bullet_imperatives_match(self):
+        content = "- Run the build\n- Install deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    def test_asterisk_bullet_imperatives_match(self):
+        content = "* Run the build\n* Install deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    def test_plus_bullet_imperatives_match(self):
+        content = "+ Run the build\n+ Install deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    # --- Regression: bare imperatives still work ---
+
+    def test_bare_imperatives_still_match(self):
+        content = "Run the build\nInstall deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    # --- Nested lists (strip removes leading whitespace) ---
+
+    def test_indented_bullet_imperatives_match(self):
+        content = "  - Run the build\n    - Install deps\n"
+        assert self._count_actionable_via_match(content) == 2
+
+    # --- False-positive guards ---
+
+    def test_bullet_without_space_does_not_match(self):
+        """A '-' with no whitespace after is not a list marker."""
+        content = "-Run the build\n"
+        assert self._count_actionable_via_match(content) == 0
+
+    def test_bullet_without_imperative_does_not_match(self):
+        """List marker alone is not enough — verb must follow."""
+        content = "- The build pipeline is fast\n* A description line\n"
+        assert self._count_actionable_via_match(content) == 0
+
+    def test_word_boundary_prevents_partial_match(self):
+        """'Running' must not match 'Run' due to \\b."""
+        content = "- Running tests takes time\n"
+        assert self._count_actionable_via_match(content) == 0
+
+    # --- Mixed content ---
+
+    def test_mixed_markers_and_prose(self):
+        content = (
+            "This skill analyzes code.\n"
+            "- Run the score script to get results.\n"
+            "1. Check the issues list for details.\n"
+            "* Install any missing deps first.\n"
+            "The output shows dimension scores.\n"
+        )
+        assert self._count_actionable_via_match(content) == 3


### PR DESCRIPTION
## Summary

`_RE_ACTIONABLE_LINES` and three sibling patterns in `patterns/base.py` missed imperatives prefixed with markdown bullets (`- Run X`, `* Use Y`, `+ Install Z`). Only numbered lists (`1. Run X`) and bare imperatives matched. This systematically under-counted `actionable_lines` in any file that uses bullet lists for procedures — i.e. most project `CLAUDE.md` files in practice.

## The fix

Extracted a shared `_LIST_MARKER` alternation (`(?:\d+\.\s*|[-*+]\s+)?`) and applied it to all four affected patterns:

- `_RE_ACTIONABLE_LINES` — efficiency
- `_RE_RUN_PATTERN` — clarity
- `_RE_DIFF_SIGNAL` — diff
- `_RE_IMPERATIVE_INSTRUCTION` — coherence

Behavior preserved for bare imperatives, numbered lists, and word boundaries. False-positive guards verified: `-Run X` (no space) does not match; `- The build is fast` does not match; `- Running tests` does not match (word boundary).

## Real-world impact

Measured against the root `CLAUDE.md` merged into `modelcontextprotocol/servers` via [PR #3733](https://github.com/modelcontextprotocol/servers/pull/3733):

| Dimension | Before | After |
|-----------|--------|-------|
| efficiency | 57 | **64** (+7) |
| composite | 59.2 | **61.0** (+1.8) |

Two `- Build...` lines in the merged MCP file were silently uncounted under the previous pattern (L34 `- Build: \`tsc\`...`, L53 `- Build system: **hatchling** (\`uv build\`)`).

## Tests

- New `TestListMarkerSupport` class with 10 cases: supported markers (dash/asterisk/plus/numbered), regression on bare imperatives, nested indentation, and three false-positive guards
- Full suite: **1017 passed** (up from 1007)

## Context

Surfaced while writing a [self-review](https://fpaul.dev/writing/scoring-my-own-mcp-contribution/) of the merged MCP PR — the blog post calls out the scorer's blindspot on bullet-prefixed imperatives. This PR closes the blindspot the post identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)