### PR TITLE
chore(release): v7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Schliff are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.1.1] - 2026-04-18
+
+### Fixed
+- **List-marker support in actionable-line patterns**: `_RE_ACTIONABLE_LINES` and three sibling patterns (`_RE_RUN_PATTERN`, `_RE_DIFF_SIGNAL`, `_RE_IMPERATIVE_INSTRUCTION`) previously only matched numbered list prefixes (`1. Run X`) or bare imperatives, silently dropping markdown bullets (`- Run X`, `* Use Y`, `+ Install Z`). A shared `_LIST_MARKER` alternation is now applied to all four. Impact on a real public CLAUDE.md (root file merged into `modelcontextprotocol/servers`): efficiency 57 → 64, composite 59.2 → 61.0.
+- **10 new regression and false-positive tests** in `TestListMarkerSupport` covering supported markers, bare-imperative regression, nested indentation, word-boundary guards, and marker-without-verb cases. Full suite: 1017 passed (up from 1007).
+
 ## [7.1.0] - 2026-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ schliff score path/to/SKILL.md
 
 ```text
 $ schliff score demo/bad-skill/SKILL.md
-schliff v7.1.0
+schliff v7.1.1
 
   structure      ███████░░░   70/100  fair
   efficiency     ████░░░░░░   35/100  poor
@@ -146,7 +146,7 @@ schliff verify path/to/SKILL.md --min-score 75 --regression
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v7.1.0
+    rev: v7.1.1
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "7.1.0"
+version = "7.1.1"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = {text = "MIT"}
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Patch release **v7.1.1**. Publishes the `_RE_ACTIONABLE_LINES` pattern fix from [PR #29](https://github.com/Zandereins/schliff/pull/29) (merged 2026-04-18) to PyPI so users who `pip install schliff` actually receive the corrected scorer.

## What's in 7.1.1

### Fixed
- **Bullet-marker support in actionable-line patterns** — `_RE_ACTIONABLE_LINES` and three sibling regex patterns previously only matched numbered list prefixes and bare imperatives. Markdown bullets (`- Run X`, `* Use Y`, `+ Install Z`) were silently dropped.
- **10 new regression and false-positive tests** in `TestListMarkerSupport`. Full suite: 1017 passed (up from 1007).
- **Real-world impact** on the root `CLAUDE.md` merged into `modelcontextprotocol/servers`: efficiency 57 → 64, composite 59.2 → 61.0.

## Release checklist

- [x] `pyproject.toml` version bump: 7.1.0 → 7.1.1
- [x] `CHANGELOG.md` entry in Keep-a-Changelog format, structure matches the 7.1.0 entry (bold feature headers, imperative-voice descriptions)
- [x] `README.md` version references updated: example-output line (L22) + pre-commit `rev:` line (L149)
- [x] Full test suite: **1017 passed**
- [x] Re-score verified on MCP CLAUDE.md: 59.2 → 61.0
- [x] Grep swept for remaining `7.1.0` strings — all remaining matches are historical v8-baseline tags and golden-snapshot references that must stay pinned

## What happens after merge

1. `gh release create v7.1.1 --target main --title "v7.1.1" --notes-file ...` creates the tag + GitHub Release
2. `.github/workflows/publish.yml` triggers on `release: published`
3. PyPI receives v7.1.1 via OIDC Trusted Publishing (no manual token)
4. `pip install --upgrade schliff` delivers the fix
5. Blog posts from earlier today stay narrative-consistent

## Not in this PR (separate follow-ups)

- Profile-README (`Zandereins/Zandereins`) will get a v7.1.1 reference and refreshed test-count in a separate PR after merge
- `install.sh` line 17 has a stale `VERSION="6.1.0"` literal — pre-dates the v7.0.0 cut, separate hygiene fix, not release-blocking

## QA plan

Three parallel subagents will cross-review this PR:
- **Release-Hygiene** (semver-correctness, CHANGELOG-format consistency, version-reference completeness)
- **Testing** (independent test-suite rerun, score-delta reproduction)
- **Downstream-Audit** (scan profile-README and other repos for stale version references that need follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)