### PR TITLE
fix(readme): cache-bust PyPI version badge after v7.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Your AI instructions are silently degrading. Schliff catches it.
 Deterministic quality scoring for CLAUDE.md, SKILL.md, .cursorrules, AGENTS.md, and system prompts. No LLM, no API key — same input, same score. Python 3.9+, **zero core dependencies** (optional `schliff[evolve]` adds litellm for the evolution loop).
 
 <p align="left">
-  <a href="https://pypi.org/project/schliff/"><img alt="PyPI" src="https://img.shields.io/pypi/v/schliff?style=flat-square&color=F59E0B&label=version"></a>
+  <a href="https://pypi.org/project/schliff/"><img alt="PyPI" src="https://img.shields.io/pypi/v/schliff?style=flat-square&color=F59E0B&label=version&v=7.1.1"></a>
   <a href="https://pypi.org/project/schliff/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/schliff?style=flat-square"></a>
   <a href="https://pypi.org/project/schliff/"><img alt="Downloads" src="https://img.shields.io/pypi/dm/schliff?style=flat-square"></a>
   <a href=".github/workflows/test.yml"><img alt="Tests" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Zandereins/130bb61237b5b9b1536718e6a2296d4a/raw/schliff-tests.json&style=flat-square"></a>


### PR DESCRIPTION
## Summary
- GitHub Camo fetched `shields.io/pypi/v/schliff` at 17:58 GMT, before PyPI had indexed v7.1.1, and pinned v7.1.0 for the 3h `max-age` TTL
- Fastly-edge PURGE doesn't reach camo's backing store — changing the URL is the only way to force a fresh fetch
- Append `&v=7.1.1` to the version-badge `src`; shields.io ignores the param, but GitHub generates a new camo hash that now reads v7.1.1 from the indexed release

## Test plan
- [ ] After merge, hard-refresh GitHub README and confirm version badge shows `v7.1.1`
- [ ] Hard-refresh https://pypi.org/project/schliff/ (no camo — shields.io origin already serves v7.1.1)
- [ ] For future releases: bump the `&v=X.Y.Z` param in the same commit as `pyproject.toml` / `CHANGELOG.md` to avoid the camo-stale window

🤖 Generated with [Claude Code](https://claude.com/claude-code)