### PR TITLE
docs(readme): bump two v7.1.1 references to v7.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ schliff score path/to/SKILL.md
 
 ```text
 $ schliff score demo/bad-skill/SKILL.md
-schliff v7.1.1
+schliff v7.2.0
 
   structure      ███████░░░   70/100  fair
   efficiency     ████░░░░░░   35/100  poor
@@ -146,7 +146,7 @@ schliff verify path/to/SKILL.md --min-score 75 --regression
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v7.1.1
+    rev: v7.2.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']


### PR DESCRIPTION
## Summary

Post-v7.2.0-release sweep for the two literal `v7.1.1` strings in README.md that `gh release create` does not touch automatically:

- `README.md:22` — demo-output block showed `schliff v7.1.1`; now shows `schliff v7.2.0`.
- `README.md:149` — pre-commit-hook snippet pinned `rev: v7.1.1`; now pins `rev: v7.2.0` so users copy-pasting the snippet get the just-released tag.

The PyPI version badge cache-bust param was already bumped to `?v=7.2.0` in 42b1033 as part of the release prep.

## Test plan
- [x] No functional code changes — docs-only
- [x] grep for `v7\.1|7\.1\.1` in README.md returns zero matches
- [x] PR-branch tested locally — no lint/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)