### PR TITLE
feat!: unify composite scoring (full-denominator) + audit follow-ups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "6.1.0",
+  "version": "7.2.0",
   "description": "Deterministic skill linter and scoring engine for Claude Code. 7-dimension scoring, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": "Zandereins",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   re-tuning. See `docs/superpowers/specs/2026-05-26-audit-followups-design.md`.
 - Anti-gaming: added a spread-keyword-stuffing penalty (efficiency dimension) and a composite
   separation gate (`benchmarks/anti-gaming`) asserting every gamed skill scores below a clean control.
+- `verify` is now coverage-aware: the pass threshold scales with measured coverage
+  (effective_min = min_score × coverage), so skills without an eval suite are judged against a
+  structural bar instead of the unreachable full default. Adding an eval suite raises the bar to
+  the full surface.
 
 ## [7.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Schliff are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+- **BREAKING (scoring):** Composite is now computed over a single canonical 7-dimension basis
+  with a full denominator — unmeasured dimensions are uncredited (not silently renormalized away).
+  Scores for skills without an eval suite are lower and now reflect coverage. This unifies the
+  `score`/`doctor`/`bench` and `evolve` paths (one number per file) and closes the anti-gaming gap
+  where a gamed skill could match a clean one at composite level. Security is reported as a separate
+  signal/gate, no longer folded into the headline. CI thresholds (`fail if score<N`) may need
+  re-tuning. See `docs/superpowers/specs/2026-05-26-audit-followups-design.md`.
+- Anti-gaming: added a spread-keyword-stuffing penalty (efficiency dimension) and a composite
+  separation gate (`benchmarks/anti-gaming`) asserting every gamed skill scores below a clean control.
+
 ## [7.2.0] - 2026-04-24
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-self test-proof test-all score lint install install-dev clean help
+.PHONY: test test-unit test-self test-proof test-all score lint install install-dev clean help
 
 SKILL_DIR := skills/schliff
 
@@ -6,7 +6,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-test: ## Run integration tests (99+ tests)
+test-unit: ## Run the pytest unit suite (1100+ tests)
+	/usr/bin/python3 -m pytest skills/schliff/tests -q
+
+test: test-unit ## Run unit tests (pytest) then integration tests
 	cd $(SKILL_DIR) && bash scripts/test-integration.sh --no-runtime-auto
 
 test-self: ## Run self-tests (20 tests)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Inspired by [Karpathy's autoresearch](https://github.com/karpathy/autoresearch) 
 | | autoresearch | Schliff |
 |---|---|---|
 | **Target** | ML training scripts | AI instruction files |
-| **Patches** | 100% LLM | 60-70% deterministic, 30-40% LLM |
+| **Patches** | 100% LLM | ~32% deterministic, rest LLM |
 | **Scoring** | 1 metric | 7 dimensions + optional runtime |
 | **Anti-gaming** | None | 6 detection vectors |
 | **Dependencies** | ML frameworks | Python 3.9+ stdlib only (core) |
@@ -263,7 +263,7 @@ flowchart TB
     end
 ```
 
-60-70% of patches follow deterministic rules. The LLM handles structural reorganization, example generation, edge case synthesis.
+~32% of patches are applied deterministically (confidence=high, single-edit effort); the rest fall back to the LLM. The LLM handles structural reorganization, example generation, edge case synthesis. (source: `scripts/measure_patch_ratio.py`)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ schliff v7.2.0
   composability  ███░░░░░░░   30/100  poor
   clarity        █████████░   90/100  great
 
-  Structural Score  ███████████░░░░░░░░░  53.8/100  [D]
-  ⚠ 4/8 dimensions measured (weight coverage: 40%). Unmeasured: triggers, quality, edges
+  Structural Score  █████░░░░░░░░░░░░░░░  22.6/100  [F]
+  ⚠ 4/7 dimensions measured (coverage 42%). Unverified dimensions are uncredited — score ceiling is 42%. Unmeasured: triggers, quality, edges
   → 13 deterministic fixes available. Run `/schliff:auto` in Claude Code to apply.
 
   Tokens: 378 / 1,000 (ok)
@@ -51,7 +51,7 @@ schliff v7.2.0
 
 ## Seen in the wild
 
-A root `CLAUDE.md` written for [`modelcontextprotocol/servers`](https://github.com/modelcontextprotocol/servers/pull/3733) (Anthropic's official MCP reference repo) merged to main on April 17th, 2026. Running schliff on it returned **59.2/100 at 40% weight coverage** — a useful measurement of where the file actually needed work and where the scorer was structurally unfair for a project-root document. [Full walkthrough →](https://fpaul.dev/writing/scoring-my-own-mcp-contribution/)
+A root `CLAUDE.md` written for [`modelcontextprotocol/servers`](https://github.com/modelcontextprotocol/servers/pull/3733) (Anthropic's official MCP reference repo) merged to main on April 17th, 2026. Running schliff on it returned **59.2/100 at 40% weight coverage** (pre-v8 scale; full-denominator scoring would place this lower) — a useful measurement of where the file actually needed work and where the scorer was structurally unfair for a project-root document. [Full walkthrough →](https://fpaul.dev/writing/scoring-my-own-mcp-contribution/)
 
 ---
 

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -75,7 +75,17 @@ BENCHMARKS = [
         "gaming_vector": "No scope boundaries, handoffs, or error behavior",
         "detection": "10 sub-checks: scope, state, I/O, handoffs, errors, etc.",
     },
+    {
+        "file": "sophisticated-gamer.md",
+        "target_dimension": "efficiency",
+        "gaming_vector": "Structurally complete + all composability boilerplate, "
+                         "but one keyword stuffed ~26% of body (spread across lines)",
+        "detection": "Spread-keyword-stuffing density penalty + full-denominator "
+                     "(triggers/quality/edges uncredited with no eval suite)",
+    },
 ]
+
+CLEAN_CONTROL = "clean-reference.md"
 
 
 def score_skill(skill_path: str) -> dict:
@@ -193,18 +203,30 @@ def format_markdown(results: list[dict]) -> str:
 
 def main():
     use_json = "--json" in sys.argv
-
     results = run_benchmarks()
 
-    if use_json:
-        # Serialize, filtering out non-serializable details
-        output = []
+    clean_path = str(_SKILLS_DIR / CLEAN_CONTROL)
+    clean_composite = score_skill(clean_path)["composite"] if Path(clean_path).exists() else None
+
+    violations = []
+    if clean_composite is not None:
         for r in results:
-            entry = {k: v for k, v in r.items() if k != "target_details"}
-            output.append(entry)
-        print(json.dumps(output, indent=2))
+            if "composite" in r and r["composite"] >= clean_composite:
+                violations.append((r["file"], r["composite"]))
+
+    if use_json:
+        output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
+        print(json.dumps({"clean_composite": clean_composite,
+                          "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
+        print(f"\nClean control composite: {clean_composite}")
+        if violations:
+            print("SEPARATION FAILURES (gamed >= clean):")
+            for f, c in violations:
+                print(f"  {f}: {c}")
+
+    sys.exit(1 if violations else 0)
 
 
 if __name__ == "__main__":

--- a/benchmarks/anti-gaming/skills/clean-reference.md
+++ b/benchmarks/anti-gaming/skills/clean-reference.md
@@ -1,0 +1,39 @@
+---
+name: changelog-updater
+description: Use when adding a release entry to CHANGELOG.md, before tagging a version, to keep the changelog consistent with Keep-a-Changelog format.
+---
+
+# Changelog Updater
+
+## When to use
+Use this when a release is about to be tagged and CHANGELOG.md needs a new version section.
+Do NOT use for editing release notes on the GitHub releases page — that is a separate surface.
+
+## Steps
+1. Read the current `## [Unreleased]` section.
+2. Create a new `## [X.Y.Z] - YYYY-MM-DD` heading below Unreleased.
+3. Move entries from Unreleased into the new section, grouped under Added / Changed / Fixed / Removed.
+4. Leave an empty Unreleased section for future entries.
+
+## Example
+Before:
+```
+## [Unreleased]
+### Fixed
+- Crash on empty input
+```
+After:
+```
+## [Unreleased]
+
+## [1.4.0] - 2026-05-26
+### Fixed
+- Crash on empty input
+```
+
+## Edge cases
+- No Unreleased entries: stop and report; do not create an empty version section.
+- Date unknown: ask for the release date rather than guessing.
+
+## Handoff
+After updating, hand off to the tagging step; this skill does not run git commands.

--- a/benchmarks/anti-gaming/skills/sophisticated-gamer.md
+++ b/benchmarks/anti-gaming/skills/sophisticated-gamer.md
@@ -1,0 +1,56 @@
+---
+name: deployment-orchestrator
+description: Use when deployment is needed — deployment pipelines, deployment rollouts, deployment verification, deployment rollback. Handles deployment orchestration, deployment automation, deployment staging, and deployment promotion across deployment environments.
+---
+
+# Deployment Orchestrator
+
+## When to use
+Use this skill when a deployment must be orchestrated across deployment stages: deployment build, deployment test, deployment staging, deployment canary, deployment production. Reach for deployment orchestration whenever deployment promotion, deployment gating, deployment verification, or deployment rollback is required for a deployment release.
+
+Do NOT use for editing application source code, for writing deployment scripts from scratch, or for infrastructure provisioning — those are separate surfaces handled elsewhere.
+
+## Inputs and outputs
+**Input:** a deployment manifest path and a target deployment environment name.
+**Output:** a deployment status report (success or failure) and a deployment audit log written to the deployment artifacts directory.
+
+## Steps
+1. Read the deployment manifest and validate the deployment target environment.
+2. Run the deployment preflight: deployment health checks, deployment dependency resolution, deployment credential checks.
+3. Execute the deployment in deployment-canary mode first, then promote the deployment to deployment-production.
+4. Verify the deployment via deployment smoke tests and record the deployment result.
+
+## Example
+Before a deployment to staging:
+```
+deploy --manifest deploy.yaml --env staging --strategy canary
+```
+After a successful deployment:
+```
+deployment: staging
+status: promoted
+canary: passed
+```
+
+## Edge cases
+- Deployment manifest missing: stop and report; do not start a partial deployment.
+- Deployment target unknown: ask for the deployment environment rather than guessing a deployment target.
+- Deployment canary fails: trigger an automatic deployment rollback and report the failed deployment.
+
+## Error behavior
+On any deployment failure the skill aborts the deployment, performs a deployment rollback to the last known-good deployment, and reports the deployment error. It never leaves a deployment in a half-promoted deployment state.
+
+## Idempotency and safety
+Re-running the same deployment is idempotent: a deployment already promoted is detected and skipped safely. The deployment never mutates global deployment state outside the named deployment environment.
+
+## Dependencies
+Requires a deployment CLI to be available; if the deployment CLI is absent, falls back to an alternative deployment API client. No other hard tool requirement.
+
+## Namespace
+All deployment artifacts are namespaced under the `deploy/` prefix to isolate deployment state from other skills.
+
+## Version compatibility
+Compatible with deployment-engine v2 and above. For deployment-engine v1, use the legacy deployment adapter.
+
+## Handoff
+After the deployment completes, hand off to the monitoring skill; this skill does not run post-deployment monitoring itself.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,7 +76,7 @@ Key behaviors:
 
 ### text-gradient.py — The Fixer
 
-Identifies specific improvements with predicted score deltas. Generates deterministic patches (frontmatter insertions, noise removal, scope boundary additions) and context-aware patches (meaningful descriptions instead of TODOs). ~60-70% of all fixes are fully deterministic.
+Identifies specific improvements with predicted score deltas. Generates deterministic patches (frontmatter insertions, noise removal, scope boundary additions) and context-aware patches (meaningful descriptions instead of TODOs). ~32% of patches are applied deterministically (confidence=high, single-edit effort); the rest fall back to the LLM. (source: `scripts/measure_patch_ratio.py`)
 
 ### dashboard.py — Health Dashboard
 

--- a/docs/specs/2026-03-28-v8-design.md
+++ b/docs/specs/2026-03-28-v8-design.md
@@ -210,7 +210,7 @@ A closed loop that no other tool provides:
 └────────────────────┬────────────────────────────┘
                      ▼
 ┌─────────────────────────────────────────────────┐
-│  2. DETERMINISTIC PATCHES (60-70% of fixes)       │
+│  2. DETERMINISTIC PATCHES (~32% of fixes)          │
 │     Frontmatter inserts, noise removal, dedup      │
 │     ~0 tokens, ~instant                            │
 └────────────────────┬────────────────────────────┘

--- a/docs/specs/plans/v8-session-prompts.md
+++ b/docs/specs/plans/v8-session-prompts.md
@@ -786,7 +786,7 @@ Du arbeitest in Worktree ../schliff-phase-2 auf Branch schliff-v8/phase-2-evolut
 
 Das ist Schliff's "Karpathy-Moment": schliff evolve verbessert Instruction Files autonom.
 Geschlossener Loop den KEIN anderes Tool hat:
-  Deterministisch scoren -> Deterministisch patchen (60-70%, $0) -> LLM verbessern -> Deterministisch verifizieren
+  Deterministisch scoren -> Deterministisch patchen (~32%, $0) -> LLM verbessern -> Deterministisch verifizieren
 
 WICHTIG:
 - LiteLLM ist OPTIONAL: pip install schliff[evolve]

--- a/docs/superpowers/plans/2026-05-26-audit-followups.md
+++ b/docs/superpowers/plans/2026-05-26-audit-followups.md
@@ -151,7 +151,7 @@ def test_separation_gamed_below_clean():
     under the no-eval-suite condition (the common case)."""
     from scoring import (score_structure, score_triggers, score_quality, score_edges,
                          score_efficiency, score_composability, score_clarity)
-    bench_skills = Path(__file__).resolve().parents[3] / "benchmarks" / "anti-gaming" / "skills"
+    bench_skills = Path(__file__).resolve().parents[4] / "benchmarks" / "anti-gaming" / "skills"
 
     def composite_of(path):
         s = {
@@ -461,7 +461,7 @@ Create the wrapper test inside `test_composite_unified.py`:
 ```python
 def test_anti_gaming_benchmark_gate():
     import subprocess
-    repo = Path(__file__).resolve().parents[3]
+    repo = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
     proc = subprocess.run(["/usr/bin/python3", "benchmarks/anti-gaming/run.py"],
                           cwd=str(repo), capture_output=True, text=True)
     assert proc.returncode == 0, f"anti-gaming separation failed:\n{proc.stdout}"
@@ -735,7 +735,7 @@ import json
 import re
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+ROOT = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
 
 
 def _pyproject_version() -> str:

--- a/docs/superpowers/plans/2026-05-26-audit-followups.md
+++ b/docs/superpowers/plans/2026-05-26-audit-followups.md
@@ -1,0 +1,957 @@
+# Audit Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the verified-real findings from the 6.1.0 audit — unify the composite (kill conceptual dual-scale + the anti-gaming hole at one root cause), substantiate the "60-70%" claim, and fix version drift — each behind a permanent test/guard.
+
+**Architecture:** The core is a single aggregation change in `scoring/composite.py`: a canonical 7-dimension headline composite using a **full denominator** (unmeasured = uncredited, not failed), with security/runtime reported as separate signals. Two regression guards pin the invariants (gamed < clean; CLI == evolve). The remaining workstreams are independent hygiene fixes, each with a self-checking test.
+
+**Tech Stack:** Python 3 (stdlib only, zero-dependency), pytest, Makefile, JSON.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `skills/schliff/scripts/scoring/composite.py` | Unified full-denominator composite over 7 canonical dims; security separated | Modify |
+| `skills/schliff/scripts/scoring/security.py` | Remove dead `get_composite_cap()` | Modify |
+| `skills/schliff/scripts/evolve/engine.py` | Use 7-dim headline composite; track security separately | Modify (verify) |
+| `benchmarks/anti-gaming/run.py` | Add clean-control + composite-separation gate | Modify |
+| `benchmarks/anti-gaming/skills/clean-reference.md` | Genuine clean skill for separation guard | Create |
+| `skills/schliff/tests/unit/test_composite_unified.py` | Guards: separation, unification, full-denominator, coverage | Create |
+| `skills/schliff/scripts/measure_patch_ratio.py` | Canonical measurement of deterministic-patch ratio | Create |
+| `skills/schliff/tests/unit/test_patch_ratio.py` | Lock the measurement methodology | Create |
+| `skills/schliff/__init__.py` | `__version__` single source of truth | Modify |
+| `.claude-plugin/plugin.json` | Bump 6.1.0 → match `__version__` | Modify |
+| `skills/schliff/tests/unit/test_version_consistency.py` | Fail on version drift | Create |
+| `skills/schliff/tests/unit/test_episodic_store.py` | Episodic memory unit coverage | Create |
+| `Makefile` | `make test` runs pytest | Modify |
+| `README.md`, `docs/ARCHITECTURE.md`, `skills/schliff/SKILL.md`, specs, `auto-improve.py` | Correct the "60-70%" claim | Modify |
+| `CHANGELOG.md` | Document the breaking score-scale change | Modify |
+
+---
+
+## Task 1: Composite guards (write first, RED)
+
+**Files:**
+- Create: `skills/schliff/tests/unit/test_composite_unified.py`
+- Create: `benchmarks/anti-gaming/skills/clean-reference.md`
+
+- [ ] **Step 1: Create a genuine clean-reference skill**
+
+Create `benchmarks/anti-gaming/skills/clean-reference.md` — a well-formed skill with real sections, no gaming:
+
+```markdown
+---
+name: changelog-updater
+description: Use when adding a release entry to CHANGELOG.md, before tagging a version, to keep the changelog consistent with Keep-a-Changelog format.
+---
+
+# Changelog Updater
+
+## When to use
+Use this when a release is about to be tagged and CHANGELOG.md needs a new version section.
+Do NOT use for editing release notes on the GitHub releases page — that is a separate surface.
+
+## Steps
+1. Read the current `## [Unreleased]` section.
+2. Create a new `## [X.Y.Z] - YYYY-MM-DD` heading below Unreleased.
+3. Move entries from Unreleased into the new section, grouped under Added / Changed / Fixed / Removed.
+4. Leave an empty Unreleased section for future entries.
+
+## Example
+Before:
+```
+## [Unreleased]
+### Fixed
+- Crash on empty input
+```
+After:
+```
+## [Unreleased]
+
+## [1.4.0] - 2026-05-26
+### Fixed
+- Crash on empty input
+```
+
+## Edge cases
+- No Unreleased entries: stop and report; do not create an empty version section.
+- Date unknown: ask for the release date rather than guessing.
+
+## Handoff
+After updating, hand off to the tagging step; this skill does not run git commands.
+```
+
+- [ ] **Step 2: Write the failing guard tests**
+
+Create `skills/schliff/tests/unit/test_composite_unified.py`:
+
+```python
+"""Guards for the unified composite (spec 2026-05-26-audit-followups §W1).
+
+Pins three invariants permanently:
+  1. Separation: a gamed skill must NOT reach/beat a clean skill at composite level.
+  2. Unification: the same file scores identically via the CLI path and the evolve path
+     (no conceptual dual-scale).
+  3. Full-denominator: unmeasured dims are uncredited — a perfect-on-measured skill with
+     missing discriminating dims cannot read as a full-coverage high score.
+"""
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from scoring.composite import compute_composite  # noqa: E402
+
+
+def _scores(**dims):
+    """Helper: build a per-dimension score dict; omit a dim to leave it unmeasured (-1)."""
+    return {d: {"score": v} for d, v in dims.items()}
+
+
+def test_full_denominator_uncredits_unmeasured():
+    # All 7 canonical dims perfect EXCEPT quality+edges unmeasured (no eval suite).
+    measured = _scores(structure=100, triggers=100, efficiency=100,
+                        composability=100, clarity=100)  # quality, edges omitted
+    result = compute_composite(measured)
+    # quality(0.20)+edges(0.15)=0.35 of canonical weight is uncredited.
+    # Perfect-on-measured therefore caps at ~65, NOT ~100.
+    assert result["score"] <= 70, f"uncredited dims still credited: {result['score']}"
+    assert result["weight_coverage"] <= 0.66
+    assert result["total_dimensions"] == 7  # security excluded from headline
+
+
+def test_full_coverage_unaffected():
+    # All 7 dims measured and perfect -> 100 (full denominator == full coverage).
+    full = _scores(structure=100, triggers=100, quality=100, edges=100,
+                   efficiency=100, composability=100, clarity=100)
+    result = compute_composite(full)
+    assert result["score"] == 100.0
+    assert result["weight_coverage"] == 1.0
+    assert result["total_dimensions"] == 7
+
+
+def test_security_excluded_from_headline():
+    # Security present and terrible must NOT move the headline composite.
+    base = _scores(structure=80, triggers=80, quality=80, edges=80,
+                   efficiency=80, composability=80, clarity=80)
+    without = compute_composite(dict(base))
+    with_sec = compute_composite({**base, "security": {"score": 0}})
+    assert without["score"] == with_sec["score"], "security leaked into headline"
+    # but security is reported separately
+    assert with_sec.get("security", {}).get("score") == 0
+
+
+def test_separation_gamed_below_clean():
+    """Real-file guard: a gamed skill must score strictly below the clean reference,
+    under the no-eval-suite condition (the common case)."""
+    from scoring import (score_structure, score_triggers, score_quality, score_edges,
+                         score_efficiency, score_composability, score_clarity)
+    bench_skills = Path(__file__).resolve().parents[3] / "benchmarks" / "anti-gaming" / "skills"
+
+    def composite_of(path):
+        s = {
+            "structure": score_structure(str(path)),
+            "triggers": score_triggers(str(path), None),
+            "quality": score_quality(str(path), None),
+            "edges": score_edges(str(path), None),
+            "efficiency": score_efficiency(str(path)),
+            "composability": score_composability(str(path)),
+            "clarity": score_clarity(str(path)),
+        }
+        return compute_composite(s)["score"]
+
+    clean = composite_of(bench_skills / "clean-reference.md")
+    for gamed in ["keyword-stuffing.md", "inflated-headers.md", "fake-examples.md",
+                  "bloated-preamble.md", "no-scope.md", "contradiction-skill.md"]:
+        gp = bench_skills / gamed
+        if gp.exists():
+            assert composite_of(gp) < clean, f"{gamed} composite >= clean ({clean})"
+
+
+def test_unification_cli_equals_evolve():
+    """The same per-dimension scores must yield one headline composite regardless of
+    whether security was also scored (CLI omits it, evolve includes it)."""
+    dims = _scores(structure=82, triggers=78, quality=70, edges=66,
+                   efficiency=88, composability=74, clarity=90)
+    cli_path = compute_composite(dict(dims))                       # 7 dims (CLI)
+    evolve_path = compute_composite({**dims, "security": {"score": 55}})  # +security (evolve)
+    assert cli_path["score"] == evolve_path["score"], "dual-scale: CLI != evolve"
+```
+
+- [ ] **Step 3: Run the guards to confirm they FAIL**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py -v`
+Expected: `test_full_denominator_uncredits_unmeasured` FAILS (current renormalization yields ~100, not ≤70); `test_security_excluded_from_headline` and `test_unification_cli_equals_evolve` may FAIL (security currently shifts the score). Capture which fail — that is the red baseline.
+
+- [ ] **Step 4: Commit the red guards**
+
+```bash
+git add skills/schliff/tests/unit/test_composite_unified.py benchmarks/anti-gaming/skills/clean-reference.md
+git commit -m "test: composite unification + anti-gaming separation guards (red)"
+```
+
+---
+
+## Task 2: Unified full-denominator composite (GREEN)
+
+**Files:**
+- Modify: `skills/schliff/scripts/scoring/composite.py:49-169`
+
+- [ ] **Step 1: Replace the aggregation in `compute_composite`**
+
+Replace the body from the weight-resolution block through the `return` (lines 64-169) with the unified version. Key changes: derive a **canonical** weight set excluding `OPT_IN_SCORERS` (unless explicitly in `custom_weights`), renormalize it to 1.0, divide by the **full** canonical weight (uncredited unmeasured), and report security separately.
+
+```python
+    from scoring.registry import get_weights, OPT_IN_SCORERS
+
+    weights = get_weights(fmt if fmt is not None else "skill.md")
+    explicit = set(custom_weights or {})
+
+    if custom_weights:
+        _SUPPLEMENTARY = {"clarity", "security"}
+        for dim in list(weights):
+            if dim in _SUPPLEMENTARY and dim not in custom_weights:
+                del weights[dim]
+        for k, v in custom_weights.items():
+            if k in weights and isinstance(v, (int, float)) and math.isfinite(v) and v >= 0:
+                weights[k] = v
+    else:
+        calibrated = _load_calibrated_weights()
+        if calibrated:
+            for k, v in calibrated.items():
+                if k in weights:
+                    weights[k] = v
+
+    # Canonical headline basis: opt-in dims (security, runtime) are NEVER folded into the
+    # headline composite unless the caller explicitly weighted them via custom_weights.
+    # This is the single basis used by every entrypoint (CLI, evolve, doctor, bench) -> no dual-scale.
+    canonical = {d: w for d, w in weights.items()
+                 if d not in OPT_IN_SCORERS or d in explicit}
+    basis = sum(canonical.values())
+    if basis > 0:
+        canonical = {d: w / basis for d, w in canonical.items()}  # renormalize to 1.0
+
+    # Full-denominator aggregation: unmeasured dims are UNCREDITED (contribute 0), not dropped.
+    # composite = Σ(score·weight over measured) / Σ(all canonical weight == 1.0)
+    # => a skill's ceiling equals its coverage until the missing dims are verified.
+    total = 0.0
+    measured_w = 0.0
+    measured = []
+    unmeasured = []
+    for dim, weight in canonical.items():
+        s = scores.get(dim, {}).get("score", -1)
+        if s >= 0:
+            total += s * weight
+            measured_w += weight
+            measured.append(dim)
+        else:
+            unmeasured.append(dim)
+
+    composite = round(total, 1)            # divisor is 1.0 (full canonical basis)
+    coverage = round(measured_w, 2)
+    measured_count = len(measured)
+    total_count = len(canonical)
+
+    warnings = []
+    if unmeasured:
+        prefix = "Only " if measured_count <= 2 else ""
+        warnings.append(
+            f"{prefix}{measured_count}/{total_count} dimensions measured "
+            f"(coverage {coverage:.0%}). Unverified dimensions are uncredited — "
+            f"score ceiling is {coverage:.0%}. Unmeasured: {', '.join(unmeasured)}"
+        )
+
+    # Security/runtime: reported as SEPARATE signals, never in the headline composite.
+    signals = {}
+    for opt in ("security", "runtime"):
+        sv = scores.get(opt, {}).get("score", -1)
+        if sv is not None and sv >= 0:
+            signals[opt] = {
+                "score": sv,
+                "status": "pass" if sv >= SECURITY_GATE else "flag",
+            } if opt == "security" else {"score": sv}
+
+    confidence_notes = {
+        "structure": "Measures file organization (frontmatter, headers, length, references). "
+                     "Cannot assess whether instructions are correct or effective.",
+        "triggers": "Measures keyword overlap between description and eval prompts using TF-IDF heuristic. "
+                     "Cannot predict actual Claude triggering behavior — that requires runtime evaluation.",
+        "quality": "Measures eval suite coverage (assertion types, feature breadth). "
+                    "Cannot assess whether following the skill produces correct output.",
+        "edges": "Measures edge case definitions in the eval suite. "
+                  "Cannot verify the skill handles edge cases correctly at runtime.",
+        "efficiency": "Measures information density (signal-to-noise ratio in text). "
+                      "Cannot assess whether the content is actually useful to Claude.",
+        "composability": "Measures scope boundaries and handoff declarations. "
+                         "Cannot verify the skill works correctly alongside other skills.",
+        "clarity": "Measures contradiction, vague reference, and ambiguity patterns. "
+                   "Cannot assess whether instructions are clear to Claude in practice.",
+    }
+
+    has_runtime = "runtime" in signals
+    score_type = "structural+runtime" if has_runtime else "structural"
+
+    return {
+        "score": composite,
+        "score_type": score_type,
+        "measured_dimensions": measured_count,
+        "total_dimensions": total_count,
+        "weight_coverage": coverage,
+        "unmeasured": unmeasured,
+        "warnings": warnings,
+        "signals": signals,
+        "security": signals.get("security", {}),
+        "confidence_notes": {k: v for k, v in confidence_notes.items() if k in measured},
+    }
+```
+
+- [ ] **Step 2: Add the `SECURITY_GATE` constant**
+
+Near the top of `composite.py` (after the imports, before `_load_calibrated_weights`), add:
+
+```python
+# Security is a separate advisory gate, never folded into the headline composite.
+SECURITY_GATE = 70
+```
+
+- [ ] **Step 3: Run the unified guards**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py -v`
+Expected: `test_full_denominator_uncredits_unmeasured`, `test_full_coverage_unaffected`, `test_security_excluded_from_headline`, `test_unification_cli_equals_evolve` all PASS. `test_separation_gamed_below_clean` PASS only if the surface dims already separate the pair — if it FAILS, that is the reproduction needed for Task 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/schliff/scripts/scoring/composite.py
+git commit -m "feat: unified full-denominator composite — one basis, security separated (fixes dual-scale)"
+```
+
+---
+
+## Task 3: Evolve loop uses the unified headline
+
+**Files:**
+- Modify: `skills/schliff/scripts/evolve/engine.py:45-52`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skills/schliff/tests/unit/test_composite_unified.py`:
+
+```python
+def test_evolve_score_file_matches_cli(tmp_path):
+    """evolve._score_file must return the same headline composite as the CLI path."""
+    import importlib
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        "---\nname: demo\ndescription: Use when demoing the evolve scoring path for parity tests.\n---\n"
+        "# Demo\n## When to use\nUse for parity testing.\n## Steps\n1. Do the thing.\n",
+        encoding="utf-8",
+    )
+    engine = importlib.import_module("evolve.engine")
+    from shared import build_scores
+    _, evolve_composite = engine._score_file(str(skill))
+    cli_composite = compute_composite(build_scores(str(skill)))["score"]  # CLI: no security
+    assert evolve_composite == cli_composite
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py::test_evolve_score_file_matches_cli -v`
+Expected: FAIL — `_score_file` passes `include_security=True`, but after Task 2 security is excluded from the headline, so they should already match. If it PASSES already, that confirms unification holds end-to-end; keep the test as a regression net and skip Step 3.
+
+- [ ] **Step 3: If failing, align `_score_file`**
+
+In `engine.py:50`, security can stay measured (for the separate signal) but must not change the headline — Task 2 already guarantees that. If the test still fails, the divergence is elsewhere; align by scoring without security for the headline decision:
+
+```python
+    scores = build_scores(skill_path, include_security=True, fmt=fmt)
+    result = compute_composite(scores, fmt=fmt)   # headline already excludes security
+    return scores, result["score"]
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py -v` → all PASS.
+
+```bash
+git add skills/schliff/scripts/evolve/engine.py skills/schliff/tests/unit/test_composite_unified.py
+git commit -m "test: pin evolve headline == CLI headline (unification end-to-end)"
+```
+
+---
+
+## Task 4: Surface-dim gaming penalty (lever 2 — conditional)
+
+**Files:**
+- Modify: `benchmarks/anti-gaming/run.py:81-138`
+- Modify: a measured-dim scorer (decided after reproduction)
+
+- [ ] **Step 1: Add the composite-separation gate to the benchmark**
+
+In `benchmarks/anti-gaming/run.py`, add a clean control and a hard gate. After `BENCHMARKS` (line 78), add:
+
+```python
+CLEAN_CONTROL = "clean-reference.md"
+```
+
+Replace `main()` (lines 194-207) so it exits non-zero when any gamed composite ≥ clean:
+
+```python
+def main():
+    use_json = "--json" in sys.argv
+    results = run_benchmarks()
+
+    clean_path = str(_SKILLS_DIR / CLEAN_CONTROL)
+    clean_composite = score_skill(clean_path)["composite"] if Path(clean_path).exists() else None
+
+    violations = []
+    if clean_composite is not None:
+        for r in results:
+            if "composite" in r and r["composite"] >= clean_composite:
+                violations.append((r["file"], r["composite"]))
+
+    if use_json:
+        output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
+        print(json.dumps({"clean_composite": clean_composite,
+                          "violations": violations, "results": output}, indent=2))
+    else:
+        print(format_markdown(results))
+        print(f"\nClean control composite: {clean_composite}")
+        if violations:
+            print("SEPARATION FAILURES (gamed >= clean):")
+            for f, c in violations:
+                print(f"  {f}: {c}")
+
+    sys.exit(1 if violations else 0)
+```
+
+- [ ] **Step 2: Reproduce — run the benchmark gate**
+
+Run: `/usr/bin/python3 benchmarks/anti-gaming/run.py`
+Expected: prints the table + clean composite. Note exit status: `echo $?`.
+- If exit 0 (no violations): 7.2.0 + the full-denominator change already separate gamed from clean. **Record this as a finding in the spec; lever 2 is unnecessary.** Skip to Step 5.
+- If exit 1: a gamed file reaches clean. Identify which dimension inflates it (compare `all_scores`); that names the lever.
+
+- [ ] **Step 3: (If reproduced) strengthen the implicated scorer**
+
+For the implicated measured dimension (most likely `triggers` via keyword density), add a density-based penalty. Example for `scoring/triggers.py` — penalize when a single token dominates the description/body vocabulary (spread-keyword stuffing the TF-IDF diminishing-returns misses). Write a focused unit test first in `test_composite_unified.py`:
+
+```python
+def test_spread_keyword_stuffing_penalized(tmp_path):
+    from scoring import score_triggers
+    stuffed = tmp_path / "stuffed.md"
+    body = " ".join(["deployment"] * 60)
+    stuffed.write_text(
+        f"---\nname: x\ndescription: deployment deployment deployment tool.\n---\n# X\n{body}\n",
+        encoding="utf-8")
+    assert score_triggers(str(stuffed), None)["score"] < 80
+```
+
+Then implement the minimal density check in the scorer until the test and the benchmark gate pass. Exact threshold calibrated against the reproduced numbers (do not over-penalize the clean control — re-run Step 2 after each change).
+
+- [ ] **Step 4: Wrap the benchmark in pytest**
+
+Create the wrapper test inside `test_composite_unified.py`:
+
+```python
+def test_anti_gaming_benchmark_gate():
+    import subprocess
+    repo = Path(__file__).resolve().parents[3]
+    proc = subprocess.run(["/usr/bin/python3", "benchmarks/anti-gaming/run.py"],
+                          cwd=str(repo), capture_output=True, text=True)
+    assert proc.returncode == 0, f"anti-gaming separation failed:\n{proc.stdout}"
+```
+
+- [ ] **Step 5: Run + commit**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py -v` → all PASS.
+
+```bash
+git add benchmarks/anti-gaming/run.py skills/schliff/tests/unit/test_composite_unified.py skills/schliff/scripts/scoring/triggers.py
+git commit -m "feat: anti-gaming composite-separation gate + surface-dim stuffing penalty"
+```
+
+---
+
+## Task 5: Re-baseline golden scores + docs + CHANGELOG
+
+**Files:**
+- Modify: any failing test fixtures encoding composite values; `benchmarks/anti-gaming` doc numbers; `CHANGELOG.md`
+
+- [ ] **Step 1: Run the full suite to surface the blast radius**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests -q 2>&1 | tail -40`
+Expected: failures in tests that assert specific composite numbers (the scale changed by design). List every failing assertion.
+
+- [ ] **Step 2: Update each failing expectation to the new value**
+
+For each failure, confirm the new value is correct by reasoning (full-denominator = old_renormalized × coverage for no-eval-suite cases), then update the expected constant. Do NOT loosen assertions to ranges — set the exact new value. If a test asserted a now-impossible "78 without eval suite", update to the coverage-correct number.
+
+- [ ] **Step 3: Regenerate documented benchmark numbers**
+
+Run: `/usr/bin/python3 benchmarks/anti-gaming/run.py --json > /tmp/ag.json` and update any composite numbers quoted in `benchmarks/anti-gaming/README.md` (if present) to match.
+
+- [ ] **Step 4: Add the CHANGELOG entry**
+
+In `CHANGELOG.md` under `## [Unreleased]`, add:
+
+```markdown
+### Changed
+- **BREAKING (scoring):** Composite is now computed over a single canonical 7-dimension basis
+  with a full denominator — unmeasured dimensions are uncredited (not silently renormalized away).
+  Scores for skills without an eval suite are lower and now reflect coverage. This unifies the
+  `score`/`doctor`/`bench` and `evolve` paths (one number per file) and closes the anti-gaming gap
+  where a gamed skill could match a clean one at composite level. Security is reported as a separate
+  signal/gate, no longer folded into the headline. CI thresholds (`fail if score<N`) may need
+  re-tuning. See `docs/superpowers/specs/2026-05-26-audit-followups-design.md`.
+```
+
+- [ ] **Step 5: Run + commit**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests -q 2>&1 | tail -5` → all PASS.
+
+```bash
+git add -A
+git commit -m "refactor: re-baseline golden scores for unified composite + CHANGELOG"
+```
+
+---
+
+## Task 6: Housekeeping — remove dead cap, verify 7/7
+
+**Files:**
+- Modify: `skills/schliff/scripts/scoring/security.py:231-239`
+- Modify: `skills/schliff/tests/unit/test_security.py` (reference to `get_composite_cap`)
+
+- [ ] **Step 1: Find references to the dead function**
+
+Run: `grep -rn "get_composite_cap" skills/ benchmarks/`
+Expected: definition at `security.py:231` + a reference in `tests/unit/test_security.py`.
+
+- [ ] **Step 2: Remove the function and its test**
+
+Delete `get_composite_cap` (`security.py:231-239`) and the test in `test_security.py` that calls it. (The composite cap was superseded by the unified composite; security is now a separate gate via `SECURITY_GATE`.)
+
+- [ ] **Step 3: Add a 7/7 assertion**
+
+Append to `test_composite_unified.py`:
+
+```python
+def test_default_run_reports_seven_of_seven():
+    full = {d: {"score": 90} for d in
+            ["structure", "triggers", "quality", "edges", "efficiency", "composability", "clarity"]}
+    r = compute_composite(full)
+    assert r["measured_dimensions"] == 7 and r["total_dimensions"] == 7
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_composite_unified.py skills/schliff/tests/unit/test_security.py -q` → PASS.
+
+```bash
+git add skills/schliff/scripts/scoring/security.py skills/schliff/tests/unit/test_security.py skills/schliff/tests/unit/test_composite_unified.py
+git commit -m "chore: remove dead get_composite_cap; assert 7/7 default reporting"
+```
+
+---
+
+## Task 7: Measure the deterministic-patch ratio
+
+**Files:**
+- Create: `skills/schliff/scripts/measure_patch_ratio.py`
+- Create: `skills/schliff/tests/unit/test_patch_ratio.py`
+
+- [ ] **Step 1: Write the failing test (pin the methodology)**
+
+Create `skills/schliff/tests/unit/test_patch_ratio.py`:
+
+```python
+"""Lock the deterministic-patch-ratio measurement methodology.
+
+'Deterministic' is defined EXACTLY as the auto-apply gate in text_gradient.py:
+    confidence == "high" AND effort <= EFFORT_SIMPLE
+"""
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from measure_patch_ratio import measure  # noqa: E402
+
+
+def test_measure_returns_consistent_shape():
+    m = measure()
+    assert m["total"] > 0
+    assert m["deterministic"] + m["llm"] == m["total"]
+    assert 0.0 <= m["deterministic_ratio"] <= 1.0
+    # The figure is whatever the catalog actually is — the test pins the contract, not a magic number.
+    assert m["definition"] == 'confidence=="high" and effort<=EFFORT_SIMPLE'
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_patch_ratio.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'measure_patch_ratio'`.
+
+- [ ] **Step 3: Implement the measurement**
+
+Create `skills/schliff/scripts/measure_patch_ratio.py`. It statically parses every gradient dict literal in `text_gradient.py` (AST — no execution, complete coverage of defined gradients) and classifies by the exact apply-gate predicate:
+
+```python
+#!/usr/bin/env python3
+"""Measure the real deterministic-vs-LLM patch ratio — canonical source for the README claim.
+
+A patch is auto-applied deterministically iff text_gradient.py's apply gate accepts it:
+    confidence == "high" AND effort <= EFFORT_SIMPLE   (text_gradient.py)
+Everything else falls back to the LLM. This script parses the gradient catalog statically.
+"""
+from __future__ import annotations
+import ast
+import json
+from pathlib import Path
+
+_GRADIENT = Path(__file__).resolve().parent / "text_gradient.py"
+EFFORT_SIMPLE = 1
+DEFINITION = 'confidence=="high" and effort<=EFFORT_SIMPLE'
+
+
+def _gradient_dicts(tree: ast.AST) -> list[dict]:
+    """Collect dict literals that look like gradients (have 'confidence' + 'delta' keys)."""
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
+        if "confidence" in keys and "delta" in keys:
+            d = {}
+            for k, v in zip(node.keys, node.values):
+                if isinstance(k, ast.Constant) and isinstance(v, ast.Constant):
+                    d[k.value] = v.value
+                elif isinstance(k, ast.Constant) and isinstance(v, ast.Name):
+                    # effort uses named constants (EFFORT_SIMPLE=1, etc.)
+                    d[k.value] = {"EFFORT_SIMPLE": 1, "EFFORT_MODERATE": 2,
+                                  "EFFORT_COMPLEX": 3, "EFFORT_MAJOR": 4}.get(v.id, 2)
+            out.append(d)
+    return out
+
+
+def measure() -> dict:
+    tree = ast.parse(_GRADIENT.read_text(encoding="utf-8"))
+    grads = _gradient_dicts(tree)
+    total = len(grads)
+    deterministic = sum(
+        1 for g in grads
+        if g.get("confidence") == "high" and int(g.get("effort", 2)) <= EFFORT_SIMPLE
+    )
+    return {
+        "total": total,
+        "deterministic": deterministic,
+        "llm": total - deterministic,
+        "deterministic_ratio": round(deterministic / total, 3) if total else 0.0,
+        "definition": DEFINITION,
+    }
+
+
+def main():
+    m = measure()
+    print(json.dumps(m, indent=2))
+    print(f"\nDeterministic patches: {m['deterministic']}/{m['total']} "
+          f"= {m['deterministic_ratio']:.0%}  ({m['definition']})")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the test + capture the real number**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_patch_ratio.py -v` → PASS.
+Run: `/usr/bin/python3 skills/schliff/scripts/measure_patch_ratio.py` → record the printed ratio (e.g. `42%`). This number feeds Task 8.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/schliff/scripts/measure_patch_ratio.py skills/schliff/tests/unit/test_patch_ratio.py
+git commit -m "feat: measure_patch_ratio.py — canonical deterministic-patch-ratio source"
+```
+
+---
+
+## Task 8: Correct the "60-70%" claim everywhere
+
+**Files:**
+- Modify: `README.md:199,266`; `docs/ARCHITECTURE.md:79`; `skills/schliff/SKILL.md:6-7`; `docs/specs/2026-03-28-v8-design.md:213`; `skills/schliff/scripts/auto-improve.py:7`; `docs/specs/plans/v8-session-prompts.md:789`
+
+- [ ] **Step 1: Locate every occurrence**
+
+Run: `grep -rn "60-70\|60–70" README.md docs/ skills/`
+Expected: the sites listed above.
+
+- [ ] **Step 2: Replace each with the measured figure**
+
+Using the number recorded in Task 7 Step 4 (call it `M%`), replace the claim with a sourced statement. For prose sites:
+
+> `~M% of patches are applied deterministically (confidence=high, single-edit effort); the rest fall back to the LLM. Measured by \`scripts/measure_patch_ratio.py\`.`
+
+For the `README.md:199` table cell: `| **Patches** | 100% LLM | ~M% deterministic, rest LLM |`.
+For `SKILL.md:6-7` and the `auto-improve.py:7` docstring: replace `60-70%` with `~M%`.
+Add a one-line footnote/reference to `measure_patch_ratio.py` in `README.md` and `docs/ARCHITECTURE.md` so the number has a single canonical source.
+
+- [ ] **Step 3: Verify no stale figure remains**
+
+Run: `grep -rn "60-70\|60–70" README.md docs/ skills/`
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/ skills/schliff/SKILL.md skills/schliff/scripts/auto-improve.py
+git commit -m "docs: correct deterministic-patch ratio to measured value with canonical source"
+```
+
+---
+
+## Task 9: Version single source of truth
+
+**Files:**
+- Modify: `skills/schliff/__init__.py`
+- Modify: `.claude-plugin/plugin.json:3`
+- Create: `skills/schliff/tests/unit/test_version_consistency.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/schliff/tests/unit/test_version_consistency.py`:
+
+```python
+"""Fail on version drift across the three places a version is declared."""
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _pyproject_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    return re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE).group(1)
+
+
+def _plugin_version() -> str:
+    return json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))["version"]
+
+
+def _package_version() -> str:
+    import sys
+    sys.path.insert(0, str(ROOT / "skills"))
+    import schliff  # skills/schliff/__init__.py
+    return schliff.__version__
+
+
+def test_all_versions_match():
+    assert _pyproject_version() == _plugin_version() == _package_version(), (
+        f"version drift: pyproject={_pyproject_version()} "
+        f"plugin={_plugin_version()} package={_package_version()}"
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_version_consistency.py -v`
+Expected: FAIL — `plugin.json` = `6.1.0` ≠ pyproject `7.2.0`, and `schliff.__version__` is undefined (`AttributeError`).
+
+- [ ] **Step 3: Add `__version__` and fix `plugin.json`**
+
+Write `skills/schliff/__init__.py`:
+
+```python
+"""Schliff — deterministic SKILL.md linter and scoring engine."""
+
+__version__ = "7.2.0"
+```
+
+In `.claude-plugin/plugin.json`, change `"version": "6.1.0"` → `"version": "7.2.0"`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_version_consistency.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/schliff/__init__.py .claude-plugin/plugin.json skills/schliff/tests/unit/test_version_consistency.py
+git commit -m "fix: single-source version + drift guard (plugin.json 6.1.0 -> 7.2.0)"
+```
+
+---
+
+## Task 10: Episodic-memory unit test
+
+**Files:**
+- Create: `skills/schliff/tests/unit/test_episodic_store.py`
+
+- [ ] **Step 1: Write the test (covers persistence, locking path, atomic rename, ranking, size cap)**
+
+Create `skills/schliff/tests/unit/test_episodic_store.py`:
+
+```python
+"""Dedicated unit coverage for the episodic memory store (audit finding #1)."""
+import importlib
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import episodic_store as es  # noqa: E402
+
+
+def _isolate(tmp_path, monkeypatch):
+    """Point the store at a temp JSONL and clear the module TF-IDF cache."""
+    p = tmp_path / "episodes.jsonl"
+    monkeypatch.setattr(es, "EPISODES_PATH", p)
+    es._tfidf_cache.update({"mtime": 0.0, "filesize": 0, "index": None, "episodes": None})
+    return p
+
+
+def test_store_then_recall_roundtrip(tmp_path, monkeypatch):
+    p = _isolate(tmp_path, monkeypatch)
+    es.store_episode("skill-a", "trigger_expansion", "keep", 5.0,
+                     "Adding synonyms improved trigger accuracy", domain="skill")
+    assert p.exists()
+    results = es.recall("trigger accuracy", top_k=5)
+    assert results and results[0]["relevance"] > 0
+    assert results[0]["strategy"] == "trigger_expansion"
+
+
+def test_persistence_across_fresh_load(tmp_path, monkeypatch):
+    """Written episodes survive a cache-less reload (cross-process surrogate)."""
+    _isolate(tmp_path, monkeypatch)
+    es.store_episode("skill-b", "noise_reduction", "discard", -1.0,
+                     "Removing hedges hurt clarity", domain="skill")
+    # simulate a second process: drop the in-memory cache, reload from disk
+    es._tfidf_cache.update({"mtime": 0.0, "filesize": 0, "index": None, "episodes": None})
+    assert es.get_stats()["total"] == 1
+    assert es.recall("clarity", top_k=3)
+
+
+def test_ranking_orders_by_relevance(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    es.store_episode("s1", "trigger_expansion", "keep", 3.0,
+                     "trigger keyword overlap synonyms description", domain="skill")
+    es.store_episode("s2", "example_addition", "keep", 2.0,
+                     "completely unrelated output formatting examples", domain="testing")
+    results = es.recall("trigger keyword synonyms", top_k=2)
+    assert results[0]["strategy"] == "trigger_expansion"
+    assert results[0]["relevance"] >= results[-1]["relevance"]
+
+
+def test_atomic_rewrite_on_consolidation(tmp_path, monkeypatch):
+    """_enforce_size_cap rewrites via temp+rename and preserves recent episodes."""
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setattr(es, "MAX_EPISODES", 5)
+    monkeypatch.setattr(es, "CONSOLIDATION_BATCH", 3)
+    # Force the size-cap parse path regardless of byte heuristic.
+    monkeypatch.setattr(es, "_enforce_size_cap", es._enforce_size_cap)
+    for i in range(8):
+        es.store_episode(f"s{i}", "strat", "keep", float(i), f"learning number {i}", domain="d")
+    es._enforce_size_cap()
+    total = es.get_stats()["total"]
+    assert total <= 8  # consolidated, not lost
+    assert not (tmp_path / "episodes.tmp").exists()  # temp cleaned up by rename
+
+
+def test_self_test_passes():
+    assert es._run_self_test() is True
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `/usr/bin/python3 -m pytest skills/schliff/tests/unit/test_episodic_store.py -v`
+Expected: PASS (the implementation already exists; this is characterization coverage). If `test_atomic_rewrite_on_consolidation` is flaky due to the byte heuristic at `_enforce_size_cap:324`, adjust the test to write enough episodes to exceed `MAX_EPISODES * 200` bytes, or `monkeypatch` the heuristic threshold — do NOT change production code for the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/schliff/tests/unit/test_episodic_store.py
+git commit -m "test: dedicated episodic-store unit coverage (persistence, ranking, atomic rewrite)"
+```
+
+---
+
+## Task 11: pytest as the default runner
+
+**Files:**
+- Modify: `Makefile:1,9-10,18`
+
+- [ ] **Step 1: Add a pytest target and route `make test` through it**
+
+In `Makefile`, update the `.PHONY` line to include `test-unit`, and change the targets:
+
+```make
+.PHONY: test test-unit test-self test-proof test-all score lint install install-dev clean help
+
+test-unit: ## Run the pytest unit suite (1100+ tests)
+	/usr/bin/python3 -m pytest skills/schliff/tests -q
+
+test: test-unit ## Run unit tests (pytest) then integration tests
+	cd $(SKILL_DIR) && bash scripts/test-integration.sh --no-runtime-auto
+```
+
+Update `test-all` to include unit explicitly (it already chains `test`):
+
+```make
+test-all: test test-self test-proof ## Run all test suites (pytest + integration + self + proof)
+```
+
+- [ ] **Step 2: Verify pytest runs via make**
+
+Run: `make test-unit`
+Expected: pytest collects and runs the suite (≥1131 + new tests), all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "build: wire pytest into make test (default runner)"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Full suite + benchmark gate + measurement**
+
+```bash
+/usr/bin/python3 -m pytest skills/schliff/tests -q 2>&1 | tail -5
+/usr/bin/python3 benchmarks/anti-gaming/run.py; echo "exit=$?"
+/usr/bin/python3 skills/schliff/scripts/measure_patch_ratio.py
+make test-unit 2>&1 | tail -3
+```
+Expected: all tests PASS; anti-gaming `exit=0`; measurement prints the canonical ratio.
+
+- [ ] **Step 2: Confirm no stale artifacts**
+
+```bash
+grep -rn "60-70\|60–70" README.md docs/ skills/ || echo "claim clean"
+grep -rn "get_composite_cap" skills/ || echo "dead code clean"
+git -C . log --oneline bc8269e..HEAD
+```
+Expected: "claim clean", "dead code clean", and the workstream commits listed.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** W1→Tasks 1-5; W6→Task 6; W2→Tasks 7-8; W3→Task 9; W4→Task 10; W5→Task 11. All spec success criteria map to a task.
+- **Honest constraint preserved:** Task 4 Step 2 explicitly handles the "no reproduction" outcome as a finding, not a forced fix.
+- **Breaking change owned:** Task 5 Step 4 CHANGELOG; threshold-semantics called out.
+- **Type consistency:** `measure()` shape (`total`/`deterministic`/`llm`/`deterministic_ratio`/`definition`) is identical in Task 7 test and impl; `compute_composite` return keys (`weight_coverage`, `total_dimensions`, `signals`, `security`) consistent across Tasks 1-6.

--- a/docs/superpowers/specs/2026-05-26-audit-followups-design.md
+++ b/docs/superpowers/specs/2026-05-26-audit-followups-design.md
@@ -1,0 +1,120 @@
+# Audit Follow-ups — Design Spec
+
+**Branch:** `schliff-v8/audit-followups` (off `feat/v8-product-completion-sprint` @ bc8269e)
+**Date:** 2026-05-26
+**Status:** Approved (design), pending implementation plan
+
+## Goal
+
+Resolve the *verified-real* findings from an external audit of schliff (run by a downstream
+project, "Jarvis", that wants to inherit schliff's episodic-memory + autonomous-loop +
+anti-gaming engines). The audit ran against an **installed 6.1.0**; the repo is at **7.2.0**.
+Four read-only research passes separated real findings from stale ones. This spec fixes the
+real ones and substantiates one unproven claim.
+
+## Context — verified delta (7.2.0)
+
+| Audit finding | Verdict in 7.2.0 | Evidence |
+|---|---|---|
+| Dual-scale composite bug (38 vs 44.9) | **STALE/FIXED** | Single normalized `compute_composite` (`scoring/composite.py:107-116`); old cap is dead code (`scoring/security.py:231`, never called) |
+| Anti-gaming: gamed ≥ clean at composite | **REAL** | `composite.py:116` drops unmeasured dims + renormalizes; without eval suite quality(0.20)+edges(0.15)=35% discriminating weight vanishes. `benchmarks/anti-gaming/run.py` has no clean-control, only asserts per-dim `<80`, never composite separation |
+| Version drift 6.1.0 vs 7.2.0 | **REAL** | `.claude-plugin/plugin.json:3` = `6.1.0`; no `__version__` single-source |
+| "60-70% rule-based patches" | **UNSUBSTANTIATED** | 7 assertion sites, no measurement; gradient catalog ~56% high-confidence |
+| Episodic memory test | **REAL gap** | `episodic_store.py` impl present (TF-IDF+cosine, flock, atomic rename); no pytest file, only `_run_self_test` CLI flag |
+| 7-vs-8 dims / "4/8 measured" | **Mostly FIXED** | Registry single-source, security opt-in; residual: `total_count` cosmetic shows "7/8" |
+| pytest not default runner | **Mostly FIXED** | testpaths+CI, 1131 tests green; residual: `make test` runs bash, no pre-commit |
+
+## Requirements
+
+### W1 — Anti-gaming composite integrity (TDD, core)
+
+**Problem.** When no eval suite is present (the common case), the substance-bearing dims
+`quality` (0.20) and `edges` (0.15) return `-1` and are dropped from the composite, which
+renormalizes over the remaining gameable surface dims. A keyword-stuffed skill can therefore
+match or beat a clean one at composite level. The anti-gaming benchmark does not guard against
+this (no clean control, no composite-separation assertion).
+
+**W1a — Guard (write first, expect red).**
+- Add a genuine clean-reference skill to `benchmarks/anti-gaming/skills/`.
+- Add a benchmark assertion: under the no-eval-suite condition (as `run.py` already scores),
+  every gamed skill's composite MUST be `< clean_composite`. Make it a real gate (non-zero
+  exit on failure) and wrap it in a pytest test so it runs in the suite.
+- Construct a representative gamed/clean pair (the audit's exact 78/76.5 files are not
+  available). **Honest constraint:** if 7.2.0 already separates the pair (better than 6.1.0),
+  that is itself a finding — the guard still has value as a regression net, and W1b's formula
+  change is reduced to the coverage-honesty lever only. Do NOT claim a reproduction not observed.
+
+**W1b — Fix until green (two levers).**
+- **(a) Coverage-confidence cap** in `composite.py`: when the discriminating dims
+  (`quality`+`edges`) are unmeasured, the composite cannot exceed a coverage-derived ceiling.
+  Addresses cross-artifact comparability (a 0.65-coverage 78 must not read as trustworthy as a
+  full-coverage 78). Lowers gamed and clean equally — does NOT by itself reorder a same-coverage
+  pair.
+- **(b) Surface-dim penalty** sufficient to make `gamed_composite < clean_composite` at equal
+  coverage. The exact lever (e.g., trigger keyword-density / vocabulary-diversity signal on the
+  measured dims) is decided only after reproducing the inversion in W1a.
+
+**Impact.** Lever (a) shifts no-eval-suite scores downward. Must: re-baseline golden-score
+fixtures, update anti-gaming benchmark numbers in docs, and **document the score shift explicitly**
+so the parallel failure-mode calibration session can absorb it. This is the one workstream that
+touches `scoring/composite.py`; coordinate before merge.
+
+### W2 — Substantiate the "60-70%" claim
+
+- Add `scripts/measure_patch_ratio.py`: count gradients in `text_gradient.py` by `confidence`
+  (deterministic/auto-appliable vs LLM), compute the real ratio. Canonical, re-runnable source.
+- Correct all 7 assertion sites (README ×2, `SKILL.md`, `docs/ARCHITECTURE.md`, 2 specs,
+  `auto-improve.py` docstring) to the **measured** figure with a footnote pointing to the script.
+
+### W3 — Version single-source
+
+- Add `__version__` to `skills/schliff/__init__.py` as the source of truth.
+- Bump `.claude-plugin/plugin.json` `6.1.0` → `7.2.0`.
+- Add a pytest test asserting version consistency across `pyproject.toml`, `plugin.json`,
+  and `__version__` (prevents future drift).
+
+### W4 — Episodic-memory unit test
+
+- Add `skills/schliff/tests/unit/test_episodic_store.py`: store/recall, cross-process
+  persistence, flock path, atomic rename, size-cap eviction, TF-IDF cosine ranking. Build on the
+  behaviours the existing `_run_self_test` already exercises.
+
+### W5 — pytest as default runner
+
+- `make test` invokes pytest (alongside, not replacing, existing integration scripts).
+- Optional minimal `.pre-commit-config.yaml` with a pytest hook. No restructuring of existing
+  integration tests.
+
+### W6 — Housekeeping (composite-coherent with W1)
+
+- Remove dead `get_composite_cap()` (`scoring/security.py:231`) and its test reference.
+- Fix cosmetic `total_count` so a default run reports "7/7" not "7/8" (exclude unmeasured opt-in
+  dims from the denominator). Implement coherently with W1's coverage logic.
+
+## Technical decisions
+
+- **TDD for W1.** Guard (red) before fix (green). The guard is the success criterion.
+- **No silent score changes.** Any composite shift is documented + golden scores re-baselined in
+  the same commit, with a note for the calibration session.
+- **Atomic commits per workstream.** Order: W1 → W6 → W2/W3/W4/W5 (latter four independent).
+- **Stay clear of in-flight worktrees** (phase-1c/3b/3c own MCP scorer modules + badges). W1/W6
+  touch `composite.py`/`security.py`, untouched by those branches but indirectly relevant to the
+  calibration session — flag at merge.
+
+## Open questions
+
+1. **W1b reproduction:** Does 7.2.0 still exhibit gamed ≥ clean with a constructed pair? Resolved
+   empirically in W1a before committing to lever (b).
+2. **Coverage-cap shape:** Hard ceiling vs proportional discount when discriminating dims absent.
+   Decided against the reproduced numbers so the cap is calibrated, not arbitrary.
+3. **Golden-score blast radius:** How many fixtures/docs encode no-eval-suite composites that W1b(a)
+   will move. Enumerated before the W1b commit.
+
+## Success criteria
+
+- `benchmarks/anti-gaming` gate: every gamed composite `<` clean composite; pytest-wrapped, green.
+- `measure_patch_ratio.py` runs; all 7 sites cite the measured figure + methodology.
+- Version consistency test green; `plugin.json` = 7.2.0.
+- `test_episodic_store.py` green; covers persistence, locking, atomic write, ranking.
+- `make test` runs pytest; full suite green (≥1131, plus new tests).
+- Dead `get_composite_cap()` gone; default run reports "7/7".

--- a/docs/superpowers/specs/2026-05-26-audit-followups-design.md
+++ b/docs/superpowers/specs/2026-05-26-audit-followups-design.md
@@ -16,8 +16,9 @@ real ones and substantiates one unproven claim.
 
 | Audit finding | Verdict in 7.2.0 | Evidence |
 |---|---|---|
-| Dual-scale composite bug (38 vs 44.9) | **STALE/FIXED** | Single normalized `compute_composite` (`scoring/composite.py:107-116`); old cap is dead code (`scoring/security.py:231`, never called) |
-| Anti-gaming: gamed ≥ clean at composite | **REAL** | `composite.py:116` drops unmeasured dims + renormalizes; without eval suite quality(0.20)+edges(0.15)=35% discriminating weight vanishes. `benchmarks/anti-gaming/run.py` has no clean-control, only asserts per-dim `<80`, never composite separation |
+| Dual-scale composite (magnitude 38 vs 44.9) | **STALE** (the 6.1.0 cap artifact is gone) | Old cap is dead code (`scoring/security.py:231`, never called) |
+| Dual-scale composite (**conceptual**) | **REAL** | Same file → two numbers: CLI/doctor/bench use 7 dims (`cli.py:114`), evolve uses 8 dims with security (`evolve/engine.py:50`). `composite.py:116` renormalizes over *measured* weight, so the denominator differs by dim-set. A measurement instrument must give one reading per input. |
+| Anti-gaming: gamed ≥ clean at composite | **REAL — same root cause as conceptual dual-scale** | `composite.py:116` renormalize-over-measured drops `quality`(0.20)+`edges`(0.15)=35% discriminating weight when no eval suite → composite from gameable surface dims only. `benchmarks/anti-gaming/run.py` has no clean-control, only asserts per-dim `<80`, never composite separation |
 | Version drift 6.1.0 vs 7.2.0 | **REAL** | `.claude-plugin/plugin.json:3` = `6.1.0`; no `__version__` single-source |
 | "60-70% rule-based patches" | **UNSUBSTANTIATED** | 7 assertion sites, no measurement; gradient catalog ~56% high-confidence |
 | Episodic memory test | **REAL gap** | `episodic_store.py` impl present (TF-IDF+cosine, flock, atomic rename); no pytest file, only `_run_self_test` CLI flag |
@@ -26,38 +27,63 @@ real ones and substantiates one unproven claim.
 
 ## Requirements
 
-### W1 — Anti-gaming composite integrity (TDD, core)
+### W1 — Unified composite + anti-gaming separation (TDD, core)
 
-**Problem.** When no eval suite is present (the common case), the substance-bearing dims
-`quality` (0.20) and `edges` (0.15) return `-1` and are dropped from the composite, which
-renormalizes over the remaining gameable surface dims. A keyword-stuffed skill can therefore
-match or beat a clean one at composite level. The anti-gaming benchmark does not guard against
-this (no clean control, no composite-separation assertion).
+**Root cause (one line, two symptoms).** `composite.py:116` computes `total / weight_sum`,
+renormalizing over the *measured* weight. This single choice produces BOTH: (1) conceptual
+dual-scale — different measured dim-sets → different denominators → different numbers for the
+same file; (2) the anti-gaming hole — unmeasured discriminating dims (`quality`+`edges`) are
+silently dropped, so without an eval suite the composite is computed from gameable surface dims
+only. One correct aggregation definition fixes both.
 
-**W1a — Guard (write first, expect red).**
+**Unified composite definition (decided — AI-evals best practice, Husain/Shankar):**
+1. **Canonical composite = the 7 default dims** (security/runtime excluded), weights renormalized
+   to sum 1.0. Every entrypoint (CLI, evolve, doctor, bench) computes this identically.
+2. **Full-denominator aggregation (Path B): unmeasured = uncredited, not failed.**
+   `composite = Σ(s·w for measured) / Σ(w for ALL canonical dims)`. No renormalization-credit for
+   dims that were never evaluated. A structurally-perfect skill with no eval suite reads ~65 = "your
+   ceiling is your coverage until you verify the rest." Rationale: (a) you don't get credit for what
+   you didn't measure (core doctrine); (b) the number means one thing at any coverage (comparable);
+   (c) right incentive — to score high you must write an eval suite (serves the v8 eval-adapter goal);
+   (d) structurally caps the gamed-no-eval-suite illusion; (e) one formula, no arbitrary ceiling knob.
+3. **Coverage is a first-class, inseparable qualifier**, not buried metadata. Headline reads e.g.
+   `verified 65/100 (coverage 65% — 35% unverified; add an eval suite to lift the ceiling)`. This is
+   the framing that makes "uncredited ≠ failed" true to the user.
+4. **Security/runtime = separate signal + gate**, never folded into the headline composite. Removes
+   the security-on/off divergence at the source and treats safety as first-class (v8 safety pillar).
+5. **Per-dimension scores stay visible** — the real decision/error-analysis surface (doctrine: don't
+   optimize a single aggregate; read the failure-mode vector).
+
+**W1a — Guards (write first, expect red).**
 - Add a genuine clean-reference skill to `benchmarks/anti-gaming/skills/`.
-- Add a benchmark assertion: under the no-eval-suite condition (as `run.py` already scores),
-  every gamed skill's composite MUST be `< clean_composite`. Make it a real gate (non-zero
-  exit on failure) and wrap it in a pytest test so it runs in the suite.
-- Construct a representative gamed/clean pair (the audit's exact 78/76.5 files are not
-  available). **Honest constraint:** if 7.2.0 already separates the pair (better than 6.1.0),
-  that is itself a finding — the guard still has value as a regression net, and W1b's formula
-  change is reduced to the coverage-honesty lever only. Do NOT claim a reproduction not observed.
+- **Guard 1 (separation):** every gamed skill's composite MUST be `< clean_composite` under the
+  no-eval-suite condition. Real gate (non-zero exit) + pytest wrapper.
+- **Guard 2 (unification / no dual-scale):** for a fixture file, CLI-headline composite ==
+  evolve-headline composite (now both 7-dim canonical). Pins the unification permanently.
+- Construct a representative gamed/clean pair (the audit's exact 78/76.5 files are unavailable).
+  **Honest constraint:** if a constructed pair does not reproduce gamed ≥ clean on 7.2.0, that is
+  itself a finding — the guards still pin the invariants as regression nets. Do NOT claim a
+  reproduction not observed.
 
-**W1b — Fix until green (two levers).**
-- **(a) Coverage-confidence cap** in `composite.py`: when the discriminating dims
-  (`quality`+`edges`) are unmeasured, the composite cannot exceed a coverage-derived ceiling.
-  Addresses cross-artifact comparability (a 0.65-coverage 78 must not read as trustworthy as a
-  full-coverage 78). Lowers gamed and clean equally — does NOT by itself reorder a same-coverage
-  pair.
-- **(b) Surface-dim penalty** sufficient to make `gamed_composite < clean_composite` at equal
-  coverage. The exact lever (e.g., trigger keyword-density / vocabulary-diversity signal on the
-  measured dims) is decided only after reproducing the inversion in W1a.
+**W1b — Fix until green (two orthogonal levers).**
+- **Lever 1 — aggregation:** implement the unified full-denominator composite (def. 1-4 above).
+  Fixes dual-scale entirely and removes the misleading-high-magnitude half of anti-gaming.
+- **Lever 2 — surface-dim gaming penalty:** make `gamed_composite < clean_composite` at *equal*
+  coverage (the denominator change alone does not reorder a same-coverage pair). Exact lever
+  (e.g. trigger keyword-density / vocabulary-diversity signal on measured dims) decided only after
+  reproducing the inversion in W1a.
 
-**Impact.** Lever (a) shifts no-eval-suite scores downward. Must: re-baseline golden-score
-fixtures, update anti-gaming benchmark numbers in docs, and **document the score shift explicitly**
-so the parallel failure-mode calibration session can absorb it. This is the one workstream that
-touches `scoring/composite.py`; coordinate before merge.
+**Impact / blast radius (the safety accounting).**
+- Full-denominator rescales no-eval-suite composites downward (~×coverage). Affects: deterministic
+  golden-score fixtures, doc example numbers, and **threshold semantics** (`fail if score<70` in the
+  GitHub Action / pre-commit) — a documented scale change at the v8 major boundary; CHANGELOG must
+  call it out as breaking.
+- **NOT affected (verified):** the failure-mode calibration corpus (`LABELS.md`) labels *binary per
+  failure-mode dimension*, it is not composite-scored — so the LLM-judge calibration is largely
+  orthogonal to this rescale. Re-baselining now (corpus in Phase-1) is cheapest.
+- Re-baseline all golden scores + regenerate anti-gaming/doc numbers in the same commit; document
+  the shift for the parallel calibration session. This is the one workstream touching
+  `scoring/composite.py` / `registry.py`; coordinate before merge.
 
 ### W2 — Substantiate the "60-70%" claim
 
@@ -87,34 +113,46 @@ touches `scoring/composite.py`; coordinate before merge.
 
 ### W6 — Housekeeping (composite-coherent with W1)
 
-- Remove dead `get_composite_cap()` (`scoring/security.py:231`) and its test reference.
-- Fix cosmetic `total_count` so a default run reports "7/7" not "7/8" (exclude unmeasured opt-in
-  dims from the denominator). Implement coherently with W1's coverage logic.
+- Remove dead `get_composite_cap()` (`scoring/security.py:231`) and its test reference. (If W1's
+  security-as-gate work needs a cap, that is a *new* gate function, not this dead one.)
+- `total_count`/coverage reporting falls out naturally once W1 makes the canonical headline set the
+  7 dims (security separated): a default run reports "7/7". Verify no "7/8" residue remains.
 
 ## Technical decisions
 
-- **TDD for W1.** Guard (red) before fix (green). The guard is the success criterion.
-- **No silent score changes.** Any composite shift is documented + golden scores re-baselined in
-  the same commit, with a note for the calibration session.
+- **Unified composite = full-denominator over 7 canonical dims, security/runtime separated**
+  (Path B). Decided as the AI-evals best practice: no credit for unmeasured dims, one comparable
+  number, coverage first-class, eval-suite-positive incentive. See W1.
+- **TDD for W1.** Guards (red) before fix (green). The guards are the success criteria.
+- **Scale change is a documented breaking change**, owned at the v8 major boundary; CHANGELOG entry
+  + threshold-semantics note. Golden scores re-baselined in the same commit, with a note for the
+  parallel calibration session. No silent score changes.
 - **Atomic commits per workstream.** Order: W1 → W6 → W2/W3/W4/W5 (latter four independent).
 - **Stay clear of in-flight worktrees** (phase-1c/3b/3c own MCP scorer modules + badges). W1/W6
-  touch `composite.py`/`security.py`, untouched by those branches but indirectly relevant to the
-  calibration session — flag at merge.
+  touch `composite.py`/`registry.py`/`security.py`, untouched by those branches but indirectly
+  relevant to the calibration session — flag at merge.
 
 ## Open questions
 
-1. **W1b reproduction:** Does 7.2.0 still exhibit gamed ≥ clean with a constructed pair? Resolved
-   empirically in W1a before committing to lever (b).
-2. **Coverage-cap shape:** Hard ceiling vs proportional discount when discriminating dims absent.
-   Decided against the reproduced numbers so the cap is calibrated, not arbitrary.
-3. **Golden-score blast radius:** How many fixtures/docs encode no-eval-suite composites that W1b(a)
-   will move. Enumerated before the W1b commit.
+1. **Lever-2 reproduction:** Does 7.2.0 still exhibit gamed ≥ clean at equal coverage with a
+   constructed pair? Resolved empirically in W1a before committing to the surface-penalty lever.
+2. **Surface-penalty lever choice:** which measured-dim signal (trigger keyword-density,
+   vocabulary diversity, cross-section repetition) reorders the pair. Decided against the
+   reproduced numbers so it is calibrated, not arbitrary.
+3. **Blast radius enumeration:** which fixtures/docs/threshold configs encode no-eval-suite
+   composites that the full-denominator change moves. Enumerated before the W1b commit.
+4. **Coverage in the headline string vs structured field only:** how loudly coverage travels with
+   the number in each surface (CLI, doctor table, badge, action output). Settled per-surface in W1b.
 
 ## Success criteria
 
-- `benchmarks/anti-gaming` gate: every gamed composite `<` clean composite; pytest-wrapped, green.
+- **Anti-gaming gate:** every gamed composite `<` clean composite; pytest-wrapped, green.
+- **Unification gate:** CLI-headline composite == evolve-headline composite for a fixture file
+  (no dual-scale); pytest-wrapped, green.
+- **Coverage honesty:** a no-eval-suite score reports its coverage inseparably; a perfect-structural
+  no-eval-suite skill cannot read as a full-coverage high score.
 - `measure_patch_ratio.py` runs; all 7 sites cite the measured figure + methodology.
 - Version consistency test green; `plugin.json` = 7.2.0.
 - `test_episodic_store.py` green; covers persistence, locking, atomic write, ranking.
-- `make test` runs pytest; full suite green (≥1131, plus new tests).
-- Dead `get_composite_cap()` gone; default run reports "7/7".
+- `make test` runs pytest; full suite green (≥1131, plus new tests), golden scores re-baselined.
+- Dead `get_composite_cap()` gone; default run reports "7/7"; CHANGELOG documents the scale change.

--- a/skills/schliff/SKILL.md
+++ b/skills/schliff/SKILL.md
@@ -3,7 +3,7 @@ name: schliff
 description: >
   Deterministic skill linter and scoring engine for Claude Code — the Ruff for
   SKILL.md files. 7-dimension structural scoring (structure, triggers, quality,
-  edges, efficiency, composability, clarity) with anti-gaming detection, 60-70%
+  edges, efficiency, composability, clarity) with anti-gaming detection, ~32%
   rule-based patches, and cross-session episodic memory. An autoresearch loop
   that measures first, then fixes — not the other way around. Use for linting,
   scoring, and autonomously improving any Claude Code skill: trigger accuracy,

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,0 +1,3 @@
+"""Schliff — deterministic SKILL.md linter and scoring engine."""
+
+__version__ = "7.2.0"

--- a/skills/schliff/references/metrics-catalog.md
+++ b/skills/schliff/references/metrics-catalog.md
@@ -169,10 +169,10 @@ total = (
 )
 ```
 
-Dimensions that return `-1` (unmeasured) are excluded and the remaining
-weights are renormalized. The scorer reports **weight coverage** — the
-fraction of total weight actually measured — and warns when coverage is
-below 50%.
+Dimensions that return `-1` (unmeasured) are uncredited — the composite
+divides by the full canonical weight sum, so the score ceiling equals
+coverage. The scorer reports **coverage** — the fraction of total weight
+actually measured — and warns when coverage is below 50%.
 
 **Quality tiers (with sufficient coverage):**
 - 90+ Excellent — production-ready, community-shareable

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -4,7 +4,7 @@
 Drives the entire improvement loop without a Claude session:
   baseline score → gradient → top-3 exploration → score → keep best/revert → log → repeat
 
-60-70% of gradients are deterministic (frontmatter fixes, noise removal, TODO cleanup).
+~32% of gradients are deterministic (measured by measure_patch_ratio.py: confidence=high, single-edit effort).
 These are applied directly. Medium/low-confidence changes fall back to claude -p.
 
 Usage:

--- a/skills/schliff/scripts/measure_patch_ratio.py
+++ b/skills/schliff/scripts/measure_patch_ratio.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Measure the real deterministic-vs-LLM patch ratio — canonical source for the README claim.
+
+A patch is auto-applied deterministically iff text_gradient.py's apply gate accepts it:
+    confidence == "high" AND effort <= EFFORT_SIMPLE   (text_gradient.py)
+Everything else falls back to the LLM. This script parses the gradient catalog statically.
+"""
+from __future__ import annotations
+import ast
+import json
+from pathlib import Path
+
+_GRADIENT = Path(__file__).resolve().parent / "text_gradient.py"
+EFFORT_SIMPLE = 1
+DEFINITION = 'confidence=="high" and effort<=EFFORT_SIMPLE'
+
+
+def _gradient_dicts(tree: ast.AST) -> list[dict]:
+    """Collect dict literals that look like gradients (have 'confidence' + 'delta' keys)."""
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
+        if "confidence" in keys and "delta" in keys and "effort" in keys:
+            d = {}
+            for k, v in zip(node.keys, node.values):
+                if isinstance(k, ast.Constant) and isinstance(v, ast.Constant):
+                    d[k.value] = v.value
+                elif isinstance(k, ast.Constant) and isinstance(v, ast.Name):
+                    # effort uses named constants (EFFORT_SIMPLE=1, etc.)
+                    d[k.value] = {"EFFORT_SIMPLE": 1, "EFFORT_MODERATE": 2,
+                                  "EFFORT_COMPLEX": 3, "EFFORT_MAJOR": 4}.get(v.id, 2)
+            out.append(d)
+    return out
+
+
+def measure() -> dict:
+    tree = ast.parse(_GRADIENT.read_text(encoding="utf-8"))
+    grads = _gradient_dicts(tree)
+    total = len(grads)
+    deterministic = sum(
+        1 for g in grads
+        if g.get("confidence") == "high" and int(g.get("effort", 2)) <= EFFORT_SIMPLE
+    )
+    return {
+        "total": total,
+        "deterministic": deterministic,
+        "llm": total - deterministic,
+        "deterministic_ratio": round(deterministic / total, 3) if total else 0.0,
+        "definition": DEFINITION,
+    }
+
+
+def main():
+    m = measure()
+    print(json.dumps(m, indent=2))
+    print(f"\nDeterministic patches: {m['deterministic']}/{m['total']} "
+          f"= {m['deterministic_ratio']:.0%}  ({m['definition']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/schliff/scripts/score-skill.py
+++ b/skills/schliff/scripts/score-skill.py
@@ -147,7 +147,7 @@ def main():
         tc = composite_result['total_dimensions']
         wc = composite_result['weight_coverage']
         if mc < tc:
-            print(f"  [{mc}/{tc} dimensions measured, {wc:.0%} weight coverage]")
+            print(f"  [{mc}/{tc} dimensions measured, {wc:.0%} coverage]")
 
         print(f"{'='*60}")
         for dim, data in scores.items():

--- a/skills/schliff/scripts/scoring/composite.py
+++ b/skills/schliff/scripts/scoring/composite.py
@@ -13,6 +13,10 @@ _calibrated_weights_mtime: float = 0.0
 _calibrated_weights_path: str = ""
 
 
+# Security is a separate advisory gate, never folded into the headline composite.
+SECURITY_GATE = 70
+
+
 def _load_calibrated_weights() -> Optional[dict]:
     """Load auto-calibrated weights from ~/.schliff/meta/calibrated-weights.json.
 
@@ -50,6 +54,13 @@ def compute_composite(scores: dict, custom_weights: Optional[dict] = None,
                       fmt: Optional[str] = None) -> dict:
     """Compute weighted composite score with confidence indicator.
 
+    Uses a full-denominator model: unmeasured dims are uncredited (contribute 0
+    but stay in the basis), so a skill's score ceiling equals its coverage. The
+    canonical headline basis is format-aware via get_headline_excluded — for the
+    skill.md family security+runtime are excluded, for system_prompt only runtime
+    is (security is a core 0.15 dim that stays in the headline). Security and
+    runtime are also reported as separate signals in `signals`/`security`.
+
     Returns both the score and metadata about how many dimensions
     were actually measured, so users know how trustworthy the number is.
 
@@ -61,79 +72,80 @@ def compute_composite(scores: dict, custom_weights: Optional[dict] = None,
         fmt: Optional format identifier. When provided, weights are loaded
             from the scorer registry. Defaults to "skill.md" weights.
     """
-    from scoring.registry import get_weights
+    from scoring.registry import get_weights, get_headline_excluded
 
     weights = get_weights(fmt if fmt is not None else "skill.md")
+    explicit = set(custom_weights or {})
 
-    # Apply custom weights if provided (highest priority)
-    # Custom weights OVERRIDE defaults for specified keys but keep unspecified dimensions.
-    # When custom_weights are active, opt-in dimensions (security, clarity) are excluded
-    # unless the user explicitly includes them in custom_weights.
     if custom_weights:
-        # When custom weights are provided, only keep dimensions that the user
-        # explicitly included. Dimensions not in custom_weights but present in
-        # the registry defaults are kept (they form the baseline). However,
-        # "supplementary" dimensions (clarity, security) that were traditionally
-        # handled specially are excluded unless explicitly in custom_weights.
         _SUPPLEMENTARY = {"clarity", "security"}
         for dim in list(weights):
             if dim in _SUPPLEMENTARY and dim not in custom_weights:
                 del weights[dim]
-        # Reject negative weights
         for k, v in custom_weights.items():
             if k in weights and isinstance(v, (int, float)) and math.isfinite(v) and v >= 0:
                 weights[k] = v
-        # Normalize all weights to sum to 1.0
-        total_w = sum(weights.values())
-        if total_w > 0:
-            weights = {k: v / total_w for k, v in weights.items()}
     else:
-        # Try auto-calibrated weights (second priority)
         calibrated = _load_calibrated_weights()
         if calibrated:
-            calibrated_filtered = {k: v for k, v in calibrated.items() if k in weights}
-            if calibrated_filtered:
-                for k, v in calibrated_filtered.items():
+            for k, v in calibrated.items():
+                if k in weights:
                     weights[k] = v
-                total_w = sum(weights.values())
-                if total_w > 0:
-                    weights = {k: v / total_w for k, v in weights.items()}
 
+    # Canonical headline basis: format-aware. Dims excluded per get_headline_excluded are NEVER
+    # folded into the headline composite unless the caller explicitly weighted them via
+    # custom_weights. For skill.md family, security+runtime are excluded (security is an opt-in
+    # 0.05 side signal). For system_prompt, security is a CORE 0.15 dim and stays in the headline;
+    # only runtime is excluded. This is the single basis used by every entrypoint -> no dual-scale.
+    excluded = get_headline_excluded(fmt if fmt is not None else "skill.md")
+    canonical = {d: w for d, w in weights.items()
+                 if d not in excluded or d in explicit}
+    basis = sum(canonical.values())
+    if basis > 0:
+        canonical = {d: w / basis for d, w in canonical.items()}  # renormalize to 1.0
+
+    # Full-denominator aggregation: unmeasured dims are UNCREDITED (contribute 0), not dropped.
+    # composite = Σ(score·weight over measured) / Σ(all canonical weight == 1.0)
+    # => a skill's ceiling equals its coverage until the missing dims are verified.
     total = 0.0
-    weight_sum = 0.0
+    measured_w = 0.0
     measured = []
     unmeasured = []
-
-    for dim, weight in weights.items():
+    for dim, weight in canonical.items():
         s = scores.get(dim, {}).get("score", -1)
         if s >= 0:
             total += s * weight
-            weight_sum += weight
+            measured_w += weight
             measured.append(dim)
         else:
             unmeasured.append(dim)
 
-    composite = round(total / weight_sum, 1) if weight_sum > 0 else 0.0
-
-    # Confidence: what fraction of total weight is actually measured
-    confidence = round(weight_sum, 2)
+    composite = round(total, 1)            # divisor is 1.0 (full canonical basis)
+    coverage = round(measured_w, 2)
     measured_count = len(measured)
-    total_count = len(weights)
+    total_count = len(canonical)
 
     warnings = []
-    # Only warn about non-opt-in unmeasured dimensions (runtime, security are opt-in)
-    from scoring.registry import OPT_IN_SCORERS
-    warn_unmeasured = [d for d in unmeasured if d not in OPT_IN_SCORERS]
-    if warn_unmeasured:
+    if basis == 0:
+        warnings.append("No weighted dimensions to score.")
+    elif unmeasured:
         prefix = "Only " if measured_count <= 2 else ""
-        suffix = " Score is unreliable —" if measured_count <= 2 else ""
         warnings.append(
             f"{prefix}{measured_count}/{total_count} dimensions measured "
-            f"(weight coverage: {confidence:.0%}).{suffix} "
-            f"{'u' if measured_count <= 2 else 'U'}nmeasured: {', '.join(warn_unmeasured)}"
+            f"(coverage {coverage:.0%}). Unverified dimensions are uncredited — "
+            f"score ceiling is {coverage:.0%}. Unmeasured: {', '.join(unmeasured)}"
         )
 
-    # Confidence notes: explain what each dimension can and cannot tell you
+    # Security/runtime: reported as SEPARATE signals, never in the headline composite.
+    signals = {}
+    for opt in ("security", "runtime"):
+        sv = scores.get(opt, {}).get("score", -1)
+        if sv is not None and sv >= 0:
+            signals[opt] = ({
+                "score": sv,
+                "status": "pass" if sv >= SECURITY_GATE else "flag",
+            } if opt == "security" else {"score": sv})
+
     confidence_notes = {
         "structure": "Measures file organization (frontmatter, headers, length, references). "
                      "Cannot assess whether instructions are correct or effective.",
@@ -149,12 +161,9 @@ def compute_composite(scores: dict, custom_weights: Optional[dict] = None,
                          "Cannot verify the skill works correctly alongside other skills.",
         "clarity": "Measures contradiction, vague reference, and ambiguity patterns. "
                    "Cannot assess whether instructions are clear to Claude in practice.",
-        "security": "Measures security anti-patterns (hardcoded secrets, injection vectors, "
-                     "unsafe operations). Cannot assess runtime security posture.",
     }
 
-    # Determine score type based on what was measured
-    has_runtime = "runtime" in measured
+    has_runtime = "runtime" in signals
     score_type = "structural+runtime" if has_runtime else "structural"
 
     return {
@@ -162,8 +171,10 @@ def compute_composite(scores: dict, custom_weights: Optional[dict] = None,
         "score_type": score_type,
         "measured_dimensions": measured_count,
         "total_dimensions": total_count,
-        "weight_coverage": confidence,
+        "weight_coverage": coverage,
         "unmeasured": unmeasured,
         "warnings": warnings,
+        "signals": signals,
+        "security": signals.get("security", {}),
         "confidence_notes": {k: v for k, v in confidence_notes.items() if k in measured},
     }

--- a/skills/schliff/scripts/scoring/efficiency.py
+++ b/skills/schliff/scripts/scoring/efficiency.py
@@ -3,13 +3,42 @@
 Measures how much useful, actionable content the skill delivers
 relative to its total size. Penalizes bloat, rewards conciseness.
 """
+from collections import Counter
+
 from shared import read_skill_safe, strip_frontmatter
+from nlp import RE_WORD_TOKEN, STOPWORDS
 from scoring.patterns import (
     _RE_ACTIONABLE_LINES, _RE_REAL_EXAMPLES, _RE_WHY_COUNT,
     _RE_VERIFICATION_CMDS, _RE_HEDGING, _RE_FILLER_PHRASES,
     _RE_OBVIOUS_INSTRUCTIONS, _RE_SCOPE_BOUNDARY,
     _RE_CODE_BLOCK_REGION,
 )
+
+# Anti-gaming: spread keyword stuffing. A body that repeats one meaningful term far
+# beyond what natural prose requires is low-information padding even when it is spread
+# across many distinct lines (so repeated_lines misses it). We count the EXCESS
+# occurrences of any over-used term as noise. Thresholds are deliberately lax so a
+# genuinely domain-focused skill (which repeats its subject a handful of times) is
+# untouched; only pathological domination is penalized.
+_STUFF_MIN_PROSE_TOKENS = 40   # need enough prose to judge term frequency
+_STUFF_DOMINANCE = 0.12        # a term exceeding 12% of meaningful prose tokens is over-used
+_STUFF_MIN_COUNT = 8           # ...and occurs at least this many times
+
+
+def _spread_stuffing_noise(prose: str) -> tuple[int, list[str]]:
+    """Return (excess-repetition noise, issues) for over-used meaningful terms in prose."""
+    tokens = [w for w in RE_WORD_TOKEN.findall(prose.lower()) if w not in STOPWORDS]
+    n = len(tokens)
+    if n < _STUFF_MIN_PROSE_TOKENS:
+        return 0, []
+    allowed = max(_STUFF_MIN_COUNT, int(_STUFF_DOMINANCE * n))
+    noise = 0
+    issues: list[str] = []
+    for term, count in Counter(tokens).most_common(3):
+        if count >= _STUFF_MIN_COUNT and count > allowed:
+            noise += count - allowed
+            issues.append(f"keyword_stuffing:{term}:{count}_of_{n}")
+    return noise, issues
 
 
 def score_efficiency(skill_path: str) -> dict:
@@ -92,6 +121,9 @@ def score_efficiency(skill_path: str) -> dict:
         line_counts[key] = line_counts.get(key, 0) + 1
     repeated_lines = sum(count - 1 for count in line_counts.values() if count >= 3)
 
+    # Spread keyword stuffing: over-used meaningful terms across distinct lines.
+    stuffing_noise, stuffing_issues = _spread_stuffing_noise(prose_content)
+
     # Empty/near-empty lines ratio
     empty_lines = sum(1 for line in lines if not line.strip())
     empty_ratio = empty_lines / max(total_lines, 1)
@@ -110,7 +142,8 @@ def score_efficiency(skill_path: str) -> dict:
         hedge_count * 3 +
         filler_phrases * 2 +
         obvious_instructions * 2 +
-        repeated_lines * 2           # Repeated identical lines are padding
+        repeated_lines * 2 +         # Repeated identical lines are padding
+        stuffing_noise * 2           # Over-used keywords spread across lines are padding
     )
 
     # Density = signal per 100 words, penalized by noise
@@ -154,6 +187,7 @@ def score_efficiency(skill_path: str) -> dict:
         issues.append(f"verbose:{total_words}_words")
     if repeated_lines > 3:
         issues.append(f"repeated_lines:{repeated_lines}")
+    issues.extend(stuffing_issues)
 
     return {
         "score": int(min(100, max(0, score))),
@@ -170,5 +204,6 @@ def score_efficiency(skill_path: str) -> dict:
             "hedge_count": hedge_count,
             "filler_phrases": filler_phrases,
             "repeated_lines": repeated_lines,
+            "stuffing_noise": stuffing_noise,
         }
     }

--- a/skills/schliff/scripts/scoring/registry.py
+++ b/skills/schliff/scripts/scoring/registry.py
@@ -66,6 +66,29 @@ FORMAT_ALIASES: dict[str, str] = {
 # Opt-in dimensions — not included in default scoring runs
 OPT_IN_SCORERS: frozenset[str] = frozenset({"runtime", "security"})
 
+# Dimensions excluded from the HEADLINE composite per format (reported as separate signals
+# instead of being folded into the headline number). For the skill.md family, security is an
+# opt-in side signal (weight 0.05, off by default). For system_prompt, security is a CORE
+# scored dimension (weight 0.15) and MUST remain in the headline. runtime is never in the
+# headline (it has no profile weight and is an opt-in side signal).
+_HEADLINE_EXCLUDED_INSTRUCTION = frozenset({"security", "runtime"})
+HEADLINE_EXCLUDED: dict[str, frozenset] = {
+    "skill.md": _HEADLINE_EXCLUDED_INSTRUCTION,
+    "claude.md": _HEADLINE_EXCLUDED_INSTRUCTION,
+    "cursorrules": _HEADLINE_EXCLUDED_INSTRUCTION,
+    "agents.md": _HEADLINE_EXCLUDED_INSTRUCTION,
+    "system_prompt": frozenset({"runtime"}),  # security is a core system_prompt dimension
+}
+
+
+def get_headline_excluded(fmt: str) -> frozenset:
+    """Return the dims excluded from the headline composite for a format (resolves aliases).
+
+    Falls back to the instruction-file exclusion set for unknown formats.
+    """
+    resolved = FORMAT_ALIASES.get(fmt, fmt)
+    return HEADLINE_EXCLUDED.get(resolved, _HEADLINE_EXCLUDED_INSTRUCTION)
+
 
 # ---------------------------------------------------------------------------
 # Public API

--- a/skills/schliff/scripts/scoring/security.py
+++ b/skills/schliff/scripts/scoring/security.py
@@ -226,14 +226,3 @@ def score_security(skill_path: str) -> dict:
             "negation_excluded": negation_excluded,
         },
     }
-
-
-def get_composite_cap(security_score: int) -> int | None:
-    """Return composite score cap based on security score, or None if no cap."""
-    if security_score < 5:
-        return 20
-    if security_score < 10:
-        return 40
-    if security_score < 20:
-        return 60
-    return None

--- a/skills/schliff/scripts/verify.py
+++ b/skills/schliff/scripts/verify.py
@@ -59,6 +59,7 @@ def _score_skill(skill_path: str, eval_suite: Optional[dict] = None) -> dict:
         "dimensions": {k: v["score"] for k, v in scores.items()},
         "warnings": composite["warnings"],
         "score_type": composite.get("score_type", "structural"),
+        "weight_coverage": composite.get("weight_coverage", 0.0),
     }
 
 
@@ -146,6 +147,7 @@ def run_verify(
     _error_verdict = {
         "skill_path": skill_path, "composite": 0.0, "grade": "F",
         "dimensions": {}, "min_score": min_score,
+        "coverage": 0.0, "effective_min": min_score,
         "passed_threshold": False, "exit_code": 2, "message": "",
         "previous_score": None, "delta": None, "regression": False,
     }
@@ -162,13 +164,28 @@ def run_verify(
     composite = result["composite"]
     grade = result["grade"]
 
+    # Coverage-aware threshold: a skill without an eval suite has unmeasured
+    # dimensions, so its composite is capped at its weight coverage. Scaling the
+    # threshold by coverage judges the per-measured-dimension quality
+    # (composite / coverage) against min_score. An eval-suite skill reaches
+    # coverage→1.0 and is held to the full min_score across all dimensions.
+    coverage = float(result.get("weight_coverage", 0.0))
+    if coverage <= 0:
+        # No measured dimensions — nothing to credit. Keep the full bar so we
+        # never pass an unscoreable skill (and never divide by zero downstream).
+        effective_min = min_score
+    else:
+        effective_min = round(min_score * coverage, 1)
+
     verdict: dict = {
         "skill_path": skill_path,
         "composite": composite,
         "grade": grade,
         "dimensions": result["dimensions"],
         "min_score": min_score,
-        "passed_threshold": composite >= min_score,
+        "coverage": coverage,
+        "effective_min": effective_min,
+        "passed_threshold": composite >= effective_min,
         "exit_code": 0,
         "message": "",
         "previous_score": None,
@@ -176,11 +193,12 @@ def run_verify(
         "regression": False,
     }
 
-    # Threshold check
-    if composite < min_score:
+    # Threshold check (coverage-aware)
+    if composite < effective_min:
         verdict["exit_code"] = 1
         verdict["message"] = (
-            f"FAIL: {composite}/100 [{grade}] < minimum {min_score}"
+            f"FAIL: {composite}/100 [{grade}] < effective minimum {effective_min} "
+            f"(min {min_score} x coverage {coverage:.0%})"
         )
         # Still record history even on failure
         append_history(skill_path, result, history_path)
@@ -210,7 +228,10 @@ def run_verify(
                 f"PASS: {composite}/100 [{grade}] (no previous score)"
             )
     else:
-        verdict["message"] = f"PASS: {composite}/100 [{grade}] >= {min_score}"
+        verdict["message"] = (
+            f"PASS: {composite}/100 [{grade}] >= effective minimum {effective_min} "
+            f"(min {min_score} x coverage {coverage:.0%})"
+        )
 
     # Record to history
     append_history(skill_path, result, history_path)

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -114,6 +114,69 @@ def test_system_prompt_keeps_security_in_headline():
     assert r_sec100["weight_coverage"] == 1.0 and r_sec0["weight_coverage"] == 1.0
 
 
+def test_spread_keyword_stuffing_penalized(tmp_path):
+    """Spread keyword stuffing (one term repeated across many distinct lines) must be
+    caught as low-information padding by the MEASURED efficiency dimension, so it
+    lowers the composite. (Triggers is uncredited without an eval suite, so a penalty
+    there cannot move the composite — it must land in a measured dim.)"""
+    from scoring import score_efficiency
+    stuffed = tmp_path / "stuffed.md"
+    body = "\n".join(f"Deployment step {i}: run the deployment." for i in range(40))
+    stuffed.write_text(
+        f"---\nname: x\ndescription: deployment tool.\n---\n# X\n## Steps\n{body}\n",
+        encoding="utf-8")
+    result = score_efficiency(str(stuffed))
+    assert result["score"] < 80, f"keyword stuffing not penalized: {result['score']}"
+    assert any("keyword_stuffing" in str(i) for i in result["issues"])
+
+
+def test_clean_body_not_stuffing_penalized(tmp_path):
+    """Negative control: a domain-focused skill that legitimately repeats its subject
+    term ~9 times across 60+ varied prose tokens must NOT be flagged as stuffed,
+    so the penalty does not regress real-world skills.
+
+    This fixture deliberately exceeds _STUFF_MIN_PROSE_TOKENS (40) so the threshold
+    logic actually runs — the original fixture (~36 meaningful tokens) short-circuited
+    before reaching the dominance check, making the test vacuous.
+    """
+    from scoring import score_efficiency
+    clean = tmp_path / "clean.md"
+    # Body has ~86 meaningful tokens; "deployment" appears 9 times (10.5% dominance),
+    # which is below the 12% _STUFF_DOMINANCE threshold — must NOT trigger stuffing.
+    body = (
+        "A deployment skill that guides teams through safe rollout practices. "
+        "Before starting a deployment, verify the target environment is healthy "
+        "and all tests have passed. Each deployment should begin with smoke checks "
+        "against a staging replica. If the deployment fails its smoke checks, roll "
+        "back automatically and record the cause in the incident log. Stagger rollout "
+        "across availability zones so that a single bad deployment cannot bring down "
+        "the entire fleet. Document the deployment window in your team calendar, notify "
+        "the on-call engineer before you begin, and keep the deployment log for "
+        "compliance audit. A canary deployment reduces blast radius by routing a "
+        "fraction of traffic first, then widens once metrics look stable. Monitor "
+        "error rates closely after each deployment and compare them with the baseline "
+        "from last week before declaring success."
+    )
+    clean.write_text(
+        f"---\nname: deploy\ndescription: Use when rolling out a new version safely.\n---\n"
+        f"# Deploy\n## When to use\nUse before releasing to production.\n"
+        f"## Steps\n{body}\n",
+        encoding="utf-8")
+    result = score_efficiency(str(clean))
+    assert not any("keyword_stuffing" in str(i) for i in result["issues"]), \
+        f"clean body wrongly flagged: {result['issues']}"
+    assert result["score"] >= 70, \
+        f"legitimate domain skill scored too low: {result['score']}"
+
+
+def test_anti_gaming_benchmark_gate():
+    import subprocess
+    repo = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
+    proc = subprocess.run(["/usr/bin/python3", "benchmarks/anti-gaming/run.py"],
+                          cwd=str(repo), capture_output=True, text=True)
+    assert proc.returncode == 0, f"anti-gaming separation failed:\n{proc.stdout}"
+
+
 def test_evolve_score_file_matches_cli(tmp_path):
     """evolve._score_file must return the same headline composite as the CLI path."""
     import importlib

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -191,3 +191,10 @@ def test_evolve_score_file_matches_cli(tmp_path):
     _, evolve_composite = engine._score_file(str(skill))
     cli_composite = compute_composite(build_scores(str(skill)))["score"]  # CLI: no security
     assert evolve_composite == cli_composite
+
+
+def test_default_run_reports_seven_of_seven():
+    full = {d: {"score": 90} for d in
+            ["structure", "triggers", "quality", "edges", "efficiency", "composability", "clarity"]}
+    r = compute_composite(full)
+    assert r["measured_dimensions"] == 7 and r["total_dimensions"] == 7

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -61,7 +61,7 @@ def test_separation_gamed_below_clean():
     under the no-eval-suite condition (the common case)."""
     from scoring import (score_structure, score_triggers, score_quality, score_edges,
                          score_efficiency, score_composability, score_clarity)
-    bench_skills = Path(__file__).resolve().parents[3] / "benchmarks" / "anti-gaming" / "skills"
+    bench_skills = Path(__file__).resolve().parents[4] / "benchmarks" / "anti-gaming" / "skills"
 
     def composite_of(path):
         s = {

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -1,0 +1,97 @@
+"""Guards for the unified composite (spec 2026-05-26-audit-followups §W1).
+
+Pins three invariants permanently:
+  1. Separation: a gamed skill must NOT reach/beat a clean skill at composite level.
+  2. Unification: the same file scores identically via the CLI path and the evolve path
+     (no conceptual dual-scale).
+  3. Full-denominator: unmeasured dims are uncredited — a perfect-on-measured skill with
+     missing discriminating dims cannot read as a full-coverage high score.
+"""
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from scoring.composite import compute_composite  # noqa: E402
+
+
+def _scores(**dims):
+    """Helper: build a per-dimension score dict; omit a dim to leave it unmeasured (-1)."""
+    return {d: {"score": v} for d, v in dims.items()}
+
+
+def test_full_denominator_uncredits_unmeasured():
+    # All 7 canonical dims perfect EXCEPT quality+edges unmeasured (no eval suite).
+    measured = _scores(structure=100, triggers=100, efficiency=100,
+                        composability=100, clarity=100)  # quality, edges omitted
+    result = compute_composite(measured)
+    # quality(0.20)+edges(0.15)=0.35 of canonical weight is uncredited.
+    # Perfect-on-measured therefore caps at ~65, NOT ~100.
+    assert result["score"] <= 70, f"uncredited dims still credited: {result['score']}"
+    # canonical coverage = 1.0 - quality(0.20) - edges(0.15) = 0.65 (<= 0.66 bound)
+    assert result["weight_coverage"] <= 0.66
+    assert result["total_dimensions"] == 7  # security excluded from headline
+
+
+def test_full_coverage_unaffected():
+    # All 7 dims measured and perfect -> 100 (full denominator == full coverage).
+    full = _scores(structure=100, triggers=100, quality=100, edges=100,
+                   efficiency=100, composability=100, clarity=100)
+    result = compute_composite(full)
+    assert result["score"] == 100.0
+    assert result["weight_coverage"] == 1.0
+    assert result["total_dimensions"] == 7
+
+
+def test_security_excluded_from_headline():
+    # Security present and terrible must NOT move the headline composite.
+    base = _scores(structure=80, triggers=80, quality=80, edges=80,
+                   efficiency=80, composability=80, clarity=80)
+    without = compute_composite(dict(base))
+    with_sec = compute_composite({**base, "security": {"score": 0}})
+    assert without["score"] == with_sec["score"], "security leaked into headline"
+    # but security is reported separately
+    assert with_sec.get("security", {}).get("score") == 0
+
+
+def test_separation_gamed_below_clean():
+    """Real-file guard: a gamed skill must score strictly below the clean reference,
+    under the no-eval-suite condition (the common case)."""
+    from scoring import (score_structure, score_triggers, score_quality, score_edges,
+                         score_efficiency, score_composability, score_clarity)
+    bench_skills = Path(__file__).resolve().parents[3] / "benchmarks" / "anti-gaming" / "skills"
+
+    def composite_of(path):
+        s = {
+            "structure": score_structure(str(path)),
+            "triggers": score_triggers(str(path), None),
+            "quality": score_quality(str(path), None),
+            "edges": score_edges(str(path), None),
+            "efficiency": score_efficiency(str(path)),
+            "composability": score_composability(str(path)),
+            "clarity": score_clarity(str(path)),
+        }
+        return compute_composite(s)["score"]
+
+    import pytest
+    existing = [g for g in ["keyword-stuffing.md", "inflated-headers.md", "fake-examples.md",
+                            "bloated-preamble.md", "no-scope.md", "contradiction-skill.md"]
+                if (bench_skills / g).exists()]
+    if not existing:
+        pytest.skip("no gamed fixtures present")
+
+    clean = composite_of(bench_skills / "clean-reference.md")
+    for gamed in existing:
+        assert composite_of(bench_skills / gamed) < clean, f"{gamed} composite >= clean ({clean})"
+
+
+def test_unification_cli_equals_evolve():
+    """The same per-dimension scores must yield one headline composite regardless of
+    whether security was also scored (CLI omits it, evolve includes it)."""
+    dims = _scores(structure=82, triggers=78, quality=70, edges=66,
+                   efficiency=88, composability=74, clarity=90)
+    cli_path = compute_composite(dict(dims))                       # 7 dims (CLI)
+    evolve_path = compute_composite({**dims, "security": {"score": 55}})  # +security (evolve)
+    assert cli_path["score"] == evolve_path["score"], "dual-scale: CLI != evolve"

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -95,3 +95,20 @@ def test_unification_cli_equals_evolve():
     cli_path = compute_composite(dict(dims))                       # 7 dims (CLI)
     evolve_path = compute_composite({**dims, "security": {"score": 55}})  # +security (evolve)
     assert cli_path["score"] == evolve_path["score"], "dual-scale: CLI != evolve"
+
+
+def test_system_prompt_keeps_security_in_headline():
+    """For system_prompt, security is a CORE dim (weight 0.15) and must stay in the headline;
+    coverage must reflect it (not falsely report 1.0 when security is unmeasured)."""
+    # All system_prompt dims measured EXCEPT security -> coverage < 1.0 (security weight not credited)
+    sp = {d: {"score": 100} for d in
+          ["structure_prompt", "output_contract", "efficiency", "clarity", "composability", "completeness"]}
+    r = compute_composite(sp, fmt="system_prompt")
+    assert r["weight_coverage"] < 1.0, "system_prompt security weight wrongly excluded from basis"
+    # And when security IS measured, it participates in the headline: security=0 must score
+    # strictly below security=100 (it's in the basis, not a side signal). Both reach full
+    # coverage, so the headline delta is the proof that security is folded into the number.
+    r_sec0 = compute_composite({**sp, "security": {"score": 0}}, fmt="system_prompt")
+    r_sec100 = compute_composite({**sp, "security": {"score": 100}}, fmt="system_prompt")
+    assert r_sec0["score"] < r_sec100["score"], "security must move the system_prompt headline"
+    assert r_sec100["weight_coverage"] == 1.0 and r_sec0["weight_coverage"] == 1.0

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -112,3 +112,19 @@ def test_system_prompt_keeps_security_in_headline():
     r_sec100 = compute_composite({**sp, "security": {"score": 100}}, fmt="system_prompt")
     assert r_sec0["score"] < r_sec100["score"], "security must move the system_prompt headline"
     assert r_sec100["weight_coverage"] == 1.0 and r_sec0["weight_coverage"] == 1.0
+
+
+def test_evolve_score_file_matches_cli(tmp_path):
+    """evolve._score_file must return the same headline composite as the CLI path."""
+    import importlib
+    skill = tmp_path / "SKILL.md"
+    skill.write_text(
+        "---\nname: demo\ndescription: Use when demoing the evolve scoring path for parity tests.\n---\n"
+        "# Demo\n## When to use\nUse for parity testing.\n## Steps\n1. Do the thing.\n",
+        encoding="utf-8",
+    )
+    engine = importlib.import_module("evolve.engine")
+    from shared import build_scores
+    _, evolve_composite = engine._score_file(str(skill))
+    cli_composite = compute_composite(build_scores(str(skill)))["score"]  # CLI: no security
+    assert evolve_composite == cli_composite

--- a/skills/schliff/tests/unit/test_composite_weights.py
+++ b/skills/schliff/tests/unit/test_composite_weights.py
@@ -342,8 +342,16 @@ class TestMinusOneExclusion:
         result = compute_composite(scores)
         assert result["score"] == 0.0
 
-    def test_single_measured_dim_drives_composite(self):
-        """With one measured dimension its score must equal the composite (weight coverage=1)."""
+    def test_single_measured_dim_contributes_only_its_weight(self):
+        """Full-denominator model: one measured dim is UNCREDITED on the rest.
+
+        Only structure (canonical weight 0.15/0.95 ≈ 0.158) is measured; the other
+        six canonical dims are unmeasured and uncredited. The composite is therefore
+        the dim's score scaled by its canonical weight, NOT the raw dim score —
+        the old renormalize-to-coverage semantics are gone.
+            composite = 77 * (0.15 / 0.95) ≈ 12.2
+            weight_coverage = 0.15 / 0.95 ≈ 0.158
+        """
         scores = {
             "structure": _score(77),
             "triggers": {"score": -1, "issues": [], "details": {}},
@@ -353,7 +361,8 @@ class TestMinusOneExclusion:
             "composability": {"score": -1, "issues": [], "details": {}},
         }
         result = compute_composite(scores)
-        assert result["score"] == pytest.approx(77.0, abs=0.2)
+        assert result["score"] == pytest.approx(77.0 * (0.15 / 0.95), abs=0.2)
+        assert result["weight_coverage"] == pytest.approx(0.15 / 0.95, abs=0.01)
 
 
 # ---------------------------------------------------------------------------

--- a/skills/schliff/tests/unit/test_episodic_store.py
+++ b/skills/schliff/tests/unit/test_episodic_store.py
@@ -1,0 +1,67 @@
+"""Dedicated unit coverage for the episodic memory store (audit finding #1)."""
+import importlib
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import episodic_store as es  # noqa: E402
+
+
+def _isolate(tmp_path, monkeypatch):
+    """Point the store at a temp JSONL and clear the module TF-IDF cache."""
+    p = tmp_path / "episodes.jsonl"
+    monkeypatch.setattr(es, "EPISODES_PATH", p)
+    es._tfidf_cache.update({"mtime": 0.0, "filesize": 0, "index": None, "episodes": None})
+    return p
+
+
+def test_store_then_recall_roundtrip(tmp_path, monkeypatch):
+    p = _isolate(tmp_path, monkeypatch)
+    es.store_episode("skill-a", "trigger_expansion", "keep", 5.0,
+                     "Adding synonyms improved trigger accuracy", domain="skill")
+    assert p.exists()
+    results = es.recall("trigger accuracy", top_k=5)
+    assert results and results[0]["relevance"] > 0
+    assert results[0]["strategy"] == "trigger_expansion"
+
+
+def test_persistence_across_fresh_load(tmp_path, monkeypatch):
+    """Written episodes survive a cache-less reload (cross-process surrogate)."""
+    _isolate(tmp_path, monkeypatch)
+    es.store_episode("skill-b", "noise_reduction", "discard", -1.0,
+                     "Removing hedges hurt clarity", domain="skill")
+    # simulate a second process: drop the in-memory cache, reload from disk
+    es._tfidf_cache.update({"mtime": 0.0, "filesize": 0, "index": None, "episodes": None})
+    assert es.get_stats()["total"] == 1
+    assert es.recall("clarity", top_k=3)
+
+
+def test_ranking_orders_by_relevance(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    es.store_episode("s1", "trigger_expansion", "keep", 3.0,
+                     "trigger keyword overlap synonyms description", domain="skill")
+    es.store_episode("s2", "example_addition", "keep", 2.0,
+                     "completely unrelated output formatting examples", domain="testing")
+    results = es.recall("trigger keyword synonyms", top_k=2)
+    assert results[0]["strategy"] == "trigger_expansion"
+    assert results[0]["relevance"] >= results[-1]["relevance"]
+
+
+def test_atomic_rewrite_on_consolidation(tmp_path, monkeypatch):
+    """_enforce_size_cap rewrites via temp+rename and preserves recent episodes."""
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setattr(es, "MAX_EPISODES", 5)
+    monkeypatch.setattr(es, "CONSOLIDATION_BATCH", 3)
+    for i in range(8):
+        es.store_episode(f"s{i}", "strat", "keep", float(i), f"learning number {i}", domain="d")
+    es._enforce_size_cap()
+    total = es.get_stats()["total"]
+    assert total <= 8  # consolidated, not lost
+    assert not (tmp_path / "episodes.tmp").exists()  # temp cleaned up by rename
+
+
+def test_self_test_passes():
+    assert es._run_self_test() is True

--- a/skills/schliff/tests/unit/test_golden.py
+++ b/skills/schliff/tests/unit/test_golden.py
@@ -159,7 +159,14 @@ class TestGoldenGoodSkill:
     def test_composite_high(self, tmp_path):
         path = _write_skill(tmp_path, GOOD_SKILL)
         result = _score_all(path)
-        assert result["score"] >= 70, f"Composite should be >=70, got {result['score']}"
+        # Unified full-denominator model: _score_all measures only 4 of 7 canonical
+        # dims (no eval suite → triggers/quality/edges uncredited), so coverage is
+        # 0.42 and the structural-only composite is ~33.3. The "high" intent is now
+        # expressed relative to the bad skill (see ordering test) and to its own
+        # ceiling — it must clear the 30 mark and stay near the 0.42 coverage cap.
+        assert 30 <= result["score"] <= 42, (
+            f"Good skill structural-only composite should be ~33 (30-42 band), got {result['score']}"
+        )
 
 
 class TestGoldenBadSkill:
@@ -192,9 +199,10 @@ class TestGoldenBadSkill:
     def test_composite_low(self, tmp_path):
         path = _write_skill(tmp_path, BAD_SKILL)
         result = _score_all(path)
-        # Golden value shifted from 45 to ~40 after registry weight unification
-        # (clarity 0.05, security 0.05 now explicit; runtime removed from defaults)
-        _assert_score_in_range(result["score"], 40, tolerance=5, label="bad_composite")
+        # Re-baselined for the unified full-denominator composite (2026-05-26):
+        # 33*(.15/.95)+40*(.10/.95)+20*(.10/.95)+100*(.05/.95) = 16.8 at coverage 0.42.
+        # Stays well below the good skill (~33.3) — ordering preserved.
+        _assert_score_in_range(result["score"], 16.8, tolerance=2, label="bad_composite")
 
 
 class TestGoldenMediumSkill:
@@ -225,20 +233,49 @@ class TestGoldenMediumSkill:
     def test_composite_medium(self, tmp_path):
         path = _write_skill(tmp_path, MEDIUM_SKILL)
         result = _score_all(path)
-        assert 50 <= result["score"] <= 90, f"Composite should be 50-90, got {result['score']}"
+        # Unified full-denominator model, structural-only (no eval suite → coverage 0.42).
+        # Verified ~32.8. Sits between bad (~16.8) and good (~33.3) — ordering preserved.
+        assert 25 <= result["score"] <= 38, (
+            f"Medium skill structural-only composite should be ~33 (25-38 band), got {result['score']}"
+        )
+
+
+class TestGoldenOrdering:
+    """Composite scores must respect strict ordering: good > medium > bad."""
+
+    def test_good_gt_medium_gt_bad(self, tmp_path):
+        good_dir = tmp_path / "good"
+        good_dir.mkdir()
+        medium_dir = tmp_path / "medium"
+        medium_dir.mkdir()
+        bad_dir = tmp_path / "bad"
+        bad_dir.mkdir()
+
+        good_composite = _score_all(_write_skill(good_dir, GOOD_SKILL))["score"]
+        medium_composite = _score_all(_write_skill(medium_dir, MEDIUM_SKILL))["score"]
+        bad_composite = _score_all(_write_skill(bad_dir, BAD_SKILL))["score"]
+
+        assert good_composite > medium_composite > bad_composite, (
+            f"Ordering violated: good={good_composite:.2f}, "
+            f"medium={medium_composite:.2f}, bad={bad_composite:.2f}. "
+            f"Expected good > medium > bad (strict)."
+        )
 
 
 class TestGoldenSelfScore:
     """Schliff's own SKILL.md should maintain S-grade."""
 
     def test_self_score_structural_high(self):
-        """Schliff's SKILL.md structural-only score must be >= 80."""
+        """Schliff's SKILL.md structural-only composite under the unified model (~38.9)."""
         skill_path = str(Path(__file__).resolve().parent.parent.parent / "SKILL.md")
         result = _score_all(skill_path)
-        # Note: without eval-suite, triggers/quality/edges are excluded.
-        # Full score with eval-suite is ~90+. Structural-only is lower.
-        assert result["score"] >= 80, (
-            f"Self-score regression! Expected >=80, got {result['score']}"
+        # Unified full-denominator model: without an eval suite, triggers/quality/edges
+        # are uncredited (not renormalized away), so coverage is 0.42 and the
+        # structural-only ceiling is ~42. Verified ~38.9 — near the coverage cap, which
+        # is the strongest a no-eval-suite skill can score. The full score WITH an eval
+        # suite (all 7 dims) is ~99.
+        assert result["score"] >= 36, (
+            f"Self-score regression! Expected >=36 (structural-only, ~38.9), got {result['score']}"
         )
 
     def test_self_structure_perfect(self):

--- a/skills/schliff/tests/unit/test_patch_ratio.py
+++ b/skills/schliff/tests/unit/test_patch_ratio.py
@@ -1,0 +1,34 @@
+"""Lock the deterministic-patch-ratio measurement methodology.
+
+'Deterministic' is defined EXACTLY as the auto-apply gate in text_gradient.py:
+    confidence == "high" AND effort <= EFFORT_SIMPLE
+"""
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from measure_patch_ratio import measure  # noqa: E402
+
+
+def test_measure_returns_consistent_shape():
+    m = measure()
+    assert m["total"] > 0
+    assert m["deterministic"] + m["llm"] == m["total"]
+    assert 0.0 <= m["deterministic_ratio"] <= 1.0
+    # The figure is whatever the catalog actually is — the test pins the contract, not a magic number.
+    assert m["definition"] == 'confidence=="high" and effort<=EFFORT_SIMPLE'
+
+
+def test_only_true_gradients_counted():
+    from measure_patch_ratio import _gradient_dicts
+    import ast
+    from pathlib import Path
+    import sys
+    scripts = Path(__file__).resolve().parents[2] / "scripts"
+    src = (scripts / "text_gradient.py").read_text(encoding="utf-8")
+    grads = _gradient_dicts(ast.parse(src))
+    assert grads, "no gradients parsed"
+    assert all("effort" in g for g in grads), "a counted dict lacks 'effort' (not a true gradient)"

--- a/skills/schliff/tests/unit/test_registry.py
+++ b/skills/schliff/tests/unit/test_registry.py
@@ -106,15 +106,26 @@ class TestRegistryAlignment:
         assert "security" in scores
 
     def test_composite_uses_registry_weights(self):
-        """compute_composite() weights come from the registry — no hardcoded fallbacks."""
+        """compute_composite() weights come from the registry — no hardcoded fallbacks.
+
+        Security is in the registry weight profile but is EXCLUDED from the headline
+        composite basis (reported as a separate signal), so the canonical basis is the
+        7 non-security dims. With every canonical dim measured the coverage is exactly
+        1.0 and there are no unmeasured headline dims.
+        """
         from scoring.composite import compute_composite
+        from scoring.registry import get_headline_excluded
 
         registry_weights = get_weights("skill.md")
+        excluded = get_headline_excluded("skill.md")
+        canonical_count = len([d for d in registry_weights if d not in excluded])
         scores = {dim: {"score": 50, "issues": [], "details": {}} for dim in registry_weights}
         result = compute_composite(scores)
 
-        # All registry-weighted dimensions should be measured
-        assert result["measured_dimensions"] == len(registry_weights)
+        # All canonical (non-security) registry-weighted dimensions are measured;
+        # security flows to signals, not the headline composite.
+        assert result["measured_dimensions"] == canonical_count
+        assert "security" in result["signals"]
         assert len(result["unmeasured"]) == 0
         assert abs(result["weight_coverage"] - 1.0) < 1e-6
 

--- a/skills/schliff/tests/unit/test_scoring.py
+++ b/skills/schliff/tests/unit/test_scoring.py
@@ -934,7 +934,13 @@ class TestDensityCurve:
         actionable = "\n".join(
             [f"Run process step {i} now." for i in range(5)]
         )
-        padding = ("word " * 95).strip()
+        # Varied prose padding (not a single repeated token) to dilute density to ~5
+        # without tripping the spread-keyword-stuffing detector — real low-density prose
+        # uses many distinct words, it does not repeat one word 95 times.
+        vocab = ("the quick brown context fox jumps over a lazy summary while many "
+                 "distinct tokens fill out this paragraph with varied prose padding "
+                 "content here and there across several plausible sentences").split()
+        padding = " ".join(vocab[i % len(vocab)] for i in range(95))
         body = f"{actionable}\n{padding}"
         content = f"---\nname: mid-density\ndescription: mid density\n---\n\n{body}\n"
         p = tmp_path / "SKILL.md"

--- a/skills/schliff/tests/unit/test_scoring.py
+++ b/skills/schliff/tests/unit/test_scoring.py
@@ -501,6 +501,9 @@ class TestComputeComposite:
         assert result["score"] == 0 or result["measured_dimensions"] == 0
 
     def test_perfect_scores(self):
+        # Six canonical dims at 100; clarity (canonical weight 0.05/0.95) is
+        # unmeasured and uncredited under the full-denominator model, so the
+        # ceiling is 0.90/0.95 * 100 ≈ 94.7, NOT 100. (Add clarity=100 to reach 100.)
         scores = {
             "structure": {"score": 100},
             "triggers": {"score": 100},
@@ -510,7 +513,7 @@ class TestComputeComposite:
             "edges": {"score": 100},
         }
         result = compute_composite(scores)
-        assert result["score"] >= 95
+        assert result["score"] == pytest.approx(0.90 / 0.95 * 100, abs=0.2)
 
     def test_clarity_dimension_present_weights_sum_to_one(self):
         scores = {

--- a/skills/schliff/tests/unit/test_security.py
+++ b/skills/schliff/tests/unit/test_security.py
@@ -310,24 +310,6 @@ class TestScoreSecurity:
         assert result["score"] >= 90
         assert result["details"]["code_block_excluded"] >= 1
 
-    def test_graduated_cap_works(self, tmp_path):
-        """Test the graduated composite cap based on security score.
-
-        score < 5  -> composite max 20
-        score < 10 -> composite max 40
-        score < 20 -> composite max 60
-        """
-        from scoring.security import get_composite_cap
-
-        assert get_composite_cap(0) == 20
-        assert get_composite_cap(4) == 20
-        assert get_composite_cap(5) == 40
-        assert get_composite_cap(9) == 40
-        assert get_composite_cap(10) == 60
-        assert get_composite_cap(19) == 60
-        assert get_composite_cap(20) is None
-        assert get_composite_cap(100) is None
-
     def test_negation_aware(self, tmp_path):
         """'never run rm -rf' should be safe (negation), but 'run rm -rf' should be flagged."""
         safe_dir = tmp_path / "safe"

--- a/skills/schliff/tests/unit/test_stress.py
+++ b/skills/schliff/tests/unit/test_stress.py
@@ -511,9 +511,13 @@ class TestRegressionGoodSkillPinned:
     def test_composite_exact(self, tmp_path):
         path = _write(tmp_path, _GOOD_SKILL_CONTENT)
         result = _score_all(path)
-        # Updated from 79.1 after registry weight unification
-        assert result["score"] == 79.0, (
-            f"good_skill composite regression: expected 79.0, got {result['score']}"
+        # Re-baselined for the unified full-denominator composite (2026-05-26).
+        # _score_all measures only structure/efficiency/composability/clarity — with
+        # no eval suite, triggers/quality/edges are uncredited → coverage 0.42, so the
+        # ceiling is ~42. Verified: 95*(.15/.95)+100*(.10/.95)+30*(.10/.95)+87*(.05/.95)
+        # = 33.3. Was 79.0 under the old renormalized (coverage-divided) scale.
+        assert result["score"] == 33.3, (
+            f"good_skill composite regression: expected 33.3, got {result['score']}"
         )
 
 
@@ -552,13 +556,17 @@ class TestRegressionBadSkillPinned:
     def test_composite_exact(self, tmp_path):
         path = _write(tmp_path, _BAD_SKILL_CONTENT)
         result = _score_all(path)
-        assert result["score"] == 39.9, (
-            f"bad_skill composite regression: expected 39.9, got {result['score']}"
+        # Re-baselined for the unified full-denominator composite (2026-05-26).
+        # 33*(.15/.95)+40*(.10/.95)+20*(.10/.95)+100*(.05/.95) = 16.8 at coverage 0.42.
+        # Was 39.9 under the old renormalized scale. Still below good_skill (33.3) —
+        # ordering preserved.
+        assert result["score"] == 16.8, (
+            f"bad_skill composite regression: expected 16.8, got {result['score']}"
         )
 
 
 class TestRegressionRealSkillMd:
-    """Schliff's own SKILL.md composite must stay within 99.0 ± 1.5."""
+    """Schliff's own SKILL.md structural-only composite must stay within 41.3 ± 1.5."""
 
     SKILL_MD_PATH = str(
         Path(__file__).resolve().parent.parent.parent / "SKILL.md"
@@ -566,10 +574,14 @@ class TestRegressionRealSkillMd:
 
     def test_composite_within_tolerance(self):
         result = _score_all(self.SKILL_MD_PATH)
-        # Measured 2026-03-25: composite after quality coherence + efficiency
-        # word compression + composability handoff fix = 99.0.
-        # Tolerance 1.5 guards against regressions.
-        expected = 99.0
+        # Re-baselined 2026-05-26 for the unified full-denominator composite.
+        # _score_all is structural-only (structure/efficiency/composability/clarity);
+        # with no eval suite triggers/quality/edges are uncredited → coverage 0.42.
+        # In-repo dims (structure 100, efficiency 92, composability 100, clarity 100):
+        # 100*(.15/.95)+92*(.10/.95)+100*(.10/.95)+100*(.05/.95) = 41.3.
+        # The full score WITH an eval suite (all 7 dims) is ~99; this structural-only
+        # path now reflects coverage rather than renormalizing the gap away.
+        expected = 41.3
         tolerance = 1.5
         assert abs(result["score"] - expected) <= tolerance, (
             f"SKILL.md composite regression: expected {expected} ±{tolerance}, "
@@ -621,29 +633,35 @@ class TestCompositeWeightMath:
             f"All dims at 0 should give composite 0.0, got {result['score']}"
         )
 
-    def test_only_structure_measured_gives_100(self):
-        """When only structure is in the scores dict (others absent), composite = 100.0.
+    def test_only_structure_measured_gives_its_weight(self):
+        """Full-denominator: only structure measured at 100 → composite = its canonical weight.
 
-        Normalization: composite = (100 * w_structure) / w_structure = 100.0
+        Under the unified model unmeasured dims are UNCREDITED (not renormalized away),
+        so a lone structure=100 contributes only its canonical weight:
+            composite = 100 * (0.15 / 0.95) ≈ 15.8
+        The old "gives 100" was the renormalization artifact this change removes.
         """
         scores = {"structure": {"score": 100, "issues": [], "details": {}}}
         result = compute_composite(scores)
-        assert result["score"] == 100.0, (
-            f"Single measured dimension at 100 should normalize to 100.0, got {result['score']}"
+        assert result["score"] == pytest.approx(100.0 * (0.15 / 0.95), abs=0.2), (
+            f"Lone structure=100 should contribute only its canonical weight "
+            f"(~15.8), got {result['score']}"
         )
-        assert result["weight_coverage"] == pytest.approx(0.15, abs=0.01)
+        assert result["weight_coverage"] == pytest.approx(0.15 / 0.95, abs=0.01)
 
     def test_structure_100_others_0_gives_structure_weight_times_100(self):
-        """Structure=100 with all others=0 (all weighted dims measured) = structure_weight * 100.
+        """Structure=100 with all others=0 → structure's CANONICAL weight * 100.
 
-        Default structure weight = 0.15, all dims measured, weight_sum = 1.0.
-        composite = (100 * 0.15) / 1.0 = 15.0
+        Security is excluded from the headline basis, so the canonical basis is the
+        7 non-security dims renormalized to 1.0 → structure's weight = 0.15/0.95 ≈ 0.158.
+        All 7 canonical dims are measured (coverage 1.0); only structure is non-zero:
+            composite = 100 * (0.15 / 0.95) ≈ 15.8
         """
         scores = _make_score_dict({d: 0 for d in _ALL_WEIGHTED_DIMS})
         scores["structure"]["score"] = 100
         result = compute_composite(scores)
-        assert result["score"] == 15.0, (
-            f"structure=100, rest=0 → expected 15.0 (0.15 * 100), got {result['score']}"
+        assert result["score"] == pytest.approx(100.0 * (0.15 / 0.95), abs=0.2), (
+            f"structure=100, rest=0 → expected ~15.8 (0.15/0.95 * 100), got {result['score']}"
         )
 
     def test_all_weighted_at_100_with_extra_dims_still_gives_100(self):
@@ -662,10 +680,14 @@ class TestCompositeWeightMath:
         assert result["weight_coverage"] == pytest.approx(1.0, abs=1e-6)
 
     def test_weight_coverage_single_dim_matches_that_dims_weight(self):
-        """Measuring only structure → weight_coverage = structure's weight (0.15)."""
+        """Measuring only structure → weight_coverage = structure's CANONICAL weight.
+
+        Security is excluded from the headline basis, so the 7 non-security dims are
+        renormalized to 1.0 and structure's canonical weight is 0.15/0.95 ≈ 0.158.
+        """
         scores = {"structure": {"score": 50, "issues": [], "details": {}}}
         result = compute_composite(scores)
-        assert result["weight_coverage"] == pytest.approx(0.15, abs=0.01)
+        assert result["weight_coverage"] == pytest.approx(0.15 / 0.95, abs=0.01)
 
     def test_composite_score_is_always_float(self):
         """compute_composite must always return a float, never an int or None."""

--- a/skills/schliff/tests/unit/test_verify.py
+++ b/skills/schliff/tests/unit/test_verify.py
@@ -201,17 +201,109 @@ class TestHistory:
 # run_verify — threshold checks
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def weak_no_eval_skill(tmp_path):
+    """A no-eval-suite skill whose measured dimensions are mediocre.
+
+    Same coverage as good_skill (no eval suite → ~0.42), but lower per-measured
+    quality, so it should fail effective_min = 75 * coverage while the good skill
+    passes. Used to prove coverage-awareness discriminates on quality, not coverage.
+    """
+    content = '''---
+name: weak
+description: A skill.
+---
+
+# Weak
+
+Stuff.
+'''
+    weak_dir = tmp_path / "weak"
+    weak_dir.mkdir()
+    skill_path = weak_dir / "SKILL.md"
+    skill_path.write_text(content, encoding="utf-8")
+    return str(skill_path)
+
+
+@pytest.fixture
+def eval_suite_full():
+    """A minimal eval suite that lifts coverage toward ~1.0.
+
+    Providing an eval suite credits the triggers/quality/edges dimensions, so
+    weight_coverage approaches 1.0 and the skill is judged against ~full min_score.
+    """
+    return {
+        "skill_name": "test-skill",
+        "triggers": [
+            {"id": "pos-1", "prompt": "Run automated quality checks on a skill file and verify scoring.", "should_trigger": True, "category": "positive"},
+            {"id": "pos-2", "prompt": "Verify the skill quality scoring produces expected results.", "should_trigger": True, "category": "positive"},
+            {"id": "neg-1", "prompt": "Create a brand new skill from scratch.", "should_trigger": False, "category": "negative"},
+        ],
+        "test_cases": [
+            {"id": "tc-1", "prompt": "Run a quality check on a skill file.",
+             "assertions": [{"type": "contains", "value": "score"}, {"type": "not_contains", "value": "TODO"}]},
+            {"id": "tc-2", "prompt": "Review the dimension breakdown for a skill.",
+             "assertions": [{"type": "contains", "value": "dimension"}]},
+            {"id": "tc-3", "prompt": "Fix a weak dimension in a skill.",
+             "assertions": [{"type": "contains", "value": "fix"}]},
+        ],
+        "edge_cases": [
+            {"id": "ec-1", "prompt": "The SKILL.md file is missing entirely.",
+             "expected_behavior": "Return exit code 2.",
+             "assertions": [{"type": "contains", "value": "exit code 2"}]},
+            {"id": "ec-2", "prompt": "Scoring crashes mid-run.",
+             "expected_behavior": "Log the error and return exit code 2.",
+             "assertions": [{"type": "contains", "value": "error"}]},
+        ],
+    }
+
+
 class TestRunVerifyThreshold:
     def test_good_skill_passes_default(self, good_skill, history_file):
-        # Structural-only score (no eval suite → triggers/quality/edges uncredited)
-        # caps the good skill near coverage (~0.42 → composite ~33). Threshold set
-        # to 30 to exercise the PASS path under the unified full-denominator model.
+        # Coverage-aware: a strong no-eval-suite skill (composite ~33, coverage ~0.42)
+        # clears effective_min = 75 * 0.42 ≈ 31.5, so the DEFAULT threshold is now
+        # reachable without an eval suite.
         verdict = verify_mod.run_verify(
-            good_skill, min_score=30.0, history_path=history_file,
+            good_skill, history_path=history_file,
         )
         assert verdict["exit_code"] == 0
         assert verdict["passed_threshold"] is True
         assert "PASS" in verdict["message"]
+
+    def test_coverage_aware_good_no_eval_suite_passes_default(self, good_skill, history_file):
+        """Strong no-eval-suite skill PASSES the default (75) via coverage scaling."""
+        verdict = verify_mod.run_verify(
+            good_skill, history_path=history_file,  # default min_score = 75.0
+        )
+        assert verdict["min_score"] == 75.0
+        # Coverage is below 1.0 (no eval suite) so effective_min is scaled down.
+        assert 0 < verdict["coverage"] < 1.0
+        assert verdict["effective_min"] == pytest.approx(75.0 * verdict["coverage"])
+        assert verdict["composite"] >= verdict["effective_min"]
+        assert verdict["exit_code"] == 0
+        assert verdict["passed_threshold"] is True
+
+    def test_coverage_aware_weak_no_eval_suite_fails_default(self, weak_no_eval_skill, history_file):
+        """Mediocre no-eval-suite skill FAILS the default despite coverage scaling."""
+        verdict = verify_mod.run_verify(
+            weak_no_eval_skill, history_path=history_file,  # default min_score = 75.0
+        )
+        assert 0 < verdict["coverage"] < 1.0
+        assert verdict["effective_min"] == pytest.approx(75.0 * verdict["coverage"])
+        assert verdict["composite"] < verdict["effective_min"]
+        assert verdict["exit_code"] == 1
+        assert verdict["passed_threshold"] is False
+        assert "FAIL" in verdict["message"]
+
+    def test_coverage_aware_eval_suite_judged_against_full(self, good_skill, eval_suite_full, history_file):
+        """An eval-suite skill has higher coverage → judged against ~full min_score."""
+        verdict = verify_mod.run_verify(
+            good_skill, history_path=history_file, eval_suite=eval_suite_full,
+        )
+        # Adding an eval suite raises coverage above the no-eval-suite baseline (~0.42).
+        no_eval = verify_mod.run_verify(good_skill, history_path=history_file)
+        assert verdict["coverage"] > no_eval["coverage"]
+        assert verdict["effective_min"] == pytest.approx(75.0 * verdict["coverage"])
 
     def test_bad_skill_fails_high_threshold(self, bad_skill, history_file):
         verdict = verify_mod.run_verify(
@@ -229,8 +321,9 @@ class TestRunVerifyThreshold:
         assert verdict["min_score"] == 99.0
 
     def test_records_history_on_pass(self, good_skill, history_file):
+        # Passes the default threshold via coverage scaling and records history.
         verify_mod.run_verify(
-            good_skill, min_score=40.0, history_path=history_file,
+            good_skill, history_path=history_file,
         )
         assert Path(history_file).exists()
         content = Path(history_file).read_text(encoding="utf-8").strip()
@@ -249,10 +342,10 @@ class TestRunVerifyThreshold:
 
 class TestRunVerifyRegression:
     def test_no_previous_score_passes(self, good_skill, history_file):
-        # 30.0 threshold clears the structural-only good skill (~33) under the
-        # unified full-denominator model (no eval suite measured here).
+        # Default threshold (75.0) is now reachable for a strong no-eval-suite
+        # skill via coverage scaling (effective_min = 75 * ~0.42 ≈ 31.5 < ~33).
         verdict = verify_mod.run_verify(
-            good_skill, min_score=30.0, check_regression=True,
+            good_skill, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 0
@@ -266,8 +359,9 @@ class TestRunVerifyRegression:
             {"composite": 10.0, "grade": "F", "dimensions": {}},
             history_file,
         )
+        # Default threshold cleared via coverage scaling, then improvement detected.
         verdict = verify_mod.run_verify(
-            good_skill, min_score=30.0, check_regression=True,
+            good_skill, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 0
@@ -282,8 +376,9 @@ class TestRunVerifyRegression:
             {"composite": 999.0, "grade": "S", "dimensions": {}},
             history_file,
         )
+        # Default threshold cleared via coverage scaling so the regression gate runs.
         verdict = verify_mod.run_verify(
-            good_skill, min_score=30.0, check_regression=True,
+            good_skill, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 1
@@ -297,8 +392,10 @@ class TestRunVerifyRegression:
             {"composite": 999.0, "grade": "S", "dimensions": {}},
             history_file,
         )
+        # Default threshold cleared via coverage scaling; without --regression
+        # the seeded score drop must be ignored.
         verdict = verify_mod.run_verify(
-            good_skill, min_score=30.0, check_regression=False,
+            good_skill, check_regression=False,
             history_path=history_file,
         )
         # Without --regression, score drop doesn't matter
@@ -364,7 +461,8 @@ class TestVerdictStructure:
         )
         expected_keys = {
             "skill_path", "composite", "grade", "dimensions",
-            "min_score", "passed_threshold", "exit_code", "message",
+            "min_score", "coverage", "effective_min",
+            "passed_threshold", "exit_code", "message",
             "previous_score", "delta", "regression",
         }
         assert set(verdict.keys()) == expected_keys

--- a/skills/schliff/tests/unit/test_verify.py
+++ b/skills/schliff/tests/unit/test_verify.py
@@ -203,8 +203,11 @@ class TestHistory:
 
 class TestRunVerifyThreshold:
     def test_good_skill_passes_default(self, good_skill, history_file):
+        # Structural-only score (no eval suite → triggers/quality/edges uncredited)
+        # caps the good skill near coverage (~0.42 → composite ~33). Threshold set
+        # to 30 to exercise the PASS path under the unified full-denominator model.
         verdict = verify_mod.run_verify(
-            good_skill, min_score=40.0, history_path=history_file,
+            good_skill, min_score=30.0, history_path=history_file,
         )
         assert verdict["exit_code"] == 0
         assert verdict["passed_threshold"] is True
@@ -246,8 +249,10 @@ class TestRunVerifyThreshold:
 
 class TestRunVerifyRegression:
     def test_no_previous_score_passes(self, good_skill, history_file):
+        # 30.0 threshold clears the structural-only good skill (~33) under the
+        # unified full-denominator model (no eval suite measured here).
         verdict = verify_mod.run_verify(
-            good_skill, min_score=40.0, check_regression=True,
+            good_skill, min_score=30.0, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 0
@@ -262,7 +267,7 @@ class TestRunVerifyRegression:
             history_file,
         )
         verdict = verify_mod.run_verify(
-            good_skill, min_score=40.0, check_regression=True,
+            good_skill, min_score=30.0, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 0
@@ -278,7 +283,7 @@ class TestRunVerifyRegression:
             history_file,
         )
         verdict = verify_mod.run_verify(
-            good_skill, min_score=40.0, check_regression=True,
+            good_skill, min_score=30.0, check_regression=True,
             history_path=history_file,
         )
         assert verdict["exit_code"] == 1
@@ -293,7 +298,7 @@ class TestRunVerifyRegression:
             history_file,
         )
         verdict = verify_mod.run_verify(
-            good_skill, min_score=40.0, check_regression=False,
+            good_skill, min_score=30.0, check_regression=False,
             history_path=history_file,
         )
         # Without --regression, score drop doesn't matter

--- a/skills/schliff/tests/unit/test_version_consistency.py
+++ b/skills/schliff/tests/unit/test_version_consistency.py
@@ -1,0 +1,29 @@
+"""Fail on version drift across the three places a version is declared."""
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
+
+
+def _pyproject_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    return re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE).group(1)
+
+
+def _plugin_version() -> str:
+    return json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))["version"]
+
+
+def _package_version() -> str:
+    import sys
+    sys.path.insert(0, str(ROOT / "skills"))
+    import schliff  # skills/schliff/__init__.py
+    return schliff.__version__
+
+
+def test_all_versions_match():
+    assert _pyproject_version() == _plugin_version() == _package_version(), (
+        f"version drift: pyproject={_pyproject_version()} "
+        f"plugin={_plugin_version()} package={_package_version()}"
+    )


### PR DESCRIPTION
## Summary

Resolves verified findings from an external audit of the scoring engine. (The audit ran against installed **6.1.0**; this branch fixes what is *still real* on 7.2.0 — several audit claims were already stale.) Six workstreams, each behind a test/guard:

- **Unified composite (BREAKING):** one canonical 7-dimension headline using a **full denominator** — unmeasured dimensions are *uncredited* (not silently renormalized away). Fixes the conceptual dual-scale (CLI/doctor/bench vs evolve now report one number per file) **and** the anti-gaming hole at a single root cause. Security/runtime are reported as separate signals/gate, never folded into the headline. Format-aware (security stays a core dim for `system_prompt`).
- **Anti-gaming separation gate:** `benchmarks/anti-gaming` now asserts every gamed skill scores **below a clean control** (previously per-dimension only). A *sophisticated* gamer reproduced the audit's composite inversion; fixed via a spread-keyword-stuffing penalty in the **efficiency** dimension (the only measured lever under full-denominator) — **0 false positives across 76 installed skills**.
- **Substantiated patch claim:** the unproven "60-70% rule-based patches" is replaced by a measured **32% (12/37)**, with `scripts/measure_patch_ratio.py` as the canonical, re-runnable source.
- **Version single-source + drift guard:** `__version__` in the package, `plugin.json` aligned to 7.2.0, consistency test.
- **Episodic-memory unit tests** (persistence, ranking, atomic rewrite).
- **Coverage-aware `verify`:** pass threshold scales with measured coverage (`effective_min = min_score x coverage`) so no-eval-suite skills are judged against a structural bar and existing CI doesn't break wholesale.
- Housekeeping: dead `get_composite_cap` removed; `make test` now runs pytest.

## ⚠️ Breaking change

Composite scores for skills **without an eval suite** are now lower and reflect coverage (a perfect-structural no-eval-suite skill caps at ~coverage×100). External CI thresholds (`fail if score<N`) may need re-tuning; `verify` is now coverage-aware to soften this. Documented in `CHANGELOG.md`.

## Merge coordination

This branch was **rebased onto `main`** and contains only these audit commits — it is **independent of and does not touch** the active `feat/v8-product-completion-sprint` branch. It does modify `scoring/composite.py` / `registry.py`, and the v8 sprint calibrates against scoring, so **coordinate merge order with the sprint** (whichever lands first, the other rebases).

## Test plan

- [x] Full unit suite: **1139 passed, 0 failed**
- [x] Anti-gaming separation gate: exit 0 (every gamed composite < clean control)
- [x] `measure_patch_ratio.py`: 12/37 = 32%
- [x] Golden ordering preserved (good > medium > bad), explicitly asserted
- [x] Version consistency test green
- [x] `make test` runs pytest

Spec: `docs/superpowers/specs/2026-05-26-audit-followups-design.md`
Plan: `docs/superpowers/plans/2026-05-26-audit-followups.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)