### PR TITLE
fix(leaderboard): version score-model epoch so v7/v8 scales never co-rank

### DIFF
--- a/skills/schliff/tests/unit/test_leaderboard_versioning.py
+++ b/skills/schliff/tests/unit/test_leaderboard_versioning.py
@@ -1,0 +1,84 @@
+"""Leaderboard scoring-model epoch versioning (Hydra PR #42 finding C-2 / #5).
+
+v8.0's full-denominator composite is a breaking scale change, so a v7-and-earlier
+composite must never co-rank with a v8+ one. These tests lock the epoch helper and
+the query-side selection that keeps a single ranking within one comparable scale.
+
+The leaderboard endpoints are standalone serverless files under web/leaderboard/api
+(stdlib-only, no relative imports), loaded here directly by path.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_API = Path(__file__).resolve().parents[4] / "web" / "leaderboard" / "api"
+
+
+def _load(mod_name, filename):
+    spec = importlib.util.spec_from_file_location(mod_name, _API / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+submit = _load("lb_submit", "submit.py")
+query = _load("lb_query", "query.py")
+
+
+@pytest.mark.parametrize("version,expected", [
+    ("8.0.0", 2), ("8.1.3", 2), ("v8.0", 2), ("10.2.1", 2), ("9.0.0", 2),
+    ("7.0.0", 1), ("7.2.0", 1), ("2.1.0", 1), ("6.1.0", 1), ("V7.0.0", 1),
+    ("", 1), ("garbage", 1), ("x.y.z", 1),
+])
+def test_score_model_for(version, expected):
+    assert submit._score_model_for(version) == expected
+    # The two serverless copies must agree (kept in sync by hand).
+    assert query._score_model_for(version) == expected
+
+
+def test_current_score_model_constants_match():
+    assert submit.CURRENT_SCORE_MODEL == query.CURRENT_SCORE_MODEL == 2
+
+
+def test_resolve_backfills_legacy_rows_from_version():
+    entries = [{"version": "7.0.0"}, {"version": "8.0.0"}]
+    filtered, active, available = query._resolve_score_model(entries, None)
+    # every row got an epoch
+    assert all("score_model" in e for e in entries)
+    assert available == [2, 1]
+
+
+def test_resolve_default_picks_latest_epoch_and_excludes_other_scale():
+    v7 = {"version": "7.0.0", "composite": 99.0}
+    v8 = {"version": "8.0.0", "composite": 41.0}
+    filtered, active, available = query._resolve_score_model([v7, v8], None)
+    assert active == 2
+    assert filtered == [v8]  # the high v7 score does NOT pollute the v8 ranking
+
+
+def test_resolve_default_never_empty_when_only_legacy_present():
+    v7a = {"version": "7.0.0"}
+    v7b = {"version": "2.1.0"}
+    filtered, active, available = query._resolve_score_model([v7a, v7b], None)
+    assert active == 1
+    assert len(filtered) == 2  # seed-only data still shows, all comparable
+
+
+def test_resolve_explicit_request_overrides_default():
+    v7 = {"version": "7.0.0"}
+    v8 = {"version": "8.0.0"}
+    filtered, active, available = query._resolve_score_model([v7, v8], 1)
+    assert active == 1
+    assert filtered == [v7]
+
+
+def test_resolve_empty_input_defaults_to_current_model():
+    filtered, active, available = query._resolve_score_model([], None)
+    assert filtered == [] and active == query.CURRENT_SCORE_MODEL and available == []
+
+
+def test_submit_entry_dict_would_carry_score_model():
+    # The stamped epoch is derived from the submitted version string.
+    assert submit._score_model_for("8.0.0") == 2
+    assert submit._score_model_for("7.2.0") == 1

--- a/web/leaderboard/api/query.py
+++ b/web/leaderboard/api/query.py
@@ -45,6 +45,42 @@ def _load_submissions():
     return []
 
 
+# --- scoring-model epoch (keep in sync with submit.py) -----------------------
+# v8.0's full-denominator composite (PR #41/#42) is a breaking scale change, so
+# v7-and-earlier composites must never co-rank with v8+ ones. Entries are stamped
+# with an epoch at submit time; legacy/seed rows predate the field and are
+# backfilled here from their version string.
+CURRENT_SCORE_MODEL = 2  # full-denominator (schliff >= 8.0)
+
+
+def _score_model_for(version: str) -> int:
+    """Map a schliff version string to its scoring-model epoch (2 = full-denominator
+    for >=8.0, 1 = legacy renormalized for earlier). Unparseable -> 1 (conservative:
+    an unknown version never pollutes the current-scale ranking)."""
+    try:
+        major = int(str(version).lstrip("vV").split(".")[0])
+    except (ValueError, AttributeError, IndexError):
+        return 1
+    return 2 if major >= 8 else 1
+
+
+def _resolve_score_model(entries, requested):
+    """Backfill score_model on every entry, then select the active epoch and keep
+    only its entries — so a single ranking never mixes incomparable scales.
+
+    Active epoch = ``requested`` when given, else the latest epoch that has data
+    (within-scale and never an empty default view). Returns
+    ``(filtered_entries, active_model, models_available_desc)``."""
+    for e in entries:
+        e.setdefault("score_model", _score_model_for(e.get("version", "")))
+    models_available = sorted({e["score_model"] for e in entries}, reverse=True)
+    if requested is not None:
+        active = requested
+    else:
+        active = models_available[0] if models_available else CURRENT_SCORE_MODEL
+    return [e for e in entries if e.get("score_model") == active], active, models_available
+
+
 def _sort_key(entry, sort_field):
     if sort_field == "date":
         return entry.get("submitted_at", "")
@@ -125,12 +161,25 @@ class handler(BaseHTTPRequestHandler):
                 self._send_json(400, {"error": f"invalid format(s): {', '.join(sorted(invalid))}"})
                 return
 
+        # --- score_model selection (optional; default = latest epoch present) ---
+        sm_raw = first("score_model")
+        requested_model = None
+        if sm_raw is not None:
+            try:
+                requested_model = int(sm_raw)
+            except ValueError:
+                self._send_json(400, {"error": "score_model must be an integer"})
+                return
+
         try:
             entries = _load_submissions()
         except Exception as exc:
             print(f"Storage error: {type(exc).__name__}: {exc}", file=sys.stderr)
             self._send_json(500, {"error": "internal storage error"})
             return
+
+        # --- keep a single, comparable scoring-model epoch (no mixed scales) ---
+        entries, active_model, models_available = _resolve_score_model(entries, requested_model)
 
         # --- filter ---
         if grade_filter:
@@ -154,6 +203,11 @@ class handler(BaseHTTPRequestHandler):
             "total": total,
             "limit": limit,
             "offset": offset,
+            # Active scoring-model epoch for this ranking + the epochs that have
+            # data, so the client can offer a scale switch. v7-and-earlier (1) and
+            # v8+ full-denominator (2) composites are never mixed in one ranking.
+            "score_model": active_model,
+            "score_models_available": models_available,
             # Leaderboard data is community self-reported and not server-verified.
             "unverified": True,
         })

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -42,6 +42,26 @@ SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "submissions.j
 _CONTROL_CHARS = set(range(0x00, 0x20)) - {0x0A, 0x0D, 0x09}  # allow \n \r \t
 _BIDI_CHARS = {0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x2066, 0x2067, 0x2068, 0x2069}
 
+# --- scoring-model epoch -----------------------------------------------------
+# v8.0 introduced the full-denominator composite (PR #41/#42): a breaking scale
+# change. A v8+ composite is capped at the skill's coverage and is NOT comparable
+# to a v7-and-earlier renormalized composite, so the two must never share a
+# ranking. Each entry is stamped with its epoch (derived from the submitted
+# schliff version); query.py ranks within a single epoch. Keep this helper in
+# sync with the copy in query.py (serverless functions are independent files).
+CURRENT_SCORE_MODEL = 2  # full-denominator (schliff >= 8.0)
+
+
+def _score_model_for(version: str) -> int:
+    """Map a schliff version string to its scoring-model epoch (2 = full-denominator
+    for >=8.0, 1 = legacy renormalized for earlier). Unparseable -> 1 (conservative:
+    an unknown version never pollutes the current-scale ranking)."""
+    try:
+        major = int(str(version).lstrip("vV").split(".")[0])
+    except (ValueError, AttributeError, IndexError):
+        return 1
+    return 2 if major >= 8 else 1
+
 
 def _has_unsafe_chars(s: str) -> bool:
     """Reject strings with control or bidirectional override characters."""
@@ -168,6 +188,9 @@ class handler(BaseHTTPRequestHandler):
             "grade": body["grade"],
             "dimensions": {k: float(v) for k, v in body["dimensions"].items()},
             "version": body["version"],
+            # Scoring-model epoch derived from the submitted version, so this
+            # entry only ever ranks against same-scale composites.
+            "score_model": _score_model_for(body["version"]),
             "submitted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             # Client-supplied, not re-scored by the server. Always false for
             # POSTed entries so consumers can distinguish self-reported scores
@@ -196,4 +219,5 @@ class handler(BaseHTTPRequestHandler):
             self._send_json(500, {"error": "internal storage error"})
             return
 
-        self._send_json(200, {"ok": True, "updated": updated, "verified": False})
+        self._send_json(200, {"ok": True, "updated": updated, "verified": False,
+                              "score_model": entry["score_model"]})


### PR DESCRIPTION
Addresses Hydra PR #42 finding **C-2** (Cassandra, MODERATE) — sprint item #5.

## Problem
v8.0's full-denominator composite (PR #41/#42) is a **breaking scale change**: a v8+ score caps at the skill's coverage and is not comparable to a v7-and-earlier renormalized score. The leaderboard stored only a free-text app `version` and sorted all composites together, so the v7 seed (e.g. `99.0`) out-ranked any honest v8 entry — an incorrect mixed-scale ranking.

## Fix
- **submit.py**: stamp each entry with a `score_model` epoch derived from the submitted version (major ≥ 8 → `2` full-denominator, else `1` legacy; unparseable → `1`, conservative). Returned in the response.
- **query.py**: backfill `score_model` on legacy/seed rows from their version, then rank within a **single epoch**. Default = the latest epoch present (within-scale, never an empty view); `?score_model=N` selects a specific scale. Response carries `score_model` (active) + `score_models_available`.
- Extracted `_resolve_score_model` as a pure, testable function.

## Verification
- `+test_leaderboard_versioning.py` (20 cases): epoch mapping, default-latest-epoch, no-mixed-scale, never-empty-on-legacy-only, explicit override.
- **1181 tests pass.**
- Integration check on real seed data: seed-only (v7) shows both entries; adding a v8 entry flips the default to the v8 scale and excludes the high v7 score; `?score_model=1` restores the legacy view.

Frontend works unchanged (new top-level fields ignored; default response already within-scale). A UI scale-toggle is optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)