### PR TITLE
release: v8.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "Deterministic skill linter and scoring engine for Claude Code. 7-dimension scoring, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": "Zandereins",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.0.0] - 2026-05-29
+
+### Added
+- Failure-mode-first AI-Eval foundation: sprint spec + 7 ADRs, Phase-0 open-coded failure-mode
+  taxonomy (10 snapshotted skills), Phase-1 calibration scaffold.
+- Deterministic judge guards (`scoring/guards.py`): destructive-command, gating-invariant
+  (linter-completeness floor), and mixed-script detectors — staged for the v8.1 judge harness, not
+  wired into the live linter; they carry no composite weight.
+- Judge v0 smoke-test harness (`judge/judge_v0.py`, optional `[judge]` extra): pinned model,
+  structured output, mock-testable. Calibration is FROZEN as v8.1 backlog (4 live runs plateaued at
+  directional 7/11; resumes only when distribution yields real users + a concrete quality miss).
+- GitHub Action (`action/action.yml`) to score skills as a CI / PR quality gate.
+- Plugin-marketplace install: schema-valid `.claude-plugin/marketplace.json`
+  (`/plugin marketplace add Zandereins/schliff`) plus `npx skills add` support.
+- Leaderboard scoring-model epoch versioning: v7-scale and v8-scale composites never co-rank;
+  `?score_model=N` selects a scale (default = the latest epoch present).
+
 ### Changed
 - **BREAKING (scoring):** Composite is now computed over a single canonical 7-dimension basis
   with a full denominator — unmeasured dimensions are uncredited (not silently renormalized away).
@@ -19,6 +36,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (effective_min = min_score × coverage), so skills without an eval suite are judged against a
   structural bar instead of the unreachable full default. Adding an eval suite raises the bar to
   the full surface.
+- Cold-start UX: the partial-coverage message reads as an invitation (ℹ "add an eval suite to score
+  the rest"), not a scold (⚠ "uncredited / ceiling").
+- README leads with native install (`/plugin marketplace add`, `npx skills add`); pip demoted to CLI/CI.
+
+### Fixed
+- `missing_refs` (structure): referenced files resolve skill-local OR against an enclosing
+  plugin/.git root (fixes false-positives on plugin-monorepo layouts), with full paths in the
+  message; plus path-traversal confinement (reject `..`, resolve-confine) so an untrusted SKILL.md
+  cannot probe the filesystem.
+- `evolve._score_file` auto-discovers the eval suite, matching `schliff score`.
+- Public playground reframes a partial-coverage result as a "Structural Score" with a neutral
+  coverage chip instead of a red failing grade (no second scale introduced).
+- Public endpoints: hard cap on decoded skill text (compute-DoS bound) + read-cap vs a lying
+  Content-Length; leaderboard responses tagged `verified:false` / `unverified:true`.
+- `commands/schliff/mesh.md` registered as `/mesh` instead of `/schliff:mesh`.
+
+### Security
+- Pre-launch audit (3 parallel lenses + Hydra closing council): removed tracked internal docs that
+  contradicted the pitch; SECURITY.md version table + network/exec claims scoped to the zero-dep core.
 
 ## [7.2.0] - 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Your AI instructions are silently degrading. Schliff catches it.
 Deterministic quality scoring for CLAUDE.md, SKILL.md, .cursorrules, AGENTS.md, and system prompts. No LLM, no API key — same input, same score. Python 3.9+, **zero core dependencies** (optional `schliff[evolve]` adds litellm for the evolution loop).
 
 <p align="left">
-  <a href="https://pypi.org/project/schliff/"><img alt="PyPI" src="https://img.shields.io/pypi/v/schliff?style=flat-square&color=F59E0B&label=version&v=7.2.0"></a>
+  <a href="https://pypi.org/project/schliff/"><img alt="PyPI" src="https://img.shields.io/pypi/v/schliff?style=flat-square&color=F59E0B&label=version&v=8.0.0"></a>
   <a href="https://pypi.org/project/schliff/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/schliff?style=flat-square"></a>
   <a href="https://pypi.org/project/schliff/"><img alt="Downloads" src="https://img.shields.io/pypi/dm/schliff?style=flat-square"></a>
   <a href=".github/workflows/test.yml"><img alt="Tests" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Zandereins/130bb61237b5b9b1536718e6a2296d4a/raw/schliff-tests.json&style=flat-square"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "7.2.0"
+version = "8.0.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = {text = "MIT"}
 requires-python = ">=3.9"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "7.2.0"
+__version__ = "8.0.0"


### PR DESCRIPTION
Version bump **7.2.0 → 8.0.0** + CHANGELOG finalize. Merging this, then publishing a GitHub Release `v8.0.0` triggers `publish.yml` (PyPI **trusted publishing**, no token).

## Changed in this PR
- `pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py` → `8.0.0` (version-consistency guard passes)
- README version badge `&v=8.0.0` (cache-bust)
- `CHANGELOG.md`: `[Unreleased]` → `[8.0.0] - 2026-05-29` with full Added/Changed/Fixed/Security

## Pre-release verification
- `python -m build` → `schliff-8.0.0.tar.gz` + `schliff-8.0.0-py3-none-any.whl` build cleanly (the exact step the publish workflow runs)
- 1181 tests green

## Note
**BREAKING (scoring):** full-denominator composite — skills without an eval suite score lower (reflect coverage). CI `fail if score<N` gates may need re-tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)