### PR TITLE
fix(deps): exclude Vercel-synthesized build artifacts from git

### DIFF
--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,11 @@
+# Vercel CLI link state
+.vercel
+
+# Vercel's Python builder synthesizes these locally from requirements.txt on
+# every `vercel build` / `vercel deploy`. They are BUILD OUTPUT, not source.
+# requirements.txt (schliff==8.1.0) is the single source of truth for the pin.
+# Committing them creates a second manifest that can override the pin on a
+# future build (see vercel/vercel#14041). Keep them out of git.
+# (.python-version IS tracked here on purpose — it pins the runtime to 3.12.)
+pyproject.toml
+uv.lock

--- a/web/leaderboard/.gitignore
+++ b/web/leaderboard/.gitignore
@@ -1,0 +1,9 @@
+# Vercel CLI link state
+.vercel
+
+# Vercel's Python builder synthesizes these locally during build/deploy.
+# They are BUILD OUTPUT, not source. The leaderboard is stdlib-only; there is
+# no authored dependency manifest to commit. Keep these out of git.
+pyproject.toml
+uv.lock
+.python-version


### PR DESCRIPTION
Closes the foot-gun (raised after the security audit) where `git add -A` silently stages the Vercel-synthesized `pyproject.toml` / `uv.lock` / `.python-version` in `playground/` and `web/leaderboard/`.

## Why
Vercel's Python builder regenerates these from `requirements.txt` on **every** build (build log: "Installing required dependencies from requirements.txt"). They are build output, not source. A committed `pyproject.toml` can become the authoritative manifest and override the `schliff==8.1.0` pin on a future build ([vercel/vercel#14041](https://github.com/vercel/vercel/issues/14041)).

## Decision (from a multi-agent git-best-practice evaluation)
- `requirements.txt` (`schliff==8.1.0`) stays the **single source of truth**.
- `uv.lock` is **intentionally not committed**: Vercel does not consume a committed copy here, so committing it only adds drift risk for zero reproducibility gain (anti-cargo-cult).
- `playground/.python-version` **stays tracked** (pins runtime 3.12); only the leaderboard's untracked one is ignored.

## Change
Two `.gitignore` files only. No code, no deploy-workflow change. Verified: `git check-ignore` matches all 5 artifacts; `git add -A` now stages only the `.gitignore` files.

Follow-up (separate, owner's decision): adopt Vercel Git Integration so server-side builds eliminate local artifact drift entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)