### PR TITLE
fix: pre-launch hardening round 1 (audit-driven, verified)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,8 +83,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           # Pure-Python wheel is interpreter-agnostic; build on a current,
-          # supported interpreter (3.9 is EOL as of 2025-10-31).
-          # requires-python in pyproject.toml is unchanged.
+          # supported interpreter. (Python 3.9 reached EOL on 2025-10-31; the
+          # project's minimum is 3.10, set via requires-python in pyproject.toml.)
           python-version: '3.12'
 
       - name: Install build tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING: drop Python 3.9 support** — minimum supported version is now Python 3.10
+  (`requires-python = ">=3.10"`). Python 3.9 reached end-of-life on 2025-10-31. The CI test
+  matrix and ruff `target-version` were updated accordingly.
+- Modernized license metadata to the PEP 639 SPDX expression form (`license = "MIT"`), dropping
+  the deprecated `License :: OSI Approved :: MIT License` classifier. Requires `setuptools>=77`.
+
 ## [8.1.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Ruff lints your Python. Biome lints your JS. Schliff lints the instruction files
 - 🧪 **Playground:** [schliff-playground.vercel.app](https://schliff-playground.vercel.app) — paste a SKILL.md, get a live structural score (or `schliff demo` in the CLI)
 - 🏆 **Leaderboard:** [schliff-leaderboard.vercel.app](https://schliff-leaderboard.vercel.app)
 
+> **Structural score** = the composite renormalized over the dimensions Schliff can
+> measure deterministically without an eval suite (structure, efficiency, composability,
+> clarity). It is what the web playground reports. The full 7-dimension composite
+> additionally folds in triggers, quality, and edges — which require an eval suite
+> (`schliff init`).
+
 Validated by **1,198 tests** (unit + integration) in `skills/schliff/tests`, with separate self and proof suites via `test-self.sh` and `test-integration.sh`.
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Schliff Architecture
 
-System design, file tree, data flow, and implementation details for Schliff v8.0.0 —
+System design, file tree, data flow, and implementation details for Schliff v8.1.0 —
 a deterministic, stdlib-only linter and scoring engine for Claude Code skills and other
 LLM instruction files.
 
@@ -375,7 +375,7 @@ weight calibration before the next run.
 
 The version is **single-sourced**: `_resolve_version()` reads it dynamically via
 `importlib.metadata.version("schliff")`, falling back to `dev` from a source checkout. From
-the installed package it resolves to **8.0.0**. There is no hardcoded version string in the
+the installed package it resolves to **8.1.0**. There is no hardcoded version string in the
 CLI.
 
 ---

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -15,6 +15,12 @@ its eval suite. These are static-analysis checks — they measure file organizat
 keyword coverage, assertion breadth, information density, and so on. They run
 instantly and require no LLM invocation.
 
+The **structural score** is the composite renormalized over the dimensions Schliff can
+measure deterministically without an eval suite — **structure, efficiency, composability,
+and clarity**. It is what the web playground reports. The full 7-dimension composite
+additionally folds in **triggers, quality, and edges**, which require an eval suite
+(`schliff init`).
+
 A high structural score is a **lint score**, not a guarantee of runtime quality. A
 skill with a 99/100 structure can still fail when Claude actually runs it. Two
 dimensions exist specifically as separate **signals** that are never folded into the
@@ -282,4 +288,4 @@ under the top-level `security` field), never folded into the skill.md-family hea
 
 Version is single-sourced: the CLI reads it via
 `importlib.metadata.version("schliff")` (`_resolve_version` in `cli.py`), falling back
-to `dev` in a source checkout. Current release: **8.0.0**.
+to `dev` in a source checkout. Current release: **8.1.0**.

--- a/docs/specs/playground-spec.json
+++ b/docs/specs/playground-spec.json
@@ -35,12 +35,16 @@
       "method": "POST /api/score",
       "request": { "content": "string (skill markdown)", "filename": "string (default: SKILL.md)" },
       "response": {
-        "composite_score": "float",
-        "grade": "S/A/B/C/D/F",
+        "structural_score": "float (composite renormalized over measured dims = composite / weight_coverage)",
+        "grade": "S/A/B/C/D/F (grade of structural_score)",
+        "composite_score": "float (canonical full-denominator composite)",
+        "full_grade": "S/A/B/C/D/F (grade of composite_score)",
         "dimensions": "dict (dim -> score, -1 = unmeasured)",
+        "unmeasured": "list[string] (eval-suite-gated dims not measured)",
         "warnings": "list[string]",
         "measured_dimensions": "int",
-        "total_dimensions": "int"
+        "total_dimensions": "int",
+        "weight_coverage": "float (fraction of total dimension weight measured)"
       },
       "constraints": [
         "500KB max content size",

--- a/install.sh
+++ b/install.sh
@@ -185,8 +185,8 @@ if [ "$MODE" = "update" ]; then
     fi
 
     # Clean up old backups, keep most recent 3
-    ls -dt "$HOME/.claude/skills/schliff.bak."* 2>/dev/null | tail -n +4 | xargs rm -rf 2>/dev/null
-    ls -dt "$HOME/.claude/commands/schliff.bak."* 2>/dev/null | tail -n +4 | xargs rm -rf 2>/dev/null
+    ls -dt "$HOME/.claude/skills/schliff.bak."* 2>/dev/null | tail -n +4 | xargs -I {} rm -rf "{}" 2>/dev/null
+    ls -dt "$HOME/.claude/commands/schliff.bak."* 2>/dev/null | tail -n +4 | xargs -I {} rm -rf "{}" 2>/dev/null
 fi
 
 # --- Install ---

--- a/playground/public/index.html
+++ b/playground/public/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='13' font-size='13' fill='%233fb950'>%E2%9C%93</text></svg>">
 <title>schliff.play — Score your SKILL.md live</title>
 <meta name="description" content="Score your SKILL.md live in the browser. Powered by Schliff.">
 <style>

--- a/playground/vercel.json
+++ b/playground/vercel.json
@@ -18,7 +18,8 @@
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" }
       ]
     }
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools>=68.0,<83"]
+requires = ["setuptools>=77,<83"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
 version = "8.1.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
-license = {text = "MIT"}
-requires-python = ">=3.9"
+license = "MIT"
+requires-python = ">=3.10"
 readme = "README.md"
 keywords = ["claude-code", "skill-linter", "autoresearch", "scoring", "deterministic", "quality", "autonomous-improvement", "linting", "code-quality", "cli", "static-analysis"]
 authors = [
@@ -17,9 +17,7 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -60,7 +58,7 @@ exclude = ["skills*.tests", "skills*.tests.*", "tests", "tests.*"]
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -49,6 +49,19 @@ def _resolve_version() -> str:
         return "dev"
 
 
+def _ensure_skill_path_exists(skill_path: str, exit_code: int = 1) -> None:
+    """Exit with the standard error if the skill path does not exist.
+
+    Centralizes the repeated existence check across commands. Callers must
+    pass exit_code=2 for the CI verify gate to preserve its exit semantics.
+    """
+    from pathlib import Path
+
+    if not Path(skill_path).exists():
+        print(f"Error: file not found: {skill_path}", file=sys.stderr)
+        sys.exit(exit_code)
+
+
 def _load_eval_suite_from_args(args: argparse.Namespace) -> "dict | None":
     """Load eval suite from --eval-suite flag or auto-discover from skill dir."""
     from pathlib import Path
@@ -263,9 +276,7 @@ def cmd_verify(args: argparse.Namespace) -> None:
 
     from shared import MAX_SKILL_SIZE, load_eval_suite
 
-    if not Path(args.skill_path).exists():
-        print(f"Error: file not found: {args.skill_path}", file=sys.stderr)
-        sys.exit(2)
+    _ensure_skill_path_exists(args.skill_path, exit_code=2)
 
     eval_suite = None
     if args.eval_suite:
@@ -332,16 +343,13 @@ def cmd_doctor(args: argparse.Namespace) -> None:
 def cmd_badge(args: argparse.Namespace) -> None:
     """Generate a markdown badge for a skill's score."""
     import urllib.parse
-    from pathlib import Path
 
     from terminal_art import score_to_grade
 
     from scoring import compute_composite
     from shared import build_scores
 
-    if not Path(args.skill_path).exists():
-        print(f"Error: file not found: {args.skill_path}", file=sys.stderr)
-        sys.exit(1)
+    _ensure_skill_path_exists(args.skill_path)
 
     eval_suite = _load_eval_suite_from_args(args)
     from scoring.formats import detect_format
@@ -639,17 +647,13 @@ def cmd_compare(args: argparse.Namespace) -> None:
 
 def cmd_suggest(args: argparse.Namespace) -> None:
     """Suggest ranked fixes with estimated score impact."""
-    from pathlib import Path
-
     import text_gradient
     from terminal_art import score_to_grade
 
     from scoring import compute_composite
     from shared import build_scores
 
-    if not Path(args.skill_path).exists():
-        print(f"Error: file not found: {args.skill_path}", file=sys.stderr)
-        sys.exit(1)
+    _ensure_skill_path_exists(args.skill_path)
 
     eval_suite = _load_eval_suite_from_args(args)
     top_n = max(1, args.top)
@@ -725,17 +729,13 @@ def cmd_suggest(args: argparse.Namespace) -> None:
 
 def cmd_report(args: argparse.Namespace) -> None:
     """Generate a Markdown score report, optionally upload as GitHub Gist."""
-    from pathlib import Path
-
     import report as report_mod
     from terminal_art import score_to_grade
 
     from scoring import compute_composite
     from shared import build_scores
 
-    if not Path(args.skill_path).exists():
-        print(f"Error: file not found: {args.skill_path}", file=sys.stderr)
-        sys.exit(1)
+    _ensure_skill_path_exists(args.skill_path)
 
     eval_suite = _load_eval_suite_from_args(args)
     from scoring.formats import check_token_budget, detect_format

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -964,13 +964,21 @@ def main():
 
     eval_suite = None
     if args.eval_suite and Path(args.eval_suite).exists():
-        eval_suite = json.loads(Path(args.eval_suite).read_text())
+        try:
+            eval_suite = json.loads(Path(args.eval_suite).read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Error: could not read eval-suite '{args.eval_suite}': {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         # Auto-discover eval-suite.json
         skill_dir = Path(args.skill_path).parent
         auto_path = skill_dir / "eval-suite.json"
         if auto_path.exists():
-            eval_suite = json.loads(auto_path.read_text())
+            try:
+                eval_suite = json.loads(auto_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                print(f"Error: could not read eval-suite '{auto_path}': {e}", file=sys.stderr)
+                sys.exit(1)
 
     # Validate eval-suite structure before processing
     if eval_suite is not None:

--- a/web/leaderboard/api/query.py
+++ b/web/leaderboard/api/query.py
@@ -21,10 +21,14 @@ VALID_SORT_FIELDS = {
     "efficiency", "composability", "clarity", "security", "date",
     "delta",
 }
-DIMENSION_KEYS = {
+# The 7 headline dimensions are the required core; `security` is an optional
+# opt-in signal (kept in sync with submit.py's REQUIRED/OPTIONAL split).
+REQUIRED_DIMENSIONS = {
     "structure", "triggers", "quality", "edges", "efficiency",
-    "composability", "clarity", "security",
+    "composability", "clarity",
 }
+OPTIONAL_DIMENSIONS = {"security"}
+DIMENSION_KEYS = REQUIRED_DIMENSIONS | OPTIONAL_DIMENSIONS
 
 # Match submit.py storage paths
 DATA_DIR = "/tmp/schliff-leaderboard"

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -25,10 +25,15 @@ MAX_BODY_BYTES = 64 * 1024  # 64 KB
 
 VALID_GRADES = {"S", "A", "B", "C", "D"}
 VALID_FORMATS = {"SKILL.md", ".cursorrules", "CLAUDE.md", "AGENTS.md"}
-VALID_DIMENSIONS = {
+# The 7 headline dimensions emitted by the engine/playground are REQUIRED.
+REQUIRED_DIMENSIONS = {
     "structure", "triggers", "quality", "edges", "efficiency",
-    "composability", "clarity", "security",
+    "composability", "clarity",
 }
+# `security` is a separate opt-in signal: accepted if present, never required.
+OPTIONAL_DIMENSIONS = {"security"}
+# Full set of recognized keys; any key outside this is rejected.
+VALID_DIMENSIONS = REQUIRED_DIMENSIONS | OPTIONAL_DIMENSIONS
 
 # TODO: Replace with external storage (Vercel KV, Postgres, or Blob)
 # for production. /tmp is ephemeral — data is lost between cold starts.
@@ -113,8 +118,13 @@ def _validate(body):
     dimensions = body["dimensions"]
     if not isinstance(dimensions, dict):
         return "dimensions must be an object"
-    if set(dimensions.keys()) != VALID_DIMENSIONS:
-        return f"dimensions must have exactly these keys: {', '.join(sorted(VALID_DIMENSIONS))}"
+    keys = set(dimensions.keys())
+    missing = REQUIRED_DIMENSIONS - keys
+    if missing:
+        return f"dimensions is missing required keys: {', '.join(sorted(missing))}"
+    unknown = keys - VALID_DIMENSIONS
+    if unknown:
+        return f"dimensions has unknown keys: {', '.join(sorted(unknown))}"
     for key, val in dimensions.items():
         if isinstance(val, bool) or not isinstance(val, (int, float)) or not (0 <= val <= 100):
             return f"dimensions.{key} must be a number between 0 and 100"

--- a/web/leaderboard/index.html
+++ b/web/leaderboard/index.html
@@ -825,6 +825,23 @@
 
     .trust-banner svg { flex-shrink: 0; }
 
+    /* Demo-mode notice — leaderboard storage is ephemeral and may reset */
+    .demo-banner {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      background: rgba(56,189,248,.07);
+      border: 1px solid rgba(56,189,248,.25);
+      border-radius: var(--radius-sm);
+      margin-top: 16px;
+      font-size: 12.5px;
+      color: var(--accent-blue);
+      line-height: 1.5;
+    }
+
+    .demo-banner svg { flex-shrink: 0; }
+
     /* Per-row unverified marker */
     .unverified-dot {
       display: inline-block;
@@ -890,6 +907,15 @@
         </div>
       </div>
     </header>
+
+    <!-- DEMO-MODE NOTICE -->
+    <div class="demo-banner" role="note">
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/>
+        <path d="M8 4.5v4M8 10.5v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+      <span>Demo mode &mdash; this leaderboard uses ephemeral storage, so entries are not persisted and may reset at any time.</span>
+    </div>
 
     <!-- CONTROLS BAR -->
     <div class="controls" role="toolbar" aria-label="Filter and sort controls">


### PR DESCRIPTION
Round 1 of a multi-round pre-launch hardening audit (multi-agent find → adversarial verify → disjoint-batch fix → central verification). **19 confirmed findings fixed**; risky dedup refactors deferred to a test-gated round 2.

## Verified centrally (not trusting agent self-claims)
- ✅ 1198/1198 tests pass · ruff clean
- ✅ `python -m build`: `License-Expression: MIT`, `Requires-Python: >=3.10`, **no SetuptoolsDeprecationWarning**
- ✅ CLI helper refactor: exit codes preserved (verify→2, badge→1, report→0)
- ✅ JSON-001: malformed eval-suite → clean `Error:` + exit 1 (was an unhandled traceback)
- ✅ leaderboard validation: 7-dim & 8-dim accepted, unknown/missing rejected
- ✅ both web apps build · leaderboard CSP sha256 hash unchanged

## Changes
**Packaging/CI:** SPDX license (`license = "MIT"`, setuptools≥77, drop MIT classifier); **drop Python 3.9** (EOL) → `requires-python>=3.10`, ruff `py310`, CI matrix `[3.10,3.11,3.12,3.13]` (3.10 was previously untested). BREAKING — in CHANGELOG.
**Robustness:** guard both eval-suite `json.loads` (graceful exit, no traceback); harden `install.sh` `xargs rm -rf`.
**Web:** playground CSP + data-URI favicon (kills 404) + spec updated to the structural-score shape; leaderboard `security` dim made **optional** (engine emits 7 headline dims; security is a separate opt-in signal) + honest **demo-mode banner** (ephemeral /tmp), added outside the CSP-pinned script.
**Simplify (safe):** `_ensure_skill_path_exists()` helper in cli.py (per-call exit codes preserved).
**Docs:** stale 8.0.0→8.1.0; define "structural score".

## Deferred → round 2 (risk / needs test-gating)
runtime-eval dedup (engine refactor), leaderboard `shared_constants` (Vercel sibling-bundle risk — same class as the earlier sys.path bug), ENC-001 read-helper, cli.py structural refactor. Owner-deferred: #51 KV storage (demo banner shipped instead), #52 query rate-limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)