### PR TITLE
feat(leaderboard): fix #51 + #52 — race fix + durable Upstash KV storage + KV rate-limit

### DIFF
--- a/docs/ops/vercel-deploy-runbook.md
+++ b/docs/ops/vercel-deploy-runbook.md
@@ -106,18 +106,18 @@ vercel firewall publish --scope zaneins-projects --yes
 > unauthenticated/unverified → 10/min/IP limits flooding. `/api/query` is
 > read-only; cap it only if you see abuse.
 
-> **`/api/query` rate limit — accepted residual (issue #52).** A per-IP cap on
-> the read-only query endpoint needs a *second* firewall rule, which this plan
-> rejects (see the plan limit above). The endpoint is read-only, returns only
-> public `unverified:true` data (no confidentiality), and already caps results
-> in code (`limit`/`offset`, max 200), so the residual risk is just
-> function-invocation cost / mild DoS — **accepted at current (near-zero)
-> traffic.** Two zero-/low-cost fixes when it matters: (a) upgrade to a plan that
-> allows a 2nd rule, then run the command below; or (b) a KV-backed global
-> counter (same Upstash Redis store as the persistence migration in §5).
+> **`/api/query` rate limit (issue #52) — solved by KV, no 2nd firewall rule
+> needed.** A *firewall* per-IP cap needs a second rule, which this plan rejects
+> (see the plan limit above). Instead, once Upstash is provisioned (see §5), the
+> functions enforce a **KV-backed per-IP limiter in code**: 100/60s/IP on
+> `/api/query` and 20/60s/IP on `/api/submit` (defense in depth behind the
+> firewall's 10/60s). Fail-open: a KV outage never blocks a request. Until Upstash
+> is provisioned the endpoint stays uncapped — accepted at current near-zero
+> traffic (read-only, public `unverified:true` data, results capped at 200 in code).
+> A firewall rule remains available as an alternative on a higher plan:
 >
 > ```bash
-> # Ready when on a plan that allows a 2nd rate-limit rule (from web/leaderboard/):
+> # Alternative (only if NOT using the KV limiter, and on a plan allowing a 2nd rule):
 > vercel firewall rules add "rl-api-query" --scope zaneins-projects --yes \
 >   --action rate_limit --rate-limit-requests 100 --rate-limit-window 60 \
 >   --rate-limit-keys ip --rate-limit-action deny \
@@ -137,25 +137,49 @@ for i in $(seq 1 75); do curl -s -o /dev/null -w "%{http_code}\n" \
 > Note: the `deny` action returns **403 Forbidden**, not 429. Both mean blocked;
 > if you specifically want 429, use a `rate_limit`/challenge action instead.
 
-## 5. Persistence (leaderboard) — known limitation
+## 5. Persistence (leaderboard) — durable storage via Upstash (issue #51)
 
-`web/leaderboard/api/{submit,query}.py` store to `/tmp/schliff-leaderboard`,
-which is **wiped on every cold start** (documented note in `submit.py`). The
-leaderboard is demo-grade until migrated to durable storage.
+`web/leaderboard/api/{submit,query}.py` support **two storage backends**, chosen at
+runtime by whether the Upstash/Vercel-KV env vars are present (design:
+`docs/specs/2026-06-11-leaderboard-kv-storage.md`):
 
-- **Within-instance integrity is fixed (issue #51 / tmp-01).** `submit.py` now
-  serializes the read-modify-write under an `flock`'d lock file and writes
-  atomically (`os.replace`), so concurrent POSTs to a warm instance no longer
-  last-write-wins clobber each other and readers never see a torn file. Covered
-  by `skills/schliff/tests/unit/test_leaderboard_storage.py`.
-- **Cross-cold-start durability is still open (issue #51, deferred).** The chosen
-  path is **Upstash Redis (= Vercel KV, $0)** per
-  `docs/specs/schliff-registry-platform.md` (roadmap "Leaderboard Persist"). For a
-  real launch, provision the KV store and swap `_load_submissions` /
-  `_save_submissions` (+ add a KV-backed global write rate-limit) before relying
-  on submitted data. Gated on real leaderboard traffic.
+- **Durable (Upstash Redis / Vercel KV, $0)** — when `KV_REST_API_URL` +
+  `KV_REST_API_TOKEN` (or `UPSTASH_REDIS_REST_*`) are set, submissions live in a
+  Redis hash. Each submit is one atomic `HSET` (dedup + no read-modify-write race,
+  durable across cold starts); query does `HGETALL` unioned with the bundled seed
+  rows. stdlib-only (`urllib`), no new dependency. **This is the fix for #51.**
+- **`/tmp` fallback (demo-grade)** — when the env vars are absent, the endpoints use
+  the per-instance `/tmp` store, **wiped on every cold start**. The within-instance
+  race is still fixed there (flock + atomic `os.replace`, #51 / tmp-01). This is the
+  default until Upstash is provisioned, so deploying the KV code changes nothing
+  until you opt in.
+
+**Provision (one-time, Franz's step):**
+
+```bash
+# from web/leaderboard/ (linked to schliff-leaderboard)
+vercel install upstash      # provisions Upstash Redis + syncs KV_REST_API_* env vars
+vercel deploy --prod        # redeploy so the functions pick up the env vars
+```
+
+**Verify durability is live (before closing #51/#52):**
+
+```bash
+# POST a submission, force a redeploy (new cold start), then confirm it survived:
+curl -s -X POST https://schliff-leaderboard.vercel.app/api/submit \
+  -H 'Content-Type: application/json' \
+  -d '{"skill_name":"kv-smoke","repo_url":"https://github.com/Zandereins/schliff","format":"SKILL.md","composite":88,"grade":"A","version":"8.1.0","dimensions":{"structure":90,"triggers":90,"quality":90,"edges":90,"efficiency":90,"composability":90,"clarity":90}}'
+vercel deploy --prod
+curl -s 'https://schliff-leaderboard.vercel.app/api/query?limit=200' | grep -c kv-smoke   # expect >=1 after cold start
+# /api/query limiter: 100 GETs in <60s from one IP -> the 101st returns 429.
+```
+
+Logic is unit-tested (`skills/schliff/tests/unit/test_leaderboard_kv.py`, fake
+Upstash) + `test_leaderboard_storage.py` (the /tmp fallback); the live round-trip
+above is the only step that needs the real store.
 
 ## 6. After launch
+
 - Watch `vercel logs <project> --prod` for 5xx / abuse spikes.
 - Custom domains (optional): Project → Domains.
 - The leaderboard already tags every entry `verified:false` / `unverified:true`

--- a/docs/ops/vercel-deploy-runbook.md
+++ b/docs/ops/vercel-deploy-runbook.md
@@ -106,6 +106,25 @@ vercel firewall publish --scope zaneins-projects --yes
 > unauthenticated/unverified → 10/min/IP limits flooding. `/api/query` is
 > read-only; cap it only if you see abuse.
 
+> **`/api/query` rate limit — accepted residual (issue #52).** A per-IP cap on
+> the read-only query endpoint needs a *second* firewall rule, which this plan
+> rejects (see the plan limit above). The endpoint is read-only, returns only
+> public `unverified:true` data (no confidentiality), and already caps results
+> in code (`limit`/`offset`, max 200), so the residual risk is just
+> function-invocation cost / mild DoS — **accepted at current (near-zero)
+> traffic.** Two zero-/low-cost fixes when it matters: (a) upgrade to a plan that
+> allows a 2nd rule, then run the command below; or (b) a KV-backed global
+> counter (same Upstash Redis store as the persistence migration in §5).
+>
+> ```bash
+> # Ready when on a plan that allows a 2nd rate-limit rule (from web/leaderboard/):
+> vercel firewall rules add "rl-api-query" --scope zaneins-projects --yes \
+>   --action rate_limit --rate-limit-requests 100 --rate-limit-window 60 \
+>   --rate-limit-keys ip --rate-limit-action deny \
+>   --condition '{"type":"path","op":"pre","value":"/api/query"}'
+> vercel firewall publish --scope zaneins-projects --yes
+> ```
+
 ## 4. Verify the gate is live
 
 ```bash
@@ -121,10 +140,20 @@ for i in $(seq 1 75); do curl -s -o /dev/null -w "%{http_code}\n" \
 ## 5. Persistence (leaderboard) — known limitation
 
 `web/leaderboard/api/{submit,query}.py` store to `/tmp/schliff-leaderboard`,
-which is **wiped on every cold start** (documented `TODO` in `submit.py`). The
-leaderboard is demo-grade until migrated to durable storage (Vercel KV / Postgres
-/ Blob). For a real launch, provision Vercel KV and swap `_load_submissions` /
-`_save_submissions` before relying on submitted data.
+which is **wiped on every cold start** (documented note in `submit.py`). The
+leaderboard is demo-grade until migrated to durable storage.
+
+- **Within-instance integrity is fixed (issue #51 / tmp-01).** `submit.py` now
+  serializes the read-modify-write under an `flock`'d lock file and writes
+  atomically (`os.replace`), so concurrent POSTs to a warm instance no longer
+  last-write-wins clobber each other and readers never see a torn file. Covered
+  by `skills/schliff/tests/unit/test_leaderboard_storage.py`.
+- **Cross-cold-start durability is still open (issue #51, deferred).** The chosen
+  path is **Upstash Redis (= Vercel KV, $0)** per
+  `docs/specs/schliff-registry-platform.md` (roadmap "Leaderboard Persist"). For a
+  real launch, provision the KV store and swap `_load_submissions` /
+  `_save_submissions` (+ add a KV-backed global write rate-limit) before relying
+  on submitted data. Gated on real leaderboard traffic.
 
 ## 6. After launch
 - Watch `vercel logs <project> --prod` for 5xx / abuse spikes.

--- a/docs/specs/2026-06-11-leaderboard-kv-storage.md
+++ b/docs/specs/2026-06-11-leaderboard-kv-storage.md
@@ -1,0 +1,91 @@
+# Leaderboard durable storage + read rate-limit (issues #51, #52)
+
+- **Status:** implemented behind fallback; pending Upstash provisioning + live verification
+- **Date:** 2026-06-11
+- **Issues:** #51 (durable storage / tmp-01 race / dos-02), #52 (`/api/query` rate-limit)
+- **Supersedes (partial):** the `/tmp` demo-grade storage note in `web/leaderboard/api/submit.py`
+
+## Goal
+
+Make the community leaderboard durable across cold starts and abuse-resistant, at
+**$0**, without adding a runtime dependency or regressing the current live deploy.
+
+## Context
+
+`web/leaderboard/api/{submit,query}.py` are standalone Vercel Python functions.
+Storage is per-instance ephemeral `/tmp` seeded from `data/submissions.json`:
+
+- **#51 tmp-01 (race):** fixed separately (flock + atomic `os.replace`, PR #58) — but
+  `/tmp` is still per-instance and **wiped on cold start** (data loss), and a global
+  write limit is impossible in-function (stateless).
+- **#51 dos-02:** IP-rotation bypasses the single per-IP firewall rule; only bounded
+  today because cold start wipes the store.
+- **#52 authz-02:** `GET /api/query` has no per-IP limit; the plan allows only one
+  firewall rate-limit rule per project (used by `/api/submit`).
+
+`docs/specs/schliff-registry-platform.md` already chose **Upstash Redis (= Vercel KV,
+$0)** as the persistence path. One shared store solves all three.
+
+## Requirements
+
+1. Durable submissions store shared across instances/cold starts.
+2. Atomic dedup upsert (no read-modify-write race, distributed).
+3. Per-IP read rate-limit on `/api/query` and write rate-limit on `/api/submit`,
+   independent of the firewall (sidesteps the 1-rule plan limit).
+4. **Zero new runtime dependency** (stdlib `urllib` against the Upstash REST API).
+5. **Fallback-safe:** if KV env vars are absent, behaviour is byte-identical to the
+   current `/tmp` path — so merging this is safe before the store is provisioned.
+6. No shared-module import between the two function files (Vercel handler context
+   makes sibling imports unreliable — the repo already hand-duplicates
+   `_score_model_for`). Duplicate the compact KV helper inline; a unit test asserts
+   the two copies stay behaviourally in sync.
+
+## Technical decisions
+
+- **Backend:** Upstash Redis REST API. Config from `KV_REST_API_URL`/`KV_REST_API_TOKEN`
+  (Vercel integration) **or** `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN`
+  (native). `_kv_config()` returns `None` when unset → `/tmp` fallback.
+- **Data model:** a single Redis **hash** `schliff:submissions`, field =
+  `sha256(repo_url + "\n" + skill_name)` (the dedup identity, NFKC-normalized
+  upstream), value = entry JSON. Submit = one atomic `HSET` (returns 1=new, 0=update)
+  → dedup and atomicity for free, no lock, no read-modify-write. Query = `HGETALL`.
+- **Seeding:** no seed-write. `query` **unions** KV entries with bundled
+  `data/submissions.json` rows whose dedup identity is not already in KV (KV wins on
+  conflict). Seed rows always show; real submissions live in KV. Avoids a seed-race.
+- **Rate-limit:** fixed-window per key via `INCR` + `EXPIRE` (`EXPIRE` only on the
+  first increment). `/api/query`: 100/60s/IP. `/api/submit`: 20/60s/IP (defense in
+  depth behind the firewall's 10/60s). Key from `x-forwarded-for` (first hop) →
+  `x-real-ip` → `"unknown"`. **Fail-open:** any KV error during the limiter check is
+  swallowed (never 500/429 a request because the limiter is unreachable).
+- **Timeouts:** 5s on every REST call; storage errors in the read/write path surface
+  as the existing generic 500 (no fallback-to-/tmp mid-request, to avoid split-brain).
+
+## Verification
+
+- **Unit (now):** fake in-memory Upstash REST (HSET/HGETALL/INCR/EXPIRE) injected at
+  the `_kv_command` boundary — atomic upsert + updated flag, query union-with-seed,
+  rate-limit allow→block, fail-open on error, and fallback-when-unconfigured. Plus the
+  existing `/tmp` concurrency tests (unchanged) and a cross-file sync test.
+- **Wire format:** verified against Upstash REST docs (pipeline + single-command
+  `{"result"|"error"}` shape) and Vercel docs (`vercel install upstash` env sync).
+- **Live (gated, before closing issues):** after `vercel install upstash`, redeploy
+  and confirm a POST→GET round-trip survives a forced redeploy/cold start, and that
+  the `/api/query` limiter returns 429 past 100/60s.
+
+## Provisioning (Franz's step)
+
+```bash
+# from web/leaderboard/ (linked to schliff-leaderboard)
+vercel install upstash            # provisions Upstash Redis + syncs KV_REST_API_* env
+vercel deploy --prod              # redeploy so the functions pick up the env vars
+```
+
+Until that runs, the deployed functions see no KV config and keep using `/tmp`
+(demo-grade) with the race fix — no behaviour change, no risk.
+
+## Open / deferred
+
+- Migrating the bundled seed into KV (vs. union-at-read) — union is simpler and
+  chosen; revisit only if seed grows large.
+- Per-IP vs. global write limit for dos-02 — per-IP chosen (matches firewall
+  semantics); a global cap can be added as a second key if coordinated abuse appears.

--- a/skills/schliff/tests/unit/test_leaderboard_kv.py
+++ b/skills/schliff/tests/unit/test_leaderboard_kv.py
@@ -1,0 +1,168 @@
+"""Leaderboard durable storage + rate-limit via Upstash Redis (issues #51, #52).
+
+The KV path is active only when the Upstash/Vercel-KV env vars are present; absent,
+the endpoints use the /tmp fallback (covered by test_leaderboard_storage.py). These
+tests exercise the KV logic against an in-memory fake injected at the `_kv_command`
+boundary — the REST wire format itself is verified against Upstash docs and live
+after provisioning. They also enforce that the helper block stays byte-identical
+across the two independently-bundled serverless files.
+"""
+import importlib.util
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+_API = Path(__file__).resolve().parents[4] / "web" / "leaderboard" / "api"
+
+
+def _load_module(mod_name, filename):
+    spec = importlib.util.spec_from_file_location(mod_name, _API / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+submit = _load_module("lb_submit_kv", "submit.py")
+query = _load_module("lb_query_kv", "query.py")
+
+
+class FakeRedis:
+    """Minimal in-memory Upstash REST stand-in (HSET / HGETALL / INCR / EXPIRE)."""
+
+    def __init__(self):
+        self.hashes = {}
+        self.counters = {}
+        self.raise_next = False
+
+    def cmd(self, cfg, *args):
+        if self.raise_next:
+            raise RuntimeError("simulated KV transport error")
+        op = str(args[0]).upper()
+        if op == "HSET":
+            _, key, field, value = args
+            bucket = self.hashes.setdefault(key, {})
+            is_new = field not in bucket
+            bucket[field] = value
+            return 1 if is_new else 0
+        if op == "HGETALL":
+            _, key = args
+            flat = []
+            for f, v in self.hashes.get(key, {}).items():
+                flat.extend([f, v])
+            return flat  # REST returns a flat [field, value, ...] array
+        if op == "INCR":
+            _, key = args
+            self.counters[key] = self.counters.get(key, 0) + 1
+            return self.counters[key]
+        if op == "EXPIRE":
+            return 1
+        raise AssertionError(f"unhandled command: {op}")
+
+
+@pytest.fixture
+def kv(monkeypatch):
+    monkeypatch.setenv("KV_REST_API_URL", "https://fake.upstash.io")
+    monkeypatch.setenv("KV_REST_API_TOKEN", "tok")
+    fake = FakeRedis()
+    monkeypatch.setattr(submit, "_kv_command", fake.cmd)
+    monkeypatch.setattr(query, "_kv_command", fake.cmd)
+    return fake
+
+
+def _entry(skill="s", repo="https://github.com/u/r"):
+    return {"skill_name": skill, "repo_url": repo, "composite": 90.0, "version": "8.1.0"}
+
+
+# --- config --------------------------------------------------------------------
+
+def test_kv_config_none_when_unset(monkeypatch):
+    for var in ("KV_REST_API_URL", "KV_REST_API_TOKEN",
+                "UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    assert submit._kv_config() is None
+
+
+def test_kv_config_reads_both_env_schemes(monkeypatch):
+    for var in ("KV_REST_API_URL", "KV_REST_API_TOKEN",
+                "UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("UPSTASH_REDIS_REST_URL", "https://x.upstash.io/")
+    monkeypatch.setenv("UPSTASH_REDIS_REST_TOKEN", "t")
+    # trailing slash trimmed
+    assert submit._kv_config() == ("https://x.upstash.io", "t")
+
+
+# --- upsert / dedup ------------------------------------------------------------
+
+def test_upsert_insert_then_update_is_atomic_and_dedups(kv):
+    cfg = submit._kv_config()
+    assert submit._kv_upsert(cfg, _entry(skill="a")) is False   # newly inserted
+    assert submit._kv_upsert(cfg, _entry(skill="a")) is True    # same identity -> update
+    # exactly one stored field for that identity
+    assert len(kv.hashes[submit.SUBMISSIONS_KEY]) == 1
+
+
+def test_dedup_field_cross_file_and_value_stable():
+    assert submit._dedup_field("r", "s") == query._dedup_field("r", "s")
+    assert submit._dedup_field("r", "s") != submit._dedup_field("r", "s2")
+
+
+# --- query load + seed union ---------------------------------------------------
+
+def test_kv_load_unions_seed_rows_not_in_kv(kv, tmp_path, monkeypatch):
+    seed = [_entry(skill="seed1", repo="https://github.com/u/seed1"),
+            _entry(skill="shared", repo="https://github.com/u/shared")]
+    seed_file = tmp_path / "seed.json"
+    seed_file.write_text(json.dumps(seed), encoding="utf-8")
+    monkeypatch.setattr(query, "SEED_PATH", str(seed_file))
+
+    cfg = query._kv_config()
+    # KV holds an updated version of "shared" + a fresh "kvonly"
+    submit._kv_upsert(cfg, {**_entry(skill="shared", repo="https://github.com/u/shared"),
+                            "composite": 11.0})
+    submit._kv_upsert(cfg, _entry(skill="kvonly", repo="https://github.com/u/kvonly"))
+
+    loaded = query._kv_load_all(cfg)
+    names = sorted(e["skill_name"] for e in loaded)
+    assert names == ["kvonly", "seed1", "shared"]  # union, no duplicate "shared"
+    shared = next(e for e in loaded if e["skill_name"] == "shared")
+    assert shared["composite"] == 11.0  # KV wins over seed on identity conflict
+
+
+def test_kv_load_empty_returns_only_seed(kv, tmp_path, monkeypatch):
+    seed_file = tmp_path / "seed.json"
+    seed_file.write_text(json.dumps([_entry(skill="only-seed")]), encoding="utf-8")
+    monkeypatch.setattr(query, "SEED_PATH", str(seed_file))
+    loaded = query._kv_load_all(query._kv_config())
+    assert [e["skill_name"] for e in loaded] == ["only-seed"]
+
+
+# --- rate limit ----------------------------------------------------------------
+
+def test_rate_limit_allows_then_blocks(kv):
+    cfg = submit._kv_config()
+    assert submit._kv_rate_limited(cfg, "rl:test:ip", limit=2, window=60) is False  # 1
+    assert submit._kv_rate_limited(cfg, "rl:test:ip", limit=2, window=60) is False  # 2
+    assert submit._kv_rate_limited(cfg, "rl:test:ip", limit=2, window=60) is True   # 3 blocked
+
+
+def test_rate_limit_fail_open_on_kv_error(kv):
+    kv.raise_next = True
+    # limiter must never block (or raise) when the KV backend errors
+    assert submit._kv_rate_limited(submit._kv_config(), "rl:x", limit=1, window=60) is False
+
+
+# --- cross-file sync guard -----------------------------------------------------
+
+@pytest.mark.parametrize("fn", ["_kv_config", "_kv_command", "_dedup_field",
+                                "_client_ip", "_kv_rate_limited"])
+def test_shared_kv_helpers_byte_identical_across_files(fn):
+    """The two serverless files duplicate this block by hand (Vercel can't share a
+    module). Guard against drift between the copies."""
+    assert inspect.getsource(getattr(submit, fn)) == inspect.getsource(getattr(query, fn))
+
+
+def test_submissions_key_matches_across_files():
+    assert submit.SUBMISSIONS_KEY == query.SUBMISSIONS_KEY

--- a/skills/schliff/tests/unit/test_leaderboard_storage.py
+++ b/skills/schliff/tests/unit/test_leaderboard_storage.py
@@ -1,0 +1,77 @@
+"""Leaderboard submission storage: concurrency + atomicity (issue #51 / tmp-01).
+
+The submit endpoint read-modify-writes a JSON file. Two concurrent POSTs must not
+last-write-wins clobber each other, and a reader must never observe a torn file.
+These tests lock the flock critical section + atomic os.replace added in
+fix/leaderboard-submit-race-and-ratelimit-docs.
+
+The leaderboard endpoints are standalone serverless files under web/leaderboard/api
+(stdlib-only, no relative imports), loaded here directly by path — storage paths are
+redirected to a tmp dir so the real /tmp is never touched.
+"""
+import importlib.util
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+_API = Path(__file__).resolve().parents[4] / "web" / "leaderboard" / "api"
+
+
+def _load_module(mod_name, filename):
+    spec = importlib.util.spec_from_file_location(mod_name, _API / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def submit(tmp_path):
+    mod = _load_module("lb_submit_storage", "submit.py")
+    data_dir = tmp_path / "schliff-leaderboard"
+    mod.DATA_DIR = str(data_dir)
+    mod.DATA_PATH = str(data_dir / "submissions.json")
+    mod.LOCK_PATH = str(data_dir / ".lock")
+    # Point the seed at a nonexistent file so each test starts from an empty store.
+    mod.SEED_PATH = str(tmp_path / "nonexistent-seed.json")
+    return mod
+
+
+def test_save_then_load_roundtrip(submit):
+    submit._save_submissions([{"skill_name": "a"}])
+    assert submit._load_submissions() == [{"skill_name": "a"}]
+
+
+def test_save_leaves_no_temp_file(submit):
+    submit._save_submissions([{"skill_name": "a"}])
+    leftovers = [p for p in os.listdir(submit.DATA_DIR) if p.endswith(".tmp")]
+    assert leftovers == [], f"atomic write left temp files behind: {leftovers}"
+
+
+def test_concurrent_writes_no_lost_update(submit):
+    """25 threads each append one unique entry under the lock. With the flock'd
+    read-modify-write critical section every entry must survive; without it,
+    last-write-wins would silently drop most of them."""
+    n = 25
+    barrier = threading.Barrier(n)  # maximize overlap to expose any race
+
+    def worker(i):
+        barrier.wait()
+        with submit._exclusive_lock():
+            entries = submit._load_submissions()
+            entries.append({
+                "skill_name": f"skill-{i}",
+                "repo_url": f"https://github.com/u/r{i}",
+            })
+            submit._save_submissions(entries)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = submit._load_submissions()
+    names = sorted(e["skill_name"] for e in final)
+    assert names == sorted(f"skill-{i}" for i in range(n)), "lost update under concurrency"

--- a/web/leaderboard/api/query.py
+++ b/web/leaderboard/api/query.py
@@ -7,9 +7,11 @@ clients can render an appropriate "community-submitted, not verified" notice.
 Read-only; CORS handled in vercel.json.
 """
 
+import hashlib
 import json
 import os
 import sys
+import urllib.request
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import parse_qs, urlparse
 
@@ -95,6 +97,103 @@ def _sort_key(entry, sort_field):
     return entry.get("dimensions", {}).get(sort_field, 0)
 
 
+# --- durable storage + rate-limit via Upstash Redis REST (issues #51/#52) -------
+# Active ONLY when the Upstash/Vercel-KV env vars are present. Absent -> every
+# helper below is bypassed and the /tmp path above runs unchanged, so merging this
+# is safe before the store is provisioned (`vercel install upstash`). stdlib-only.
+# KEEP THIS BLOCK BYTE-IDENTICAL to the copy in submit.py — Vercel bundles each
+# function independently, so the two files cannot share a module (test enforces it).
+SUBMISSIONS_KEY = "schliff:submissions"
+
+
+def _kv_config():
+    """(url, token) for the Upstash REST API, or None when not configured."""
+    url = os.environ.get("KV_REST_API_URL") or os.environ.get("UPSTASH_REDIS_REST_URL")
+    token = os.environ.get("KV_REST_API_TOKEN") or os.environ.get("UPSTASH_REDIS_REST_TOKEN")
+    return (url.rstrip("/"), token) if url and token else None
+
+
+def _kv_command(cfg, *args):
+    """Run one Redis command via the Upstash REST API and return its `result`.
+    Raises on transport / HTTP / Redis-level error."""
+    url, token = cfg
+    data = json.dumps([str(a) for a in args]).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    if isinstance(payload, dict) and "error" in payload:
+        raise RuntimeError(f"KV error: {payload['error']}")
+    return payload.get("result") if isinstance(payload, dict) else payload
+
+
+def _dedup_field(repo_url, skill_name):
+    """Stable hash of the (repo_url, skill_name) identity — the submissions-hash
+    field and the dedup key. Inputs are NFKC-normalized + invalid-char-rejected
+    upstream, so this is a 1:1 identity."""
+    return hashlib.sha256(f"{repo_url}\n{skill_name}".encode("utf-8")).hexdigest()
+
+
+def _client_ip(handler):
+    """Best-effort client IP from Vercel's forwarding headers."""
+    fwd = handler.headers.get("x-forwarded-for", "")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return handler.headers.get("x-real-ip", "") or "unknown"
+
+
+def _kv_rate_limited(cfg, key, limit, window):
+    """Fixed-window per-key limiter (INCR + EXPIRE on first hit). Returns True to
+    block. Fail-open: any KV error -> not limited (never break a request because the
+    limiter is unreachable)."""
+    try:
+        count = _kv_command(cfg, "INCR", key)
+        if count == 1:
+            _kv_command(cfg, "EXPIRE", key, window)
+        return count > limit
+    except Exception as exc:
+        print(f"Rate-limit check skipped (KV error): {type(exc).__name__}: {exc}", file=sys.stderr)
+        return False
+
+
+def _load_seed():
+    """Bundled, read-only demo rows (data/submissions.json)."""
+    if os.path.exists(SEED_PATH):
+        with open(SEED_PATH, "r", encoding="utf-8") as f:
+            content = f.read().strip()
+            return json.loads(content) if content else []
+    return []
+
+
+def _kv_load_all(cfg):
+    """All submissions from KV, unioned with bundled seed rows not yet resubmitted
+    into KV (KV wins on identity conflict). HGETALL over REST returns a flat
+    [field, value, field, value, ...] array."""
+    raw = _kv_command(cfg, "HGETALL", SUBMISSIONS_KEY)
+    if isinstance(raw, list):
+        values = raw[1::2]
+    elif isinstance(raw, dict):
+        values = list(raw.values())
+    else:
+        values = []
+
+    entries, seen = [], set()
+    for v in values:
+        try:
+            e = json.loads(v)
+        except (ValueError, TypeError):
+            continue
+        entries.append(e)
+        seen.add(_dedup_field(e.get("repo_url", ""), e.get("skill_name", "")))
+
+    for e in _load_seed():
+        if _dedup_field(e.get("repo_url", ""), e.get("skill_name", "")) not in seen:
+            entries.append(e)
+    return entries
+
+
 class handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
@@ -114,6 +213,13 @@ class handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
+        # Per-IP read rate-limit when KV is configured (issue #52); the firewall's
+        # single rule is spent on /api/submit, so this is the cap for /api/query.
+        cfg = _kv_config()
+        if cfg and _kv_rate_limited(cfg, f"rl:query:{_client_ip(self)}", 100, 60):
+            self._send_json(429, {"error": "rate limit exceeded"})
+            return
+
         parsed = urlparse(self.path)
         params = parse_qs(parsed.query)
 
@@ -176,7 +282,7 @@ class handler(BaseHTTPRequestHandler):
                 return
 
         try:
-            entries = _load_submissions()
+            entries = _kv_load_all(cfg) if cfg else _load_submissions()
         except Exception as exc:
             print(f"Storage error: {type(exc).__name__}: {exc}", file=sys.stderr)
             self._send_json(500, {"error": "internal storage error"})

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -6,20 +6,22 @@ scoring engine, so a caller can claim any (valid-range) score. Every stored
 entry is therefore tagged `"verified": false`, and consumers must treat the
 leaderboard as untrusted, self-reported data, not as an authoritative ranking.
 
-There is NO per-IP/per-caller rate limiting in this function: serverless
-invocations share no state across cold starts, so a real cross-request limit
-cannot live here. Flood/abuse protection must be configured at the Vercel
-Firewall level (dashboard / `vercel firewall` CLI / REST API) — see the
-deploy-side checklist. Storage is also ephemeral /tmp (see DATA_DIR note below).
+STORAGE & RATE LIMITING are backend-dependent (see the DATA_DIR / KV notes below):
+when Upstash/Vercel-KV env vars are present, submissions are durable (Redis) and a
+KV-backed per-IP rate limit is enforced in-function; absent, storage is per-instance
+ephemeral /tmp and cross-request limiting must come from the Vercel Firewall
+(dashboard / `vercel firewall` CLI / REST API) — see the deploy-side runbook.
 """
 
 import contextlib
 import fcntl
+import hashlib
 import json
 import os
 import sys
 import tempfile
 import unicodedata
+import urllib.request
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import urlparse
@@ -198,6 +200,78 @@ def _exclusive_lock():
         os.close(lock_fd)
 
 
+# --- durable storage + rate-limit via Upstash Redis REST (issues #51/#52) -------
+# Active ONLY when the Upstash/Vercel-KV env vars are present. Absent -> every
+# helper below is bypassed and the /tmp path above runs unchanged, so merging this
+# is safe before the store is provisioned (`vercel install upstash`). stdlib-only.
+# KEEP THIS BLOCK BYTE-IDENTICAL to the copy in query.py — Vercel bundles each
+# function independently, so the two files cannot share a module (test enforces it).
+SUBMISSIONS_KEY = "schliff:submissions"
+
+
+def _kv_config():
+    """(url, token) for the Upstash REST API, or None when not configured."""
+    url = os.environ.get("KV_REST_API_URL") or os.environ.get("UPSTASH_REDIS_REST_URL")
+    token = os.environ.get("KV_REST_API_TOKEN") or os.environ.get("UPSTASH_REDIS_REST_TOKEN")
+    return (url.rstrip("/"), token) if url and token else None
+
+
+def _kv_command(cfg, *args):
+    """Run one Redis command via the Upstash REST API and return its `result`.
+    Raises on transport / HTTP / Redis-level error."""
+    url, token = cfg
+    data = json.dumps([str(a) for a in args]).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    if isinstance(payload, dict) and "error" in payload:
+        raise RuntimeError(f"KV error: {payload['error']}")
+    return payload.get("result") if isinstance(payload, dict) else payload
+
+
+def _dedup_field(repo_url, skill_name):
+    """Stable hash of the (repo_url, skill_name) identity — the submissions-hash
+    field and the dedup key. Inputs are NFKC-normalized + invalid-char-rejected
+    upstream, so this is a 1:1 identity."""
+    return hashlib.sha256(f"{repo_url}\n{skill_name}".encode("utf-8")).hexdigest()
+
+
+def _client_ip(handler):
+    """Best-effort client IP from Vercel's forwarding headers."""
+    fwd = handler.headers.get("x-forwarded-for", "")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return handler.headers.get("x-real-ip", "") or "unknown"
+
+
+def _kv_rate_limited(cfg, key, limit, window):
+    """Fixed-window per-key limiter (INCR + EXPIRE on first hit). Returns True to
+    block. Fail-open: any KV error -> not limited (never break a request because the
+    limiter is unreachable)."""
+    try:
+        count = _kv_command(cfg, "INCR", key)
+        if count == 1:
+            _kv_command(cfg, "EXPIRE", key, window)
+        return count > limit
+    except Exception as exc:
+        print(f"Rate-limit check skipped (KV error): {type(exc).__name__}: {exc}", file=sys.stderr)
+        return False
+
+
+def _kv_upsert(cfg, entry):
+    """Atomic insert-or-update of one entry in the submissions hash. Returns True if
+    an existing entry was updated, False if newly inserted. One HSET = no
+    read-modify-write race, durable across cold starts (issue #51)."""
+    field = _dedup_field(entry["repo_url"], entry["skill_name"])
+    result = _kv_command(cfg, "HSET", SUBMISSIONS_KEY, field,
+                         json.dumps(entry, ensure_ascii=False))
+    # HSET returns the count of NEW fields: 1 = inserted, 0 = updated existing.
+    return result == 0
+
+
 class handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
@@ -263,25 +337,34 @@ class handler(BaseHTTPRequestHandler):
             "verified": False,
         }
 
+        cfg = _kv_config()
+        if cfg and _kv_rate_limited(cfg, f"rl:submit:{_client_ip(self)}", 20, 60):
+            self._send_json(429, {"error": "rate limit exceeded"})
+            return
+
         try:
-            # Hold the lock across load->dedup->save so two concurrent POSTs
-            # cannot both read the old list and last-write-wins clobber each other.
-            with _exclusive_lock():
-                entries = _load_submissions()
+            if cfg:
+                # Durable, atomic upsert — no read-modify-write, no cold-start loss.
+                updated = _kv_upsert(cfg, entry)
+            else:
+                # /tmp fallback (demo-grade). Hold the lock across load->dedup->save
+                # so two concurrent POSTs cannot last-write-wins clobber each other.
+                with _exclusive_lock():
+                    entries = _load_submissions()
 
-                # Dedup: update existing entry if repo_url + skill_name match.
-                key_repo = entry["repo_url"]
-                key_skill = entry["skill_name"]
-                updated = False
-                for i, existing in enumerate(entries):
-                    if existing.get("repo_url") == key_repo and existing.get("skill_name") == key_skill:
-                        entries[i] = entry
-                        updated = True
-                        break
-                if not updated:
-                    entries.append(entry)
+                    # Dedup: update existing entry if repo_url + skill_name match.
+                    key_repo = entry["repo_url"]
+                    key_skill = entry["skill_name"]
+                    updated = False
+                    for i, existing in enumerate(entries):
+                        if existing.get("repo_url") == key_repo and existing.get("skill_name") == key_skill:
+                            entries[i] = entry
+                            updated = True
+                            break
+                    if not updated:
+                        entries.append(entry)
 
-                _save_submissions(entries)
+                    _save_submissions(entries)
         except Exception as exc:
             print(f"Storage error: {type(exc).__name__}: {exc}", file=sys.stderr)
             self._send_json(500, {"error": "internal storage error"})

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -13,9 +13,12 @@ Firewall level (dashboard / `vercel firewall` CLI / REST API) — see the
 deploy-side checklist. Storage is also ephemeral /tmp (see DATA_DIR note below).
 """
 
+import contextlib
+import fcntl
 import json
 import os
 import sys
+import tempfile
 import unicodedata
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler
@@ -35,11 +38,16 @@ OPTIONAL_DIMENSIONS = {"security"}
 # Full set of recognized keys; any key outside this is rejected.
 VALID_DIMENSIONS = REQUIRED_DIMENSIONS | OPTIONAL_DIMENSIONS
 
-# TODO: Replace with external storage (Vercel KV, Postgres, or Blob)
-# for production. /tmp is ephemeral — data is lost between cold starts.
-# This works for demo/prototype but NOT for persistent leaderboard data.
+# Storage is per-instance, ephemeral /tmp seeded from the bundled data file.
+# Within a warm instance, concurrent POSTs are serialized by an flock'd lock file
+# and writes are atomic (os.replace), so no entry is lost to a read-modify-write
+# race or torn read (issue #51 / tmp-01). DURABILITY across cold starts is a
+# separate, deferred concern: the chosen path is Upstash Redis (= Vercel KV, $0),
+# per docs/specs/schliff-registry-platform.md — gated on real leaderboard traffic.
+# Until then the leaderboard is demo-grade by design.
 DATA_DIR = "/tmp/schliff-leaderboard"
 DATA_PATH = os.path.join(DATA_DIR, "submissions.json")
+LOCK_PATH = os.path.join(DATA_DIR, ".lock")
 
 # Seed data path (bundled with deployment, read-only)
 SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "submissions.json")
@@ -151,12 +159,43 @@ def _load_submissions():
 
 
 def _save_submissions(entries):
-    """Save submissions to /tmp (ephemeral)."""
+    """Atomically persist submissions: write a sibling temp file, fsync it, then
+    os.replace() into place so a concurrent reader never observes a torn file.
+    Callers mutate under _exclusive_lock() to also prevent lost updates."""
     os.makedirs(DATA_DIR, exist_ok=True)
     data = json.dumps(entries, indent=2, ensure_ascii=False)
-    with open(DATA_PATH, "w", encoding="utf-8") as f:
-        f.write(data)
-        f.flush()
+    fd, tmp_path = tempfile.mkstemp(dir=DATA_DIR, prefix=".submissions.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, DATA_PATH)
+    except BaseException:
+        # Never leave a partial temp file behind on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+@contextlib.contextmanager
+def _exclusive_lock():
+    """Serialize the submissions read-modify-write within a warm instance.
+
+    /tmp is per-instance, so an OS advisory lock (flock) on a sibling lock file is
+    enough to stop two concurrent POSTs from last-write-wins clobbering each other
+    (issue #51 / tmp-01). Cross-instance durability is out of scope here — see the
+    storage note above."""
+    os.makedirs(DATA_DIR, exist_ok=True)
+    lock_fd = os.open(LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
 
 
 class handler(BaseHTTPRequestHandler):
@@ -225,21 +264,24 @@ class handler(BaseHTTPRequestHandler):
         }
 
         try:
-            entries = _load_submissions()
+            # Hold the lock across load->dedup->save so two concurrent POSTs
+            # cannot both read the old list and last-write-wins clobber each other.
+            with _exclusive_lock():
+                entries = _load_submissions()
 
-            # Dedup: update existing entry if repo_url + skill_name match.
-            key_repo = entry["repo_url"]
-            key_skill = entry["skill_name"]
-            updated = False
-            for i, existing in enumerate(entries):
-                if existing.get("repo_url") == key_repo and existing.get("skill_name") == key_skill:
-                    entries[i] = entry
-                    updated = True
-                    break
-            if not updated:
-                entries.append(entry)
+                # Dedup: update existing entry if repo_url + skill_name match.
+                key_repo = entry["repo_url"]
+                key_skill = entry["skill_name"]
+                updated = False
+                for i, existing in enumerate(entries):
+                    if existing.get("repo_url") == key_repo and existing.get("skill_name") == key_skill:
+                        entries[i] = entry
+                        updated = True
+                        break
+                if not updated:
+                    entries.append(entry)
 
-            _save_submissions(entries)
+                _save_submissions(entries)
         except Exception as exc:
             print(f"Storage error: {type(exc).__name__}: {exc}", file=sys.stderr)
             self._send_json(500, {"error": "internal storage error"})


### PR DESCRIPTION
Addresses **#51** (durable storage / tmp-01 race / dos-02) and **#52** (`/api/query` rate-limit). Two commits:

### 1. `fix:` within-instance race (tmp-01) — fully verifiable now
`submit.py` read-modify-wrote `/tmp/.../submissions.json` with no lock + non-atomic write → concurrent POSTs to a warm instance could last-write-wins drop entries, readers could see torn files. Now: `flock`'d lock across `load→dedup→save` + atomic `tempfile`→`fsync`→`os.replace`. Negative control: **1/25** survive without the lock, **25/25** with it.

### 2. `feat:` durable Upstash Redis (= Vercel KV, $0) + KV rate-limit — behind fallback
Optional backend, selected at runtime by `KV_REST_API_*` / `UPSTASH_REDIS_*` env vars. **Absent → byte-identical `/tmp` fallback**, so this is safe to merge before provisioning (the live deploy is unchanged until you opt in).
- **#51 durable:** submissions in a Redis hash keyed by `sha256(repo_url, skill_name)`. Submit = one atomic `HSET` (dedup + no race + survives cold starts); query = `HGETALL` unioned with bundled seed rows. stdlib `urllib`, **no new dependency**.
- **#52 rate-limit:** KV-backed per-IP fixed-window (`INCR`+`EXPIRE`), 100/60s on `/api/query`, 20/60s on `/api/submit`, fail-open. Sidesteps the 1-firewall-rule plan limit at $0.

### Verification
- **1227 unit tests green, ruff clean.** New: `test_leaderboard_storage.py` (concurrency/atomicity), `test_leaderboard_kv.py` (14 tests, fake Upstash: atomic upsert, seed-union, rate-limit allow→block, fail-open, dual-env config, **cross-file byte-identical sync guard**).
- Wire format verified against Upstash + Vercel docs (not memory).
- **Live round-trip is gated** — needs `vercel install upstash` + redeploy. Until then the deployed functions stay on `/tmp` (with the race fix).

### Merge / close ordering
Safe to merge now (fallback-safe). Issues **#51/#52 stay open** until: merge → `vercel install upstash` → redeploy → live POST/GET-survives-cold-start + 429-past-limit verified (runbook §5). Design: `docs/specs/2026-06-11-leaderboard-kv-storage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)