### PR TITLE
release: v8.2.0 (security: ReDoS fix + accumulated hardening)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Deterministic skill linter and scoring engine for Claude Code. 7-dimension scoring, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": "Zandereins",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.2.0] - 2026-06-11
+
+### Added
+- Public **Vercel deployments**: an interactive playground (`POST /api/score`, real scoring
+  engine) and a community leaderboard (`/api/submit`, `/api/query`). (#50, #54)
+- Leaderboard **durable storage on Upstash Redis (Vercel KV, $0)** — atomic dedup upsert that
+  survives cold starts, plus a KV-backed per-IP rate limiter; transparent ephemeral `/tmp`
+  fallback when KV is not configured. (#58, #59)
+- **CodeQL** SAST workflow (`security-extended`, SHA-pinned, least-privilege). (#59)
+- Machine-readable version output / agentic-integration groundwork. (#57)
+
 ### Changed
 - **BREAKING: drop Python 3.9 support** — minimum supported version is now Python 3.10
   (`requires-python = ">=3.10"`). Python 3.9 reached end-of-life on 2025-10-31. The CI test
-  matrix and ruff `target-version` were updated accordingly.
+  matrix and ruff `target-version` were updated accordingly. (#55)
 - Modernized license metadata to the PEP 639 SPDX expression form (`license = "MIT"`), dropping
-  the deprecated `License :: OSI Approved :: MIT License` classifier. Requires `setuptools>=77`.
+  the deprecated `License :: OSI Approved :: MIT License` classifier. Requires `setuptools>=77`. (#55)
+- Playground now reports an **honest structural score** (renormalized over the four deterministic
+  dimensions) instead of a coverage-capped composite; removed a phantom `sync` dimension. (#54)
+
+### Fixed
+- Leaderboard submit read-modify-write **race + non-atomic write** (now flock-serialized +
+  atomic `os.replace`). (#58)
+- Vercel deployability (score.py `sys.path` bootstrap, `framework:null`, build-artifact
+  gitignore), JSON crash guard, `install.sh` hardening, CLI error UX, and web
+  a11y/contrast/keyboard + Google-Fonts CSP. (#50, #53, #55, #56)
+
+### Security
+- **Fix ReDoS / remote CPU-DoS in the scoring engine.** `_RE_REAL_EXAMPLES` / `_RE_DIFF_EXAMPLE`
+  used an unbounded `input.*output` (O(n²) under `findall`); a ~256KB single-line payload via the
+  public playground pegged a serverless function's CPU for ~90s. Bounded to `input.{0,200}?output`
+  (linear), regression-guarded, and the playground caps scored input at 32KB as defense-in-depth. (#59)
+- **Prompt-injection hardening** — nonce-wrap untrusted skill content in the judge and runtime
+  evaluators; pre-validate regex complexity. (#56)
+- Hardened web security headers across both apps: CSP (playground drops `script-src
+  'unsafe-inline'` via a sha256 pin), HSTS, **Permissions-Policy**, X-Frame-Options, nosniff,
+  Referrer-Policy, `Cache-Control: no-store`. (#50, #56, #59)
+- **Bound durable leaderboard submissions** (global 500/3600s + 10000-entry size cap) against
+  persistent pollution; NFKC + invisible-character dedup-bypass guard; generic 500s. (#50, #58, #59)
+- Supply chain & repo posture: SHA-pinned actions, OIDC trusted publishing, pinned `schliff` in
+  the web apps, `.env*.local` gitignored, and `main` branch protection (required CI checks). (#59)
 
 ## [8.1.0] - 2026-06-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.1.0"
+version = "8.2.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.1.0"
+__version__ = "8.2.0"


### PR DESCRIPTION
Cuts **v8.2.0** — releases everything merged to main since 8.1.0 (#50–#59), headlined by the **ReDoS / remote CPU-DoS fix** in the scoring engine (the published 8.1.0 is vulnerable; the public playground runs it).

- Version bumped in lockstep (`pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`) — `test_version_consistency` green.
- Comprehensive CHANGELOG `[8.2.0]`.
- **Minor (not patch):** main carries a BREAKING change (Python 3.9 drop, #55), so this cannot be an 8.1.x patch.

After merge: draft + publish GitHub release `v8.2.0` → OIDC test-gated `publish.yml` → PyPI. Then bump `playground/requirements.txt` → `schliff==8.2.0` + redeploy so the playground runs the ReDoS-fixed engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)