### PR TITLE
chore(playground): pin engine to schliff==8.2.0 (ReDoS root fix live)

### DIFF
--- a/playground/public/index.html
+++ b/playground/public/index.html
@@ -704,7 +704,7 @@ Instructions go here..." spellcheck="false"></textarea>
 
   <!-- Footer -->
   <footer>
-    Powered by Schliff v8.1.0 &middot;
+    Powered by Schliff v8.2.0 &middot;
     <a href="https://github.com/Zandereins/schliff" target="_blank" rel="noopener">GitHub</a> &middot;
     <a href="https://schliff-leaderboard.vercel.app" target="_blank" rel="noopener">Leaderboard</a> &middot;
     <code>pip install schliff</code>

--- a/playground/requirements.txt
+++ b/playground/requirements.txt
@@ -1,1 +1,1 @@
-schliff==8.1.0
+schliff==8.2.0


### PR DESCRIPTION
Bumps the playground's pinned engine to the just-published `schliff==8.2.0` so the deployed scorer runs the bounded ReDoS-fixed regex (not only the 32KB input cap). Corrects the hardcoded footer version; CSP sha256 pin unchanged (footer is outside the script block). After merge: redeploy playground + verify a malicious payload is linear on the 8.2.0 engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)