### PR TITLE
docs: bump version references to 8.2.0 (release hygiene)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A deterministic quality scorer for AI instruction files.** Same input, same score — every time, on every machine. Think the [Ruff](https://github.com/astral-sh/ruff) for `SKILL.md`, `CLAUDE.md`, and `AGENTS.md`. It measures the things linters miss, the same way every time, so degradation shows up as a number that drops instead of a bug you chase.
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.1.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.2.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
@@ -17,7 +17,7 @@ schliff score path/to/SKILL.md
 ```
 
 ```text
-schliff v8.1.0
+schliff v8.2.0
 
   structure      ████████░░   78/100  good
   triggers       ███████░░░   72/100  good
@@ -151,7 +151,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.1.0
+    rev: v8.2.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Schliff Architecture
 
-System design, file tree, data flow, and implementation details for Schliff v8.1.0 —
+System design, file tree, data flow, and implementation details for Schliff v8.2.0 —
 a deterministic, stdlib-only linter and scoring engine for Claude Code skills and other
 LLM instruction files.
 
@@ -375,7 +375,7 @@ weight calibration before the next run.
 
 The version is **single-sourced**: `_resolve_version()` reads it dynamically via
 `importlib.metadata.version("schliff")`, falling back to `dev` from a source checkout. From
-the installed package it resolves to **8.1.0**. There is no hardcoded version string in the
+the installed package it resolves to **8.2.0**. There is no hardcoded version string in the
 CLI.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.1.0.**
+**Current version: 8.2.0.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -288,4 +288,4 @@ under the top-level `security` field), never folded into the skill.md-family hea
 
 Version is single-sourced: the CLI reads it via
 `importlib.metadata.version("schliff")` (`_resolve_version` in `cli.py`), falling back
-to `dev` in a source checkout. Current release: **8.1.0**.
+to `dev` in a source checkout. Current release: **8.2.0**.


### PR DESCRIPTION
Public-facing docs still showed 8.1.0 after the 8.2.0 ship: README PyPI badge `&v=` (camo cache-bust), `schliff v8.1.0` header, pre-commit `rev: v8.1.0` pin, and `docs/{README,ARCHITECTURE,SCORING}.md` version lines. Bumped all to 8.2.0. Historical specs, test fixtures, and the leaderboard seed entry keep 8.1.0 on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)