### PR TITLE
AGENTS.md scoring profile: spec + adversarial review + implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ build/
 
 # Local uv dev lockfile — schliff ships as a library via pyproject (no dep pinning)
 uv.lock
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/docs/specs/agents-md-scoring-profile.md
+++ b/docs/specs/agents-md-scoring-profile.md
@@ -1,0 +1,135 @@
+# Spec: AGENTS.md scoring profile
+
+Status: DRAFT (dogfood-verified, awaiting build greenlight)
+Date: 2026-06-25
+Owner: Franz
+Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md")
+
+## Goal
+
+Make schliff produce **defensible, AGENTS.md-appropriate scores** so the engine and the
+GitHub Action become a credible quality gate for the cross-tool **AGENTS.md** standard
+(Cursor / Codex / Copilot / Claude Code / Devin). Today schliff applied to AGENTS.md is an
+*anti-billboard*: it tells well-formed files they are failing for SKILL-only reasons. This
+profile is the contained engine change that turns the largest-TAM format from a liability
+into the product's wedge.
+
+Non-goal: changing how `SKILL.md`, `CLAUDE.md`, `.cursorrules`, or `system_prompt` are
+scored. Those must stay byte-identical (golden-score gate).
+
+## Context — the verified problem
+
+AGENTS.md is **project context for coding agents** (setup, build/test commands, code style,
+PR/commit rules, gotchas). It is *always-on* context, not a *reusable skill with triggers
+and an eval suite*. But it is currently scored through the shared SKILL scorer registry.
+
+Dogfood evidence — the real engine (v8.2.0) over the 30 real public AGENTS.md files in
+`docs/launch/corpus/agents/`:
+
+```
+N=30   composite: mean 28.3, median 29.2, range 18.9–33.7
+grade=None:            30/30   (every file)
+>=1 null dimension:    30/30   (triggers, quality, edges — all null)
+"add an eval suite" warning: 30/30
+ceiling: 42% for all (full-denominator cap on the 3 eval-gated dims)
+```
+
+Per-dimension distribution across the same 30 files:
+
+| Dimension | n | mean | median | min | max | verdict for AGENTS.md |
+|---|---|---|---|---|---|---|
+| `structure` | 30 | 83.2 | 85.0 | 50 | 95 | **discriminates well — keep** |
+| `efficiency` | 30 | 64.6 | 65.5 | 25 | 95 | **discriminates well — keep** |
+| `clarity` | 30 | 98.9 | 100 | 92 | 100 | saturated (no discrimination) — keep, low weight |
+| `composability` | 30 | 29.7 | 30.0 | 20 | 50 | **mis-fit** — measures SKILL scope/handoffs; punishes all AGENTS.md |
+| `triggers` | 0 | — | — | — | — | **inapplicable** — "when to invoke a skill"; AGENTS.md is always-on |
+| `quality` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
+| `edges` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
+
+Root cause: (1) `triggers`/`quality`/`edges` require an eval suite (a SKILL concept) and the
+full-denominator composite keeps them in the denominator → permanent 42% cap; (2) the
+`composability` scorer encodes SKILL semantics (scope boundaries, I/O contract, handoffs)
+that do not map to a project-context file; (3) the warning text hard-codes
+`/schliff:init` + "add an eval suite", which is incoherent advice for an AGENTS.md author.
+
+## Requirements
+
+- **R1 — defensible spread.** A well-formed AGENTS.md (setup + build/test + code-style + PR
+  rules + gotchas) must land in a defensible band (B/A); a sloppy one in C/D. No more "every
+  file is ~28/None".
+- **R2 — no SKILL-only output.** The AGENTS.md result must not surface `triggers`/`quality`/
+  `edges`, the eval-suite warning, or `/schliff:init` guidance. Warnings/suggestions must be
+  AGENTS.md-relevant.
+- **R3 — determinism preserved.** No LLM in the scoring path; reproducible, same score on any
+  machine (the core selling point).
+- **R4 — no regression elsewhere.** `SKILL.md` / `CLAUDE.md` / `.cursorrules` / `system_prompt`
+  scores unchanged (golden-score byte-identity over the existing corpus).
+- **R5 — locked.** A golden-score regression test pins the new AGENTS.md scores over the
+  30-file corpus so the profile cannot silently rot.
+
+## Technical decisions
+
+### Dimension set for `fmt == agents.md`
+
+Drop the inapplicable eval-gated dims from the **denominator** (not just report them null):
+`triggers`, `quality`, `edges`.
+
+Keep and re-weight the dims that discriminate: `structure`, `efficiency`, `clarity`
+(low weight — saturated). `security` / `runtime` remain side signals as today.
+
+`composability`: **re-purpose or drop** (open question Q1). As-is it is a low-discrimination
+penalty (20–50) that measures SKILL handoff semantics. Either drop it for AGENTS.md or
+redefine it as "does the file reference/links other docs and stay modular".
+
+### MVP vs. differentiated profile
+
+- **MVP (Option A — re-weight, ship fast):** for `fmt == agents.md`, composite =
+  renormalized over `{structure, efficiency, clarity}` (+ re-purposed/omitted composability),
+  eval-gated dims removed from the denominator, eval-suite warning suppressed. This alone
+  lifts the 30-file corpus off the 42% cap and produces an honest spread driven by the two
+  signals that already work (structure, efficiency). Smallest, lowest-risk change — the
+  "contained build" the tournament required.
+- **Fast-follow (Option B — one AGENTS.md-native dimension):** add an **operational-coverage**
+  scorer that rewards what actually makes an AGENTS.md useful to an agent: presence of
+  runnable **setup**, **build**, and **test** commands; **code-style/conventions**; **PR/commit
+  rules**; **gotchas/constraints**. This is the discriminating dimension AND it powers the
+  PR-comment fix-path ("add a Build & Test section: +N") that converts an impression into an
+  adopter. Deterministic (section/keyword/code-fence detection), no eval suite.
+
+Recommendation: ship **Option A** to make scores defensible immediately, then add the single
+**operational-coverage** dimension from Option B as the differentiator before the Action
+rebrand. Do **not** build a wide new scorer set — that re-enters the over-build trap.
+
+### Implementation surface (to confirm during build)
+
+- `skills/schliff/scripts/scoring/formats.py` already defines `FORMAT_AGENTS_MD` and a
+  3000-token budget — the format hook exists.
+- The composite/denominator logic and the eval-gated-dim warning live in the scoring
+  composite layer (`scripts/scoring/`); the change is a per-format branch, not engine surgery.
+- Golden-score fixtures: the 30 files in `docs/launch/corpus/agents/`.
+
+## Open questions
+
+- **Q1 — composability:** drop for AGENTS.md, or redefine to a meaningful project-context
+  signal (cross-file references / modularity)? Current behavior unfairly compresses all files
+  to 20–50.
+- **Q2 — token budget:** is 3000 right for real AGENTS.md? (Check the corpus length
+  distribution; some real files are much longer/shorter.)
+- **Q3 — grade bands:** reuse the global S/A/B/C/D/E/F bands, or AGENTS.md-specific bands? A
+  re-weighted MVP may still cluster — verify the spread before deciding.
+- **Q4 — composite weights for Option A:** exact weights for `{structure, efficiency,
+  clarity, (composability?)}` — set to maximize discrimination on the corpus without rewarding
+  padding (the anti-gaming guards must still apply).
+
+## Acceptance test
+
+The same 30 corpus files re-scored under the profile must show: (1) no `grade=None`, no null
+eval dims, no eval-suite warning; (2) a real spread (good files B/A, sloppy ones C/D — not all
+within one band); (3) `SKILL.md`/`CLAUDE.md`/`.cursorrules`/`system_prompt` golden scores
+unchanged; (4) a golden-score regression test committed for the AGENTS.md corpus.
+
+## Dual-use of the dogfood batch
+
+The 30-file scoring run is also the seed for a one-shot **"State of AGENTS.md 2026"** launch
+data point (a single post/data hook — explicitly NOT a perpetual crawler/index, which the
+tournament refused as a second full-time job).

--- a/docs/specs/agents-md-scoring-profile.md
+++ b/docs/specs/agents-md-scoring-profile.md
@@ -1,178 +1,206 @@
 # Spec: AGENTS.md scoring profile
 
-Status: RESOLVED — build-ready (awaiting build greenlight)
+Status: RESOLVED + REVIEW-CORRECTED — build-ready (awaiting build greenlight)
 Date: 2026-06-25
 Owner: Franz
-Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md"). The 4 open questions were resolved by an engine-backed subagent panel (Q1/Q2 empirical, Q4 weights, Q3 bands) with adversarial verification over the 30-file corpus.
+Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md"). The 4 open questions were resolved by an engine-backed subagent panel, then this spec was put through a double-sided adversarial review (5 specialists, every finding verified refute-by-default). The review caught a **critical inert-recipe bug** in the first draft (the frozenset-only edit shipped score 26.4 — worse than baseline); the implementation recipe below is the independently re-reproduced fix.
 
 ## Goal
 
 Make schliff produce **defensible, AGENTS.md-appropriate scores** so the engine and the
 GitHub Action become a credible quality gate for the cross-tool **AGENTS.md** standard
 (Cursor / Codex / Copilot / Claude Code / Devin). Today schliff applied to AGENTS.md is an
-*anti-billboard*: it tells well-formed files they are failing for SKILL-only reasons. This
-profile is the contained engine change that turns the largest-TAM format from a liability
-into the product's wedge.
+*anti-billboard*: it tells well-formed files they are failing for SKILL-only reasons.
 
-Non-goal: changing how `SKILL.md`, `CLAUDE.md`, `.cursorrules`, or `system_prompt` are
-scored. Those must stay byte-identical (golden-score gate).
+### Scope and NON-GOALS (review-hardened)
+
+- **Non-goal — other formats:** do not change `SKILL.md` / `CLAUDE.md` / `.cursorrules` /
+  `system_prompt` scoring. Byte-identical (golden gate).
+- **Non-goal — correctness/safety (v1):** the v1 headline scores **form/structure + information
+  density only**. It does **not** assess whether the documented commands are correct or safe.
+  Verified: a deliberately dangerous but well-structured AGENTS.md (`curl … | sudo bash`,
+  `git push --force origin main`, commit `.env`, `--no-verify`, self-merge) scores **90.0 / A**
+  under this profile (security signal is `None` — `security.py` excludes code-block commands).
+  Therefore README/Action copy MUST NOT imply a safety stamp. Real safety detection is
+  Fast-follow scorer work.
+- **Non-goal — content coverage (v1):** the headline does not verify that required operational
+  sections (setup/build/test) are present. That is the Fast-follow operational-coverage dim.
 
 ## Context — the verified problem
 
 AGENTS.md is **project context for coding agents** (setup, build/test commands, code style,
-PR/commit rules, gotchas). It is *always-on* context, not a *reusable skill with triggers
-and an eval suite*. But it is currently scored through the shared SKILL scorer registry.
+PR/commit rules, gotchas). It is *always-on* context, not a *reusable skill with triggers and
+an eval suite*. But it is currently scored through the shared SKILL scorer registry.
 
 Dogfood evidence — the real engine (v8.2.0) over the 30 real public AGENTS.md files in
-`docs/launch/corpus/agents/`:
+`docs/launch/corpus/agents/` (all numbers reproduced in review):
 
 ```text
-N=30   composite: mean 28.3, median 29.2, range 18.9–33.7
+N=30   composite: mean 28.26, median 29.25, range 18.9–33.7
 grade=None:            30/30   (every file)
 >=1 null dimension:    30/30   (triggers, quality, edges — all null)
 "add an eval suite" warning: 30/30
-ceiling: 42% for all (full-denominator cap on the 3 eval-gated dims)
+ceiling: 42% (full-denominator cap on the eval-gated dims)
 ```
 
-Per-dimension distribution across the same 30 files:
+Per-dimension distribution across the same 30 files (stdev = population, ddof=0):
 
-| Dimension | n | mean | median | min | max | verdict for AGENTS.md |
+| Dimension | n | mean | stdev | min | max | verdict for AGENTS.md |
 |---|---|---|---|---|---|---|
-| `structure` | 30 | 83.2 | 85.0 | 50 | 95 | **discriminates well — keep** |
-| `efficiency` | 30 | 64.6 | 65.5 | 25 | 95 | **discriminates well — keep** |
-| `clarity` | 30 | 98.9 | 100 | 92 | 100 | **saturated (stdev 2.60, corr -0.11) — drop from headline** |
-| `composability` | 30 | 29.7 | 30.0 | 20 | 50 | **mis-fit (corr ~0) — drop from headline** |
-| `triggers` | 0 | — | — | — | — | **inapplicable** — "when to invoke a skill"; AGENTS.md is always-on |
-| `quality` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
-| `edges` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
+| `structure` | 30 | 83.2 | 10.46 | 50 | 95 | **discriminates — keep** |
+| `efficiency` | 30 | 64.6 | 17.07 | 25 | 95 | **discriminates — keep** (signal/noise ratio: rewards actionable lines, examples, bash command fences — not raw char/4) |
+| `clarity` | 30 | 98.9 | 2.60 | 92 | 100 | saturated, corr -0.11 → **drop from headline** |
+| `composability` | 30 | 29.7 | — | 20 | 50 | mis-fit SKILL semantics, corr ~0 → **drop from headline** |
+| `triggers`/`quality`/`edges` | 0 | — | — | — | — | **inapplicable** (eval-suite-gated) → **drop from denominator** |
 
-Root cause: (1) `triggers`/`quality`/`edges` require an eval suite (a SKILL concept) and the
-full-denominator composite keeps them in the denominator → permanent 42% cap; (2) the
-`composability` scorer encodes SKILL semantics (scope boundaries, I/O contract, handoffs,
-namespace, version-compat, idempotency) that a project-context file legitimately lacks; (3)
-the warning text hard-codes `/schliff:init` + "add an eval suite", incoherent for an
-AGENTS.md author.
+Root cause: `triggers`/`quality`/`edges` require an eval suite (a SKILL concept) and the
+full-denominator composite keeps them in the denominator → permanent cap; `composability`
+encodes SKILL invocable-unit semantics a project doc lacks; the warning hard-codes
+`/schliff:init` + "add an eval suite", incoherent for an AGENTS.md author.
 
 ## Requirements
 
-- **R1 — defensible spread.** A well-formed AGENTS.md (setup + build/test + code-style + PR
-  rules + gotchas) must land in a defensible band (B/A); a sloppy one in C/D.
-- **R2 — no SKILL-only output.** The AGENTS.md result must not surface `triggers`/`quality`/
-  `edges`, the eval-suite warning, or `/schliff:init` guidance. **Prerequisite:** the file must
-  be detected as `fmt == agents.md` (see Implementation surface — today mangled fixture names
-  detect as `unknown`).
+- **R1 — defensible spread.** A well-formed AGENTS.md lands in a defensible band (B/A); a sloppy
+  one in C/D.
+- **R2 — no SKILL-only output (headline AND fix-path).**
+  - The headline composite must fold in **no eval-gated dim** and must emit **no eval-suite
+    warning**. (The JSON `dimensions` / `dimension_status` side-signal block legitimately may
+    still *report* triggers/quality/edges/composability/clarity — they are scored, just not in
+    the headline. This is consistent with keeping the scorers running for `guards.py`.)
+  - `suggest` / `evolve` must **not** emit SKILL-only fixes for `fmt == agents.md`. Verified
+    today they do: `suggest` on a real AGENTS.md returns "Add YAML frontmatter (name/description)",
+    "Create eval-suite.json with trigger test cases", "Add handoff points", "Add 'Use this skill
+    when…'". These are the exact anti-billboard advice R2 forbids.
 - **R3 — determinism preserved.** No LLM in the scoring path; reproducible.
-- **R4 — no regression elsewhere.** `SKILL.md` / `CLAUDE.md` / `.cursorrules` / `system_prompt`
-  scores unchanged (golden-score byte-identity).
-- **R5 — locked.** A golden-score regression test pins the new AGENTS.md scores over the
-  30-file corpus, including the lower-bound-inclusive band-boundary files.
+- **R4 — no regression elsewhere.** The other four formats stay byte-identical.
+- **R5 — locked.** A golden-score regression test pins the AGENTS.md corpus scores (including
+  band boundaries) AND asserts no SKILL-only `suggest` output for agents.md.
 
-## Technical decisions (RESOLVED)
+## Technical decisions (RESOLVED + corrected)
 
-### Dimension set for `fmt == agents.md`
+### Dimension set & weights for `fmt == agents.md`
 
-Headline composite is computed over **`{structure, efficiency}` only**. Removed from the
-**denominator** (still scored and reported as side signals, just not folded into the headline
-number):
+Headline composite = **`0.5 * structure + 0.5 * efficiency`**, renormalized over those two dims
+only. Everything else is removed from the **denominator**: eval-gated `triggers`/`quality`/
+`edges` (inapplicable), `clarity` (saturated, mean 98.87 / stdev 2.60 / corr -0.11), and
+`composability` (mis-fit, corr ~0). `security`/`runtime` remain side signals. The per-dim
+scorers for the dropped dims **still run** (guards + side-signal report intact); they leave the
+headline denominator only.
 
-- eval-gated `triggers`, `quality`, `edges` — inapplicable (no eval suite for a project doc);
-- `clarity` (Q4) — saturated on the corpus (mean 98.87, stdev 2.60, corr -0.11 with
-  composite); any weight injects a near-constant ~99 offset that compresses spread without
-  separating good from sloppy docs;
-- `composability` (Q1) — measures SKILL invocable-unit semantics a project-onboarding doc
-  legitimately lacks (mean 29.67, range 20-50, 10/30 floor at exactly 20 passing zero positive
-  checks, `no_version_compat` fails 30/30, corr ~0 with structure/efficiency). Redefining it
-  (cross-file refs / modularity) is the over-build trap and is explicitly **not** done.
-- `security` / `runtime` remain opt-in side signals as today.
+50/50 over the two discriminating, distinct (inter-corr 0.718) axes; rejected the
+efficiency-heavy 0.4/0.6 (marginally higher raw spread but hostage to the noisier efficiency
+dim, stdev 17.07) and any clarity-weighted vector (saturation collapses files into one band).
 
-The per-dimension scorers for the dropped dims **still run** (so `guards.py` and the
-side-signal report stay intact); they are excluded from the headline denominator only.
-
-### Composite weights (Q4)
-
-`fmt == agents.md` composite = **`0.5 * structure + 0.5 * efficiency`**, renormalized over
-those two dims only. Both discriminate (structure 50-95, efficiency 25-95), are distinct
-(inter-corr 0.718), and 50/50 avoids over-weighting the noisier efficiency dim (stdev 17.07,
-hostage to the char/4 density proxy). Result over the 30-file corpus: **mean 73.90, median
-77.25, min 37.5, max 95.0, stdev 12.74, range 57.5**. Rejected: `clarity`-inclusive equal-3
-(collapses 20/30 into the A band), and 0.4/0.6 efficiency-heavy (marginally higher raw spread
-but hostage to the density proxy — rejected at the tie per the edge-case-correct rule).
+Result over the 30-file corpus (population stdev): **mean 73.90, median 77.25, min 37.5,
+max 95.0, stdev 12.74**.
 
 ### Token budget (Q2)
 
-Keep `FORMAT_TOKEN_BUDGETS['agents.md'] = 3000`. It is **advisory-only**: it feeds the
-separate `token_budget` JSON block in `cli.py`, **not** the efficiency dimension (density-only)
-and **not** the composite — changing it moves both by 0. 3000 lands in the empty gap between
-the 25-file dense cluster (≤2079 tokens) and the 5-file long tail (≥3219), flagging exactly
-the 5 genuinely-long files (25 ok / 0 warning / 5 over). Do **not** lower below 2079 (would
-warn on normal-length real files) or raise above 3219 (would stop flagging the long tail). The
-budget/efficiency-low-tail co-variation is coincidental — do not market it as a density proxy.
+Keep `FORMAT_TOKEN_BUDGETS['agents.md'] = 3000`. It is **advisory-only**: it feeds the separate
+`token_budget` JSON block in `cli.py`, NOT the efficiency dimension and NOT the composite —
+changing it moves both by 0. 3000 lands in the empty gap between the 25-file cluster
+(≤2079 tokens) and the 5-file tail (≥3219). Do not lower below 2079 / raise above 3219. The
+budget/efficiency co-variation is coincidental — do not market it as a density proxy.
 
-### Grade bands (Q3)
+### Grade bands (Q3) — claim corrected
 
 Reuse the **global** bands unchanged: S≥95, A≥85, B≥75, C≥65, D≥50, E≥35, F<35 (lower-bound
-inclusive). `score_to_grade` is format-agnostic; reuse preserves cross-format comparability (a
-'B' means the same across all formats) — the cross-tool guarantee the AGENTS.md wedge sells.
-The 50/50 composite spans 6 of 7 bands (**S=2, A=2, B=12, C=7, D=6, E=1, F=0**) with a
-monotone, face-valid ordering (meltano/underway S@95.0; kudu B@84.5; gordonwatts stub D@52.5;
-VCnoC bloat E@37.5), so the spec's condition for agents-specific bands is not met.
+inclusive). `score_to_grade` is format-agnostic. The 50/50 composite spans 6 of 7 bands
+(**S=2, A=2, B=12, C=7, D=6, E=1, F=0**) with monotone, face-valid ordering — no pathological
+clustering, so agents-specific bands are not warranted.
 
-### Implementation surface
+**Corrected (review P3):** do NOT claim "a B means the same across all formats." It does not — a
+SKILL.md `B` is gated on behavioral dims (triggers/quality/edges + composability/clarity); an
+AGENTS.md `B` is gated on structure+efficiency only (10/12 corpus B-files have composability
+≤31, i.e. content largely unmeasured). AGENTS.md grades are **form/structure-oriented**; band
+equivalence must not be marketed until the operational-coverage dim lands.
 
-- **BLOCKING PREREQUISITE (R2), verified:** the engine classifies the corpus fixtures
-  (basenames `*__AGENTS.md.md`) as `format='unknown'` (budget 1500). Confirmed: the same
-  content named `AGENTS.md` detects as `agents.md`; `--format agents` also works; the composite
-  is identical (29.6) across all three because the budget is inert (Q2) — so the per-dim stats
-  above are valid regardless, BUT the profile (composability/clarity exclusion + weights, gated
-  on `fmt==agents.md`) is a **no-op on the fixtures until they route to `agents.md`**. Fix
-  first: copy the 30 fixtures to canonical `AGENTS.md` basenames in per-repo subdirs (or harden
-  `detect_format`). The golden test must be written against `agents.md`-detected scores, never
-  the `unknown` ones.
-- `skills/schliff/scripts/scoring/registry.py:74-79` — give `agents.md` its **own**
-  `HEADLINE_EXCLUDED` frozenset = `_HEADLINE_EXCLUDED_INSTRUCTION | {"composability", "clarity"}`.
-  Do **not** mutate the shared `_HEADLINE_EXCLUDED_INSTRUCTION` (line 74) — that would leak into
-  skill.md/claude.md/cursorrules and break their byte-identity. Excluding from the denominator
-  (not weight=0) is required so the composite renormalizes over `{structure, efficiency}`;
-  weight=0 would leave the dim in the denominator and re-introduce a cap.
-- The agents.md profile weights (`structure` 0.5, `efficiency` 0.5) live in the per-format
-  weight table in `registry.py` / `scripts/scoring/`.
-- `scripts/scoring/formats.py` — `FORMAT_AGENTS_MD` and the 3000 budget already exist; no change.
-- Golden-score fixtures: the 30 files in `docs/launch/corpus/agents/` (routed to `agents.md`).
+### Calibration honesty (review M3)
 
-## Risks
+The weights/drops were chosen by **spread maximization on N=30 with no ground-truth labels**
+(no rubric/label file exists under `docs/launch/corpus/`). Ship the profile labeled
+**provisional / uncalibrated**; the R5 golden test is a *reproducibility lock*, not a calibrated
+cross-tool standard. Optional hardening: hand-label ~30 files on a 3-class rubric and report
+per-class rank separation before any "standard" claim.
 
-- **Byte-identity trap:** editing the shared `_HEADLINE_EXCLUDED_INSTRUCTION` instead of giving
-  `agents.md` its own frozenset would silently drop composability/clarity from
-  skill.md/claude.md/cursorrules too. The `agents.md` entry must get its OWN frozenset.
-- **Format-routing no-op:** if the build skips the format-detection prerequisite, every change
-  is inert and the golden test pins the wrong (unknown-format) numbers.
-- **Advisory-budget surprise:** a reviewer expecting the 3000 budget to lift the efficiency low
-  tail will be wrong — it gates nothing. State advisory-only explicitly in the PR.
-- **Denominator now only structure+efficiency:** if a future larger/differently-sampled corpus
-  shows the efficiency char/4 density proxy misranking a dense-but-unstructured doc above a
-  well-organized one, revisit by adding the Option-B operational-coverage dimension — **not** by
-  repartitioning the bands (breaks cross-format comparability).
-- **Boundary semantics:** two files sit exactly at 95.0 (S) and several near 85.0; the R5 golden
-  test must pin these so a future off-by-one in the `score >= threshold` comparator is caught.
+### Implementation surface — VERIFIED two-edit recipe
+
+> **Both edits are required.** Either alone fails. Independently reproduced on `kudu` (structure
+> 85, efficiency 84): frozenset-only (excl composability+clarity, default weights) → **26.4,
+> capped 31%, warning present** (worse than baseline); + exclude eval-gated but default weights →
+> 84.6 (the unintended **0.6/0.4** split, see below); + exclude eval-gated AND explicit 0.5/0.5 →
+> **84.5, no warning** ✓.
+
+1. **Weight table (PRIMARY).** `registry.py` `WEIGHT_PROFILES['agents.md']` = a **fresh literal**
+   `{"structure": 0.5, "efficiency": 0.5}` — do **not** reuse `dict(_INSTRUCTION_FILE_WEIGHTS)`
+   (the default 0.15/0.10 renormalizes to **0.6/0.4**, not the Q4-mandated 0.5/0.5). The entry is
+   already an independent dict copy (registry.py:49), so this is a correctness change, not a
+   byte-identity one.
+2. **Headline exclusion.** `registry.py` `HEADLINE_EXCLUDED['agents.md']` = its **own** frozenset
+   `_HEADLINE_EXCLUDED_INSTRUCTION | {"triggers", "quality", "edges", "composability", "clarity"}`.
+   The eval-gated null dims MUST also leave the denominator or the cap + eval-suite warning
+   survive. Do **not** mutate the shared `_HEADLINE_EXCLUDED_INSTRUCTION` (registry.py:74) — that
+   would leak into the other formats and break their byte-identity.
+   - Mechanism note: exclusion removes the dim from the renormalized basis (canonical set in
+     `compute_composite`). A weight of 0 would NOT cap the score (the dim contributes 0 to a
+     basis it is still in) but WOULD keep it "unmeasured" and **re-trigger the eval-suite
+     warning** — so exclusion, not weight-0, is required to satisfy R2.
+3. **Fix-path (R2).** Gate the SKILL-specific gradient computers in `text_gradient.py` on
+   `detected_fmt`; pass `fmt` into `compute_gradients` so frontmatter / eval-suite / trigger /
+   handoff / composability / quality / edges fixes are suppressed for agents.md (suppress, not
+   replace — cheap, deterministic, no over-build). AGENTS.md v1 then has a score with few
+   suggestions; the rich fix-path is Fast-follow.
+4. **Format-routing prerequisite (BLOCKING, verified).** The corpus fixtures (`*__AGENTS.md.md`)
+   detect as `format='unknown'` (budget 1500); identical content named `AGENTS.md` detects as
+   `agents.md`; composite is identical (budget inert) so the per-dim stats are valid, BUT the
+   profile (gated on `fmt==agents.md`) is a **no-op** on the fixtures until they route to
+   `agents.md`. Fix first: copy fixtures to canonical `AGENTS.md` basenames in per-repo subdirs
+   (or harden `detect_format`). Write the golden test against `agents.md`-detected scores.
+5. `scripts/scoring/formats.py` — `FORMAT_AGENTS_MD` + 3000 budget already exist; no change.
+
+## Risks (review-augmented)
+
+- **Inert-recipe trap (caught):** the frozenset edit alone is worse than baseline. Both edits +
+  the explicit 0.5/0.5 dict are mandatory.
+- **Byte-identity trap:** editing the shared `_HEADLINE_EXCLUDED_INSTRUCTION` (not the agents.md
+  entry) would silently change the other formats. Use an own frozenset.
+- **Fix-path leak (R2):** if only the headline is changed, `suggest`/`evolve` still emit SKILL
+  advice — the anti-billboard returns through the side door.
+- **Safety mis-read:** a form-only headline grade-A's dangerous content (verified 90/A). Copy
+  must not imply a safety/correctness stamp (see NON-GOALS).
+- **State-of-AGENTS-2026 self-own:** a per-repo ranking on a form/density metric invites the
+  rebuttal that thorough, content-rich docs rank lower for length (verified: FilOzone/synapse-sdk
+  C@69.5 below underway S@95). Publish aggregate/anonymized only, or gate per-repo ranking on the
+  operational-coverage Fast-follow.
+- **Uncalibrated weights:** N=30, no ground truth; single files set the S/E boundaries. Label
+  provisional.
 
 ## Acceptance test
 
 The 30 corpus files, **routed to `agents.md`**, re-scored under the profile must show: (1) no
-`grade=None`, no null eval dims, no eval-suite warning; (2) the resolved distribution (mean
-73.90, median 77.25, stdev 12.74; bands S=2, A=2, B=12, C=7, D=6, E=1, F=0); (3)
-`SKILL.md`/`CLAUDE.md`/`.cursorrules`/`system_prompt` golden scores unchanged; (4) a
-golden-score regression test committed for the AGENTS.md corpus including the band-boundary
-files.
+eval dim folded into the headline, no eval-suite warning; (2) the resolved distribution
+(mean 73.90, median 77.25; bands S=2, A=2, B=12, C=7, D=6, E=1, F=0); (3) the other four formats'
+golden scores unchanged; (4) `suggest` on an agents.md emits **no** SKILL-only fix (no
+frontmatter/eval-suite/trigger/handoff/"use this skill when"); (5) a golden-score regression test
+committed, pinning convention-free quantities (mean 73.90, median 77.25, band counts, and the
+named anchors) plus the two exact-95.0 boundary files **meltano** and **underway** asserting
+`score == 95.0 AND grade == 'S'` (the only off-by-one-sensitive boundary; no corpus file sits at
+exactly 85.0 — the tight cluster is 86.0/A, 84.5/B, 84.0/B). Do not pin a stdev (convention-
+dependent).
 
-## Fast-follow (deliberate later increment, not an open question)
+## Fast-follow (deferred — confirmed by review, do NOT fold into v1)
 
-One AGENTS.md-native **operational-coverage** dimension (presence of runnable setup/build/test
-commands, code-style, PR/commit rules, gotchas) — the differentiated signal that powers the
-PR-comment fix-path ("add a Build & Test section: +N"). Add only if a larger corpus shows the
-2-dim composite misranks; do **not** build a wide new scorer suite (over-build trap).
+One AGENTS.md-native **operational-coverage** dimension (runnable setup/build/test commands,
+code-style, PR/commit rules, gotchas) — the differentiated signal + the rich PR-comment fix-path.
+The review verified the misrank that would justify it **does not reproduce** (a content-free
+platitude caps at efficiency ~77 → B, a band below a genuine ops file at A, because efficiency
+already rewards bash command fences), and a naive 4-item rubric scores the showcase misrank pair
+identically — so building it now is the over-build trap with no validated trigger. The **real**
+trigger to add it: a reproduced empty-doc gaming case (verified: 5 bare headings → 57.5/C) **plus**
+a corpus-validated misrank. When built, key it on **content presence under headings**, not bash/sh
+fences alone (which miss inline-backtick commands and false-negative good non-command docs).
 
 ## Dual-use of the dogfood batch
 
-The 30-file scoring run is also the seed for a one-shot **"State of AGENTS.md 2026"** launch
-data point (a single post/data hook — explicitly NOT a perpetual crawler/index, which the
-tournament refused as a second full-time job).
+The 30-file run also seeds a one-shot **"State of AGENTS.md 2026"** data point — **aggregate /
+anonymized only** for v1 (per the ranking-rebuttal risk above), NOT a perpetual crawler/index.

--- a/docs/specs/agents-md-scoring-profile.md
+++ b/docs/specs/agents-md-scoring-profile.md
@@ -1,6 +1,6 @@
 # Spec: AGENTS.md scoring profile
 
-Status: RESOLVED + REVIEW-CORRECTED — build-ready (awaiting build greenlight)
+Status: IMPLEMENTED — TDD, 1238 tests green, ruff-clean, end-to-end verified (PR #67)
 Date: 2026-06-25
 Owner: Franz
 Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md"). The 4 open questions were resolved by an engine-backed subagent panel, then this spec was put through a double-sided adversarial review (5 specialists, every finding verified refute-by-default). The review caught a **critical inert-recipe bug** in the first draft (the frozenset-only edit shipped score 26.4 — worse than baseline); the implementation recipe below is the independently re-reproduced fix.

--- a/docs/specs/agents-md-scoring-profile.md
+++ b/docs/specs/agents-md-scoring-profile.md
@@ -1,9 +1,9 @@
 # Spec: AGENTS.md scoring profile
 
-Status: DRAFT (dogfood-verified, awaiting build greenlight)
+Status: RESOLVED — build-ready (awaiting build greenlight)
 Date: 2026-06-25
 Owner: Franz
-Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md")
+Origin: moonshot strategy tournament — wave-rider bet ("agentsmd-lint: the deterministic CI quality gate for AGENTS.md"). The 4 open questions were resolved by an engine-backed subagent panel (Q1/Q2 empirical, Q4 weights, Q3 bands) with adversarial verification over the 30-file corpus.
 
 ## Goal
 
@@ -26,7 +26,7 @@ and an eval suite*. But it is currently scored through the shared SKILL scorer r
 Dogfood evidence — the real engine (v8.2.0) over the 30 real public AGENTS.md files in
 `docs/launch/corpus/agents/`:
 
-```
+```text
 N=30   composite: mean 28.3, median 29.2, range 18.9–33.7
 grade=None:            30/30   (every file)
 >=1 null dimension:    30/30   (triggers, quality, edges — all null)
@@ -40,93 +40,136 @@ Per-dimension distribution across the same 30 files:
 |---|---|---|---|---|---|---|
 | `structure` | 30 | 83.2 | 85.0 | 50 | 95 | **discriminates well — keep** |
 | `efficiency` | 30 | 64.6 | 65.5 | 25 | 95 | **discriminates well — keep** |
-| `clarity` | 30 | 98.9 | 100 | 92 | 100 | saturated (no discrimination) — keep, low weight |
-| `composability` | 30 | 29.7 | 30.0 | 20 | 50 | **mis-fit** — measures SKILL scope/handoffs; punishes all AGENTS.md |
+| `clarity` | 30 | 98.9 | 100 | 92 | 100 | **saturated (stdev 2.60, corr -0.11) — drop from headline** |
+| `composability` | 30 | 29.7 | 30.0 | 20 | 50 | **mis-fit (corr ~0) — drop from headline** |
 | `triggers` | 0 | — | — | — | — | **inapplicable** — "when to invoke a skill"; AGENTS.md is always-on |
 | `quality` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
 | `edges` | 0 | — | — | — | — | **inapplicable** — eval-suite-gated |
 
 Root cause: (1) `triggers`/`quality`/`edges` require an eval suite (a SKILL concept) and the
 full-denominator composite keeps them in the denominator → permanent 42% cap; (2) the
-`composability` scorer encodes SKILL semantics (scope boundaries, I/O contract, handoffs)
-that do not map to a project-context file; (3) the warning text hard-codes
-`/schliff:init` + "add an eval suite", which is incoherent advice for an AGENTS.md author.
+`composability` scorer encodes SKILL semantics (scope boundaries, I/O contract, handoffs,
+namespace, version-compat, idempotency) that a project-context file legitimately lacks; (3)
+the warning text hard-codes `/schliff:init` + "add an eval suite", incoherent for an
+AGENTS.md author.
 
 ## Requirements
 
 - **R1 — defensible spread.** A well-formed AGENTS.md (setup + build/test + code-style + PR
-  rules + gotchas) must land in a defensible band (B/A); a sloppy one in C/D. No more "every
-  file is ~28/None".
+  rules + gotchas) must land in a defensible band (B/A); a sloppy one in C/D.
 - **R2 — no SKILL-only output.** The AGENTS.md result must not surface `triggers`/`quality`/
-  `edges`, the eval-suite warning, or `/schliff:init` guidance. Warnings/suggestions must be
-  AGENTS.md-relevant.
-- **R3 — determinism preserved.** No LLM in the scoring path; reproducible, same score on any
-  machine (the core selling point).
+  `edges`, the eval-suite warning, or `/schliff:init` guidance. **Prerequisite:** the file must
+  be detected as `fmt == agents.md` (see Implementation surface — today mangled fixture names
+  detect as `unknown`).
+- **R3 — determinism preserved.** No LLM in the scoring path; reproducible.
 - **R4 — no regression elsewhere.** `SKILL.md` / `CLAUDE.md` / `.cursorrules` / `system_prompt`
-  scores unchanged (golden-score byte-identity over the existing corpus).
+  scores unchanged (golden-score byte-identity).
 - **R5 — locked.** A golden-score regression test pins the new AGENTS.md scores over the
-  30-file corpus so the profile cannot silently rot.
+  30-file corpus, including the lower-bound-inclusive band-boundary files.
 
-## Technical decisions
+## Technical decisions (RESOLVED)
 
 ### Dimension set for `fmt == agents.md`
 
-Drop the inapplicable eval-gated dims from the **denominator** (not just report them null):
-`triggers`, `quality`, `edges`.
+Headline composite is computed over **`{structure, efficiency}` only**. Removed from the
+**denominator** (still scored and reported as side signals, just not folded into the headline
+number):
 
-Keep and re-weight the dims that discriminate: `structure`, `efficiency`, `clarity`
-(low weight — saturated). `security` / `runtime` remain side signals as today.
+- eval-gated `triggers`, `quality`, `edges` — inapplicable (no eval suite for a project doc);
+- `clarity` (Q4) — saturated on the corpus (mean 98.87, stdev 2.60, corr -0.11 with
+  composite); any weight injects a near-constant ~99 offset that compresses spread without
+  separating good from sloppy docs;
+- `composability` (Q1) — measures SKILL invocable-unit semantics a project-onboarding doc
+  legitimately lacks (mean 29.67, range 20-50, 10/30 floor at exactly 20 passing zero positive
+  checks, `no_version_compat` fails 30/30, corr ~0 with structure/efficiency). Redefining it
+  (cross-file refs / modularity) is the over-build trap and is explicitly **not** done.
+- `security` / `runtime` remain opt-in side signals as today.
 
-`composability`: **re-purpose or drop** (open question Q1). As-is it is a low-discrimination
-penalty (20–50) that measures SKILL handoff semantics. Either drop it for AGENTS.md or
-redefine it as "does the file reference/links other docs and stay modular".
+The per-dimension scorers for the dropped dims **still run** (so `guards.py` and the
+side-signal report stay intact); they are excluded from the headline denominator only.
 
-### MVP vs. differentiated profile
+### Composite weights (Q4)
 
-- **MVP (Option A — re-weight, ship fast):** for `fmt == agents.md`, composite =
-  renormalized over `{structure, efficiency, clarity}` (+ re-purposed/omitted composability),
-  eval-gated dims removed from the denominator, eval-suite warning suppressed. This alone
-  lifts the 30-file corpus off the 42% cap and produces an honest spread driven by the two
-  signals that already work (structure, efficiency). Smallest, lowest-risk change — the
-  "contained build" the tournament required.
-- **Fast-follow (Option B — one AGENTS.md-native dimension):** add an **operational-coverage**
-  scorer that rewards what actually makes an AGENTS.md useful to an agent: presence of
-  runnable **setup**, **build**, and **test** commands; **code-style/conventions**; **PR/commit
-  rules**; **gotchas/constraints**. This is the discriminating dimension AND it powers the
-  PR-comment fix-path ("add a Build & Test section: +N") that converts an impression into an
-  adopter. Deterministic (section/keyword/code-fence detection), no eval suite.
+`fmt == agents.md` composite = **`0.5 * structure + 0.5 * efficiency`**, renormalized over
+those two dims only. Both discriminate (structure 50-95, efficiency 25-95), are distinct
+(inter-corr 0.718), and 50/50 avoids over-weighting the noisier efficiency dim (stdev 17.07,
+hostage to the char/4 density proxy). Result over the 30-file corpus: **mean 73.90, median
+77.25, min 37.5, max 95.0, stdev 12.74, range 57.5**. Rejected: `clarity`-inclusive equal-3
+(collapses 20/30 into the A band), and 0.4/0.6 efficiency-heavy (marginally higher raw spread
+but hostage to the density proxy — rejected at the tie per the edge-case-correct rule).
 
-Recommendation: ship **Option A** to make scores defensible immediately, then add the single
-**operational-coverage** dimension from Option B as the differentiator before the Action
-rebrand. Do **not** build a wide new scorer set — that re-enters the over-build trap.
+### Token budget (Q2)
 
-### Implementation surface (to confirm during build)
+Keep `FORMAT_TOKEN_BUDGETS['agents.md'] = 3000`. It is **advisory-only**: it feeds the
+separate `token_budget` JSON block in `cli.py`, **not** the efficiency dimension (density-only)
+and **not** the composite — changing it moves both by 0. 3000 lands in the empty gap between
+the 25-file dense cluster (≤2079 tokens) and the 5-file long tail (≥3219), flagging exactly
+the 5 genuinely-long files (25 ok / 0 warning / 5 over). Do **not** lower below 2079 (would
+warn on normal-length real files) or raise above 3219 (would stop flagging the long tail). The
+budget/efficiency-low-tail co-variation is coincidental — do not market it as a density proxy.
 
-- `skills/schliff/scripts/scoring/formats.py` already defines `FORMAT_AGENTS_MD` and a
-  3000-token budget — the format hook exists.
-- The composite/denominator logic and the eval-gated-dim warning live in the scoring
-  composite layer (`scripts/scoring/`); the change is a per-format branch, not engine surgery.
-- Golden-score fixtures: the 30 files in `docs/launch/corpus/agents/`.
+### Grade bands (Q3)
 
-## Open questions
+Reuse the **global** bands unchanged: S≥95, A≥85, B≥75, C≥65, D≥50, E≥35, F<35 (lower-bound
+inclusive). `score_to_grade` is format-agnostic; reuse preserves cross-format comparability (a
+'B' means the same across all formats) — the cross-tool guarantee the AGENTS.md wedge sells.
+The 50/50 composite spans 6 of 7 bands (**S=2, A=2, B=12, C=7, D=6, E=1, F=0**) with a
+monotone, face-valid ordering (meltano/underway S@95.0; kudu B@84.5; gordonwatts stub D@52.5;
+VCnoC bloat E@37.5), so the spec's condition for agents-specific bands is not met.
 
-- **Q1 — composability:** drop for AGENTS.md, or redefine to a meaningful project-context
-  signal (cross-file references / modularity)? Current behavior unfairly compresses all files
-  to 20–50.
-- **Q2 — token budget:** is 3000 right for real AGENTS.md? (Check the corpus length
-  distribution; some real files are much longer/shorter.)
-- **Q3 — grade bands:** reuse the global S/A/B/C/D/E/F bands, or AGENTS.md-specific bands? A
-  re-weighted MVP may still cluster — verify the spread before deciding.
-- **Q4 — composite weights for Option A:** exact weights for `{structure, efficiency,
-  clarity, (composability?)}` — set to maximize discrimination on the corpus without rewarding
-  padding (the anti-gaming guards must still apply).
+### Implementation surface
+
+- **BLOCKING PREREQUISITE (R2), verified:** the engine classifies the corpus fixtures
+  (basenames `*__AGENTS.md.md`) as `format='unknown'` (budget 1500). Confirmed: the same
+  content named `AGENTS.md` detects as `agents.md`; `--format agents` also works; the composite
+  is identical (29.6) across all three because the budget is inert (Q2) — so the per-dim stats
+  above are valid regardless, BUT the profile (composability/clarity exclusion + weights, gated
+  on `fmt==agents.md`) is a **no-op on the fixtures until they route to `agents.md`**. Fix
+  first: copy the 30 fixtures to canonical `AGENTS.md` basenames in per-repo subdirs (or harden
+  `detect_format`). The golden test must be written against `agents.md`-detected scores, never
+  the `unknown` ones.
+- `skills/schliff/scripts/scoring/registry.py:74-79` — give `agents.md` its **own**
+  `HEADLINE_EXCLUDED` frozenset = `_HEADLINE_EXCLUDED_INSTRUCTION | {"composability", "clarity"}`.
+  Do **not** mutate the shared `_HEADLINE_EXCLUDED_INSTRUCTION` (line 74) — that would leak into
+  skill.md/claude.md/cursorrules and break their byte-identity. Excluding from the denominator
+  (not weight=0) is required so the composite renormalizes over `{structure, efficiency}`;
+  weight=0 would leave the dim in the denominator and re-introduce a cap.
+- The agents.md profile weights (`structure` 0.5, `efficiency` 0.5) live in the per-format
+  weight table in `registry.py` / `scripts/scoring/`.
+- `scripts/scoring/formats.py` — `FORMAT_AGENTS_MD` and the 3000 budget already exist; no change.
+- Golden-score fixtures: the 30 files in `docs/launch/corpus/agents/` (routed to `agents.md`).
+
+## Risks
+
+- **Byte-identity trap:** editing the shared `_HEADLINE_EXCLUDED_INSTRUCTION` instead of giving
+  `agents.md` its own frozenset would silently drop composability/clarity from
+  skill.md/claude.md/cursorrules too. The `agents.md` entry must get its OWN frozenset.
+- **Format-routing no-op:** if the build skips the format-detection prerequisite, every change
+  is inert and the golden test pins the wrong (unknown-format) numbers.
+- **Advisory-budget surprise:** a reviewer expecting the 3000 budget to lift the efficiency low
+  tail will be wrong — it gates nothing. State advisory-only explicitly in the PR.
+- **Denominator now only structure+efficiency:** if a future larger/differently-sampled corpus
+  shows the efficiency char/4 density proxy misranking a dense-but-unstructured doc above a
+  well-organized one, revisit by adding the Option-B operational-coverage dimension — **not** by
+  repartitioning the bands (breaks cross-format comparability).
+- **Boundary semantics:** two files sit exactly at 95.0 (S) and several near 85.0; the R5 golden
+  test must pin these so a future off-by-one in the `score >= threshold` comparator is caught.
 
 ## Acceptance test
 
-The same 30 corpus files re-scored under the profile must show: (1) no `grade=None`, no null
-eval dims, no eval-suite warning; (2) a real spread (good files B/A, sloppy ones C/D — not all
-within one band); (3) `SKILL.md`/`CLAUDE.md`/`.cursorrules`/`system_prompt` golden scores
-unchanged; (4) a golden-score regression test committed for the AGENTS.md corpus.
+The 30 corpus files, **routed to `agents.md`**, re-scored under the profile must show: (1) no
+`grade=None`, no null eval dims, no eval-suite warning; (2) the resolved distribution (mean
+73.90, median 77.25, stdev 12.74; bands S=2, A=2, B=12, C=7, D=6, E=1, F=0); (3)
+`SKILL.md`/`CLAUDE.md`/`.cursorrules`/`system_prompt` golden scores unchanged; (4) a
+golden-score regression test committed for the AGENTS.md corpus including the band-boundary
+files.
+
+## Fast-follow (deliberate later increment, not an open question)
+
+One AGENTS.md-native **operational-coverage** dimension (presence of runnable setup/build/test
+commands, code-style, PR/commit rules, gotchas) — the differentiated signal that powers the
+PR-comment fix-path ("add a Build & Test section: +N"). Add only if a larger corpus shows the
+2-dim composite misranks; do **not** build a wide new scorer suite (over-build trap).
 
 ## Dual-use of the dogfood batch
 

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -224,7 +224,7 @@ def cmd_score(args: argparse.Namespace) -> None:
             # Count available deterministic fixes
             try:
                 gradients = text_gradient.compute_gradients(
-                    skill_path, eval_suite, include_clarity=True,
+                    skill_path, eval_suite, include_clarity=True, fmt=detected_fmt,
                 )
                 # Honest count: only patches /schliff:auto can actually apply,
                 # not every diagnosed gradient (many are manual-only). Mirrors
@@ -743,7 +743,7 @@ def cmd_suggest(args: argparse.Namespace) -> None:
     # Get all ranked gradients (include clarity for full picture)
     try:
         gradients = text_gradient.compute_gradients(
-            args.skill_path, eval_suite, include_clarity=True,
+            args.skill_path, eval_suite, include_clarity=True, fmt=detected_fmt,
         )
     except Exception as exc:
         print(f"Error: failed to compute gradients: {exc}", file=sys.stderr)

--- a/skills/schliff/scripts/evolve/engine.py
+++ b/skills/schliff/scripts/evolve/engine.py
@@ -79,7 +79,7 @@ def _apply_deterministic_patches(skill_path: str, config: EvolutionConfig,
     patch_count = 0
 
     eval_suite = load_eval_suite(skill_path)
-    gradients = text_gradient.compute_gradients(skill_path, eval_suite, include_clarity=True)
+    gradients = text_gradient.compute_gradients(skill_path, eval_suite, include_clarity=True, fmt=config.fmt)
     patches = text_gradient.generate_patches(skill_path, gradients)
 
     if not patches:
@@ -287,7 +287,7 @@ def run_evolution(config: EvolutionConfig,
                         break
 
                 # Build prompt based on strategy
-                gradients = text_gradient.compute_gradients(skill_path, cached_eval_suite, include_clarity=True)
+                gradients = text_gradient.compute_gradients(skill_path, cached_eval_suite, include_clarity=True, fmt=config.fmt)
 
                 if strategy == "dimension" and config.dimension:
                     user_prompt = build_dimension_prompt(

--- a/skills/schliff/scripts/scoring/registry.py
+++ b/skills/schliff/scripts/scoring/registry.py
@@ -46,7 +46,11 @@ WEIGHT_PROFILES: dict[str, dict[str, float]] = {
     "skill.md": dict(_INSTRUCTION_FILE_WEIGHTS),
     "claude.md": dict(_INSTRUCTION_FILE_WEIGHTS),
     "cursorrules": dict(_INSTRUCTION_FILE_WEIGHTS),
-    "agents.md": dict(_INSTRUCTION_FILE_WEIGHTS),
+    # AGENTS.md is project context for coding agents, not a reusable skill: its
+    # headline is structure+efficiency only (0.5/0.5). Must be an explicit literal —
+    # reusing the 0.15/0.10 instruction weights would renormalize to 0.6/0.4, not the
+    # calibrated 0.5/0.5. See docs/specs/agents-md-scoring-profile.md.
+    "agents.md": {"structure": 0.5, "efficiency": 0.5},
     "system_prompt": {
         "structure_prompt": 0.15, "output_contract": 0.15, "efficiency": 0.15,
         "clarity": 0.15, "security": 0.15, "composability": 0.10, "completeness": 0.15,
@@ -76,7 +80,13 @@ HEADLINE_EXCLUDED: dict[str, frozenset] = {
     "skill.md": _HEADLINE_EXCLUDED_INSTRUCTION,
     "claude.md": _HEADLINE_EXCLUDED_INSTRUCTION,
     "cursorrules": _HEADLINE_EXCLUDED_INSTRUCTION,
-    "agents.md": _HEADLINE_EXCLUDED_INSTRUCTION,
+    # AGENTS.md: the eval-gated dims (triggers/quality/edges) are inapplicable to a
+    # project-context file and would otherwise cap the headline + trigger a nonsensical
+    # "add an eval suite" warning; composability is mis-fit SKILL semantics and clarity is
+    # saturated. All five leave the denominator (exclude, not weight-0 — weight-0 keeps the
+    # warning). The scorers still run as side signals. See the spec.
+    "agents.md": _HEADLINE_EXCLUDED_INSTRUCTION
+    | frozenset({"triggers", "quality", "edges", "composability", "clarity"}),
     "system_prompt": frozenset({"runtime"}),  # security is a core system_prompt dimension
 }
 

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -579,19 +579,41 @@ def compute_gradients(
     eval_suite: Optional[dict] = None,
     include_clarity: bool = False,
     top_n: Optional[int] = None,
+    fmt: Optional[str] = None,
 ) -> list[dict]:
-    """Compute all gradients, rank by priority (delta/effort), return top N."""
+    """Compute all gradients, rank by priority (delta/effort), return top N.
+
+    For ``fmt == agents.md`` only the headline dims (structure, efficiency) are
+    inverted into fixes; the SKILL-only computers (triggers/quality/edges/
+    composability/clarity) are suppressed so an AGENTS.md never receives
+    nonsensical advice like "add YAML frontmatter" or "create eval-suite.json".
+    See docs/specs/agents-md-scoring-profile.md (R2 fix-path).
+    """
+    from scoring.registry import FORMAT_ALIASES
+
+    resolved = FORMAT_ALIASES.get(fmt, fmt) if fmt is not None else None
+    agents_only = resolved == "agents.md"
+
     gradients = []
 
-    gradients.extend(_compute_structure_gradients(skill_path))
-    gradients.extend(_compute_trigger_gradients(skill_path, eval_suite))
+    structure_grads = _compute_structure_gradients(skill_path)
+    if agents_only:
+        # AGENTS.md uses no SKILL-style YAML name/description frontmatter; the engine
+        # synthesizes it before scoring (so the score is not penalized), and the fix-path
+        # must not advise adding it. Suppress the frontmatter-family structure issues. (R2)
+        _SKILL_ONLY_STRUCTURE = {"no_frontmatter", "missing_name", "missing_description"}
+        structure_grads = [g for g in structure_grads if g["issue"] not in _SKILL_ONLY_STRUCTURE]
+    gradients.extend(structure_grads)
     gradients.extend(_compute_efficiency_gradients(skill_path))
-    gradients.extend(_compute_composability_gradients(skill_path))
-    gradients.extend(_compute_quality_gradients(skill_path, eval_suite))
-    gradients.extend(_compute_edges_gradients(skill_path, eval_suite))
 
-    if include_clarity:
-        gradients.extend(_compute_clarity_gradients(skill_path))
+    if not agents_only:
+        gradients.extend(_compute_trigger_gradients(skill_path, eval_suite))
+        gradients.extend(_compute_composability_gradients(skill_path))
+        gradients.extend(_compute_quality_gradients(skill_path, eval_suite))
+        gradients.extend(_compute_edges_gradients(skill_path, eval_suite))
+
+        if include_clarity:
+            gradients.extend(_compute_clarity_gradients(skill_path))
 
     # Dimension weights from registry (match composite formula)
     from scoring.registry import get_weights

--- a/skills/schliff/tests/unit/test_agents_md_profile.py
+++ b/skills/schliff/tests/unit/test_agents_md_profile.py
@@ -1,0 +1,190 @@
+"""Golden + regression tests for the AGENTS.md scoring profile.
+
+Spec: docs/specs/agents-md-scoring-profile.md.
+
+AGENTS.md is project context for coding agents, not a reusable skill. Its
+headline composite is therefore computed over {structure, efficiency} only
+(0.5/0.5), with the eval-gated dims (triggers/quality/edges) plus the
+mis-fit composability and the saturated clarity excluded from the headline
+denominator. These tests pin that profile and guard the other four formats
+against regression (byte-identity).
+
+Corpus golden values were established empirically over the 30 real public
+AGENTS.md files in docs/launch/corpus/agents/ and are reproducible because
+the profile is deterministic (no LLM, no calibration).
+"""
+from __future__ import annotations
+
+import statistics
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import text_gradient
+from terminal_art import score_to_grade
+
+from scoring import compute_composite
+from scoring.registry import (
+    _INSTRUCTION_FILE_WEIGHTS,
+    WEIGHT_PROFILES,
+    get_headline_excluded,
+    get_weights,
+)
+from shared import build_scores
+
+_CORPUS = Path(__file__).resolve().parents[4] / "docs" / "launch" / "corpus" / "agents"
+
+_GOOD_AGENTS_MD = """# AGENTS.md
+
+This file gives coding agents the context they need to work in this repository.
+
+## Project overview
+
+`acme-api` is a Python FastAPI service for order management. Source lives in
+`src/acme_api/`, tests in `tests/`.
+
+## Setup
+
+```bash
+uv sync --all-extras
+cp .env.example .env
+```
+
+## Build and test
+
+Always run the full check before proposing a change:
+
+```bash
+uv run ruff check .
+uv run pytest -q
+```
+
+A change is not done until `ruff` and `pytest` both pass.
+
+## Code style
+
+- Python 3.11+, type-hint every public function.
+- Prefer stdlib; justify any new dependency in the PR description.
+
+## Pull requests
+
+- Title format: `feat:`, `fix:`, `chore:` (Conventional Commits).
+- Every PR must update or add tests for the changed behavior.
+
+## Gotchas
+
+- The `orders` table uses soft-deletes — filter `deleted_at IS NULL`.
+- Migrations are applied automatically in CI; never edit a shipped migration.
+"""
+
+
+def _write(tmp_path: Path, content: str, name: str = "AGENTS.md") -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def _score_agents(path: str) -> dict:
+    scores = build_scores(path, None, include_runtime=True, fmt="agents.md")
+    return compute_composite(scores, fmt="agents.md", use_calibrated=False)
+
+
+# --- Profile registry shape -------------------------------------------------
+
+def test_agents_md_weight_profile_is_structure_efficiency_5050():
+    assert WEIGHT_PROFILES["agents.md"] == {"structure": 0.5, "efficiency": 0.5}
+
+
+def test_agents_md_headline_excludes_eval_gated_plus_composability_clarity():
+    assert get_headline_excluded("agents.md") == frozenset(
+        {"security", "runtime", "triggers", "quality", "edges", "composability", "clarity"}
+    )
+
+
+def test_other_formats_unchanged_byte_identity():
+    # The other four formats must keep the shared instruction weights + {security,runtime}.
+    for fmt in ("skill.md", "claude.md", "cursorrules"):
+        assert get_weights(fmt) == _INSTRUCTION_FILE_WEIGHTS
+        assert get_headline_excluded(fmt) == frozenset({"security", "runtime"})
+
+
+# --- Headline behavior ------------------------------------------------------
+
+def test_well_formed_agents_md_no_eval_warning_two_dim(tmp_path):
+    path = _write(tmp_path, _GOOD_AGENTS_MD)
+    scores = build_scores(path, None, include_runtime=True, fmt="agents.md")
+    result = compute_composite(scores, fmt="agents.md", use_calibrated=False)
+
+    # No SKILL-only eval-suite warning, no cap.
+    assert not any("eval suite" in w for w in result["warnings"])
+    # Headline is over exactly the two kept dims.
+    assert result["measured_dimensions"] == 2
+    assert result["total_dimensions"] == 2
+    # Score == 0.5*structure + 0.5*efficiency.
+    expected = 0.5 * scores["structure"]["score"] + 0.5 * scores["efficiency"]["score"]
+    assert result["score"] == pytest.approx(round(expected, 1))
+    assert score_to_grade(result["score"]) in {"S", "A", "B", "C", "D", "E", "F"}
+
+
+# --- Fix-path: suggest/evolve must not emit SKILL-only advice ----------------
+
+def test_compute_gradients_agents_md_emits_no_skill_only_advice(tmp_path):
+    path = _write(tmp_path, _GOOD_AGENTS_MD)
+    gradients = text_gradient.compute_gradients(path, None, include_clarity=True, fmt="agents.md")
+
+    # No gradient from a SKILL-only dimension.
+    skill_only_dims = {"triggers", "quality", "edges", "composability", "clarity"}
+    offending = [g for g in gradients if g["dimension"] in skill_only_dims]
+    assert offending == [], f"AGENTS.md fix-path leaked SKILL-only dimension: {offending}"
+
+    # No SKILL-only structure issues (frontmatter family — AGENTS.md uses none).
+    skill_only_issues = {"no_frontmatter", "missing_name", "missing_description"}
+    leaked = [g for g in gradients if g["issue"] in skill_only_issues]
+    assert leaked == [], f"AGENTS.md fix-path leaked frontmatter advice: {leaked}"
+
+    # And no SKILL-only phrasing anywhere in target or instruction text.
+    for g in gradients:
+        blob = f"{g.get('target', '')} {g.get('instruction', '')}".lower()
+        for forbidden in ("frontmatter", "eval-suite", "eval suite", "this skill", "handoff"):
+            assert forbidden not in blob, f"AGENTS.md fix-path leaked '{forbidden}': {g}"
+
+
+# --- Corpus golden distribution --------------------------------------------
+
+@pytest.mark.skipif(not _CORPUS.is_dir(), reason="corpus fixtures not present")
+def test_agents_md_corpus_golden_distribution():
+    rows = []
+    for f in sorted(_CORPUS.glob("*.md")):
+        result = _score_agents(str(f))
+        rows.append((f.name, result["score"], score_to_grade(result["score"]), result["warnings"]))
+
+    scores = [r[1] for r in rows]
+    bands = Counter(r[2] for r in rows)
+
+    assert len(rows) == 30
+    assert statistics.mean(scores) == pytest.approx(73.90, abs=0.05)
+    assert statistics.median(scores) == pytest.approx(77.25, abs=0.05)
+    assert min(scores) == pytest.approx(37.5, abs=0.05)
+    assert max(scores) == pytest.approx(95.0, abs=0.05)
+
+    # Exact band counts (golden lock). F intentionally 0.
+    assert bands["S"] == 2
+    assert bands["A"] == 2
+    assert bands["B"] == 12
+    assert bands["C"] == 7
+    assert bands["D"] == 6
+    assert bands["E"] == 1
+    assert bands["F"] == 0
+
+    # No file emits the SKILL-only eval-suite warning.
+    assert not any("eval suite" in w for _, _, _, ws in rows for w in ws)
+
+
+@pytest.mark.skipif(not _CORPUS.is_dir(), reason="corpus fixtures not present")
+def test_agents_md_boundary_files_are_exactly_S():
+    # Off-by-one guard on the score >= threshold comparator: only these two
+    # files compute to exactly 95.0 and must grade S.
+    for name in ("meltano__meltano__AGENTS.md.md", "maxcountryman__underway__AGENTS.md.md"):
+        result = _score_agents(str(_CORPUS / name))
+        assert result["score"] == pytest.approx(95.0, abs=0.05)
+        assert score_to_grade(result["score"]) == "S"

--- a/skills/schliff/tests/unit/test_registry.py
+++ b/skills/schliff/tests/unit/test_registry.py
@@ -7,19 +7,35 @@ These tests prove the current divergence between the three sources of truth:
 """
 import pytest
 
-from scoring.registry import get_scorers, get_weights, SCORER_REGISTRY, WEIGHT_PROFILES, OPT_IN_SCORERS
+from scoring.registry import (
+    get_scorers,
+    get_weights,
+    SCORER_REGISTRY,
+    WEIGHT_PROFILES,
+    OPT_IN_SCORERS,
+    get_headline_excluded,
+)
 
 
 class TestRegistryIntegrity:
     """Tests for the registry's own internal consistency."""
 
     def test_registry_weights_cover_all_scorers(self):
-        """Every scorer in SCORER_REGISTRY must have a weight in WEIGHT_PROFILES."""
+        """Every headline scorer in SCORER_REGISTRY must have a weight.
+
+        A scorer may legitimately lack a headline weight if it is opt-in
+        (runtime/security) OR excluded from the format's headline composite
+        (e.g. AGENTS.md still runs triggers/quality/edges/composability/clarity
+        as side signals but they are not folded into the headline number).
+        """
         for fmt, scorers in SCORER_REGISTRY.items():
             weights = WEIGHT_PROFILES.get(fmt, {})
+            excluded = get_headline_excluded(fmt)
             for scorer in scorers:
                 if scorer in OPT_IN_SCORERS and scorer not in weights:
                     continue  # opt-in scorers like runtime may lack weights
+                if scorer in excluded:
+                    continue  # excluded from the headline → needs no headline weight
                 assert scorer in weights, (
                     f"Scorer '{scorer}' has no weight for format '{fmt}'"
                 )


### PR DESCRIPTION
Decision artifact from the moonshot strategy tournament. **No engine code yet** — this is the spec-first step before any scoring change.

## The bet (tournament verdict)
Pivot schliff from the Claude-only SKILL.md niche onto the **AGENTS.md wave** — the cross-tool agent-instruction standard (Cursor/Codex/Copilot/Claude Code/Devin), far bigger TAM, no incumbent linter. The GitHub Action's PR comment becomes a self-advertising billboard on other people's repos.

## Why it needs a build first (dogfood, verified with the real engine)
schliff applied to AGENTS.md today is an **anti-billboard**. Over the 30 real public AGENTS.md in `docs/launch/corpus/agents/`:

| metric | value |
|---|---|
| composite | mean **28.3**, median 29.2, range 18.9–33.7 |
| grade=None | **30/30** |
| null eval dims (triggers/quality/edges) | **30/30** |
| "add an eval suite" warning | **30/30** |
| ceiling | 42% (full-denominator cap) |

Per-dim: `structure` (mean 83.2) and `efficiency` (64.6) **discriminate well**; `clarity` is saturated (98.9); `composability` is mis-fit (20–50, measures SKILL handoff semantics); `triggers/quality/edges` are inapplicable (eval-suite-gated SKILL concepts).

## What the spec proposes
- Per-format profile for `fmt==agents.md`: drop the inapplicable eval-gated dims from the **denominator**, suppress the eval-suite warning, re-weight onto the dims that work, re-purpose/drop composability.
- One AGENTS.md-native **operational-coverage** dimension (setup/build/test/code-style/PR/gotchas) → the discriminating signal + the PR-comment fix-path ("add a Build & Test section: +N").
- Hard constraints: determinism preserved, **SKILL/CLAUDE/cursor/system_prompt golden scores byte-identical**, golden-score regression test for the AGENTS.md corpus.

## Honest odds (from the panel)
"#1 / repo of the year" ≈ 2–4% (needs a conjunction no solo dev can force). Realistic ceiling: a quiet, correct niche CI linter, low-tens-to-low-hundreds of stars over 6–12 months *if* 1–2 external repos adopt the Action publicly; ~30–40% it stays at the ~3-star floor. The bet's job is to plant maximum cheap, zero-maintenance billboards so schliff owns the category if the wave breaks.

## Open questions (in spec)
composability re-purpose vs drop · token budget 3000 · grade bands · Option-A weights.

**Next after review:** greenlight → build the profile on a feature branch (Option A MVP + the one native dim), then v1 tag + Marketplace + Action rebrand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)