### PR TITLE
docs(readme): lead GitHub Action with uses: Zandereins/schliff@v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,24 +139,34 @@ pip install "schliff[evolve,judge]"  # optional LLM-judge / evolve extras
 
 ### GitHub Action
 
-Gate pull requests on instruction-file quality:
+Gate pull requests on instruction-file quality. The action defaults to your
+repo-root `AGENTS.md` and posts a scored comment on every PR:
 
 ```yaml
-# .github/workflows/schliff.yml
-name: schliff
+# .github/workflows/agents-lint.yml
+name: AGENTS.md Lint
 on: [pull_request]
 jobs:
   score:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.12" }
-      - run: pip install schliff
-      - run: schliff verify path/to/SKILL.md --min-score 75
+      - uses: Zandereins/schliff@v1
+        with:
+          minimum-score: '75'   # optional: fail the PR below this score
 ```
 
-`schliff verify` exits non-zero below the threshold — a clean CI gate.
+By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
+`SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead.
+
+Prefer not to depend on a third-party action? The dependency-light equivalent:
+
+```yaml
+      - run: pip install schliff
+      - run: schliff verify AGENTS.md --min-score 75
+```
+
+`schliff verify` exits non-zero below the threshold — a clean CI gate either way.
 
 ### pre-commit
 


### PR DESCRIPTION
The float `v1` tag now exists, so `uses: Zandereins/schliff@v1` resolves (no 404). This leads the README GitHub Action section with the AGENTS.md-first Marketplace one-liner (defaults to repo-root `AGENTS.md`, posts a scored PR comment — the self-advertising billboard), keeping `pip install schliff` + `schliff verify` as the dependency-light alternative.

- Hero CI example: `uses: Zandereins/schliff@v1` with optional `minimum-score`.
- Note that `skill-path:` switches to SKILL.md/CLAUDE.md/.cursorrules.
- `verify` example updated SKILL.md → AGENTS.md to match positioning.

Docs-only; no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)