### PR TITLE
ci(publish): skip-existing on PyPI upload (idempotent releases)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,3 +107,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true
+          # Idempotent: a release re-cut from an already-published version (e.g.
+          # publishing the Action to the Marketplace from an existing tag) is a
+          # no-op upload instead of a hard 400 "file already exists" failure.
+          skip-existing: true


### PR DESCRIPTION
Makes the PyPI publish step idempotent so the **GitHub Marketplace publish run stays green**.

## Why
Publishing the Action to the Marketplace requires a *published* GitHub Release, which fires `publish.yml`. Without `skip-existing`, re-cutting a release from an already-published version (e.g. listing the Action from the existing `v1`/`v8.2.0` tag) fails the upload with a `400 File already exists`. With `skip-existing: true` the duplicate upload is a clean no-op → green run, no false-alarm failure email.

Also a general robustness win: any future re-run/re-cut of a release is now idempotent.

## Note on merging
This PR touches `.github/workflows/` — merge it via the **web UI** (the CLI/PAT path is blocked without `workflow` scope, same as the Dependabot PRs).

Workflow-only change; no engine/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)