### PR TITLE
release: v8.3.0 — AGENTS.md scoring profile + AGENTS.md Lint Action

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Deterministic skill linter and scoring engine for Claude Code. 7-dimension scoring, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": "Zandereins",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.3.0] - 2026-06-25
+
+### Added
+- **AGENTS.md scoring profile.** `AGENTS.md` is project context for coding agents,
+  not a reusable skill, so it is now scored on a dedicated headline
+  (`0.5·structure + 0.5·efficiency`) instead of the SKILL.md rubric. The
+  eval-gated dimensions (triggers/quality/edges) plus the mis-fit composability and
+  the saturated clarity are excluded from the headline denominator, and the
+  nonsensical "add an eval suite" warning is suppressed for this format. A
+  well-formed `AGENTS.md` now scores a defensible B/A instead of a capped ~28/None.
+  Other formats (`SKILL.md`/`CLAUDE.md`/`.cursorrules`/`system_prompt`) are
+  byte-identical. Spec: `docs/specs/agents-md-scoring-profile.md`. (#67)
+- `suggest`/`evolve` no longer emit SKILL-only advice (frontmatter, eval-suite,
+  handoffs) for `AGENTS.md`. (#67)
+- **GitHub Action rebranded to "AGENTS.md Lint".** `action.yml` now lives at the
+  repository root (Marketplace-eligible), defaults to scoring a root `AGENTS.md`
+  (`skill-path` is optional), and posts a format-aware scored PR comment. Usable as
+  `uses: Zandereins/schliff@v1`. (#66, #68, #69)
+
+### Fixed
+- The Action's PR comment no longer renders unmeasured (`null`) dimensions as a
+  misleading `0/100`; they are omitted, matching the engine's terminal output. (#68)
+
 ## [8.2.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A deterministic quality scorer for AI instruction files.** Same input, same score — every time, on every machine. Think the [Ruff](https://github.com/astral-sh/ruff) for `SKILL.md`, `CLAUDE.md`, and `AGENTS.md`. It measures the things linters miss, the same way every time, so degradation shows up as a number that drops instead of a bug you chase.
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.2.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.3.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
@@ -17,7 +17,7 @@ schliff score path/to/SKILL.md
 ```
 
 ```text
-schliff v8.2.0
+schliff v8.3.0
 
   structure      ████████░░   78/100  good
   triggers       ███████░░░   72/100  good
@@ -174,7 +174,7 @@ Prefer not to depend on a third-party action? The dependency-light equivalent:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.2.0
+    rev: v8.3.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.2.0"
+version = "8.3.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.2.0"
+__version__ = "8.3.0"


### PR DESCRIPTION
Ships the **AGENTS.md scoring profile** (#67) and the rebranded **"AGENTS.md Lint"** Action (#66/#68/#69) to PyPI.

## Why this release matters
The GitHub Action `pip install schliff` — so until the profile is on **PyPI**, `uses: Zandereins/schliff@v1` scores an `AGENTS.md` at the old, capped **~28/None with an "add an eval suite" warning** (verified). This release is the unlock.

**End-to-end verified** (isolated venvs, Python 3.12 — exactly how the Action installs):

| schliff | AGENTS.md score | warning |
|---|---|---|
| 8.2.0 wheel (current PyPI) | 31.3 | "add an eval suite" ❌ |
| **8.3.0 wheel (this PR, built clean)** | **92.5** | none ✅ |

Built clean in an isolated venv → `schliff-8.3.0` sdist + wheel, METADATA `Version: 8.3.0`.

## Changes
- Bump version in lockstep: `pyproject.toml` + `.claude-plugin/plugin.json` + `skills/schliff/__init__.py` → 8.3.0 (gated by `test_version_consistency`).
- `CHANGELOG.md` [8.3.0] entry (AGENTS.md profile, Action rebrand, PR-comment null-dim fix).
- README: PyPI badge cache-bust `v=8.3.0`, sample-output version, pre-commit `rev: v8.3.0`.
- **1238 tests green.**

## After merge — the release + Marketplace flow (Franz, UI)
1. **Re-point the `v1` float tag** to the 8.3.0 commit so `uses: @v1` tracks latest:
   `git checkout main && git pull && git tag -f v1 <8.3.0-merge-commit> && git push origin v1 --force`
2. **Releases → Draft a new release → tag `v8.3.0`** → paste the CHANGELOG notes →
   tick **"Publish this Action to the GitHub Marketplace"** (accept the one-time Developer Agreement, 2FA) → pick category (Continuous integration) → **Publish release**.
   - Publishing fires `publish.yml` → test-gate → build → **PyPI 8.3.0** (clean, new version) **and** lists the Action on the Marketplace — one action, both done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
