### PR TITLE
security: resolve CodeQL alerts #1-4 (path-injection, clear-text-log, url-substring)

### DIFF
--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -71,13 +71,20 @@ CORS_HEADERS = {
 def _run_scoring(content: str, filename: str) -> dict:
     """Write content to a temp file, run schliff scoring, return result dict."""
     from skills.schliff.scripts.scoring.composite import compute_composite
+    from skills.schliff.scripts.scoring.formats import detect_format
     from skills.schliff.scripts.shared import build_scores
     from skills.schliff.scripts.terminal_art import score_to_grade
 
+    # The untrusted `filename` is used ONLY to pick the scoring format (SKILL.md
+    # vs AGENTS.md vs CLAUDE.md). detect_format reads only the basename via pure
+    # string ops — for the `.md`-only names this endpoint accepts it never touches
+    # the filesystem — so resolving the format up front lets us keep user data
+    # entirely out of any path expression. The file on disk uses a constant,
+    # non-user-derived name, which removes the path-injection sink at the source.
+    fmt = detect_format(filename)
+
     tmp_dir = tempfile.mkdtemp()
-    # Use only the basename to prevent path traversal
-    safe_name = os.path.basename(filename)
-    skill_path = os.path.join(tmp_dir, safe_name)
+    skill_path = os.path.join(tmp_dir, "skill.md")
 
     try:
         with open(skill_path, "w", encoding="utf-8") as f:
@@ -92,7 +99,7 @@ def _run_scoring(content: str, filename: str) -> dict:
         # that ARE measured deterministically, using the engine's own weights
         # (structural_score = composite / weight_coverage). The canonical
         # full-denominator composite is still returned for transparency.
-        scores = build_scores(skill_path, eval_suite=None, include_runtime=False)
+        scores = build_scores(skill_path, eval_suite=None, include_runtime=False, fmt=fmt)
         composite = compute_composite(scores)
 
         coverage = composite.get("weight_coverage", 0) or 0

--- a/skills/schliff/scripts/evolve/lineage.py
+++ b/skills/schliff/scripts/evolve/lineage.py
@@ -97,8 +97,8 @@ class LineageSession:
         if secrets_found:
             import sys
             print(
-                f"Warning: Content contains secret-like patterns ({', '.join(secrets_found)}). "
-                f"Snapshot will be redacted. Use --no-snapshots to skip snapshots entirely.",
+                "Warning: Content contains secret-like patterns. "
+                "Snapshot will be redacted. Use --no-snapshots to skip snapshots entirely.",
                 file=sys.stderr,
             )
             content = redact_secrets(content)

--- a/skills/schliff/tests/unit/test_drift.py
+++ b/skills/schliff/tests/unit/test_drift.py
@@ -75,8 +75,7 @@ class TestExtractReferences:
     def test_ignores_urls(self):
         content = "See https://example.com/path/to/file.html for docs."
         refs = drift_mod.extract_references(content)
-        urls = [r for r in refs if "example.com" in str(r["ref"])]
-        assert len(urls) == 0, "URLs should not be treated as paths"
+        assert refs == [], "URLs should not be extracted as file references"
 
     def test_line_numbers_are_correct(self):
         content = "line one\n`lib/utils.py` is here\nline three\n`src/index.ts` there"


### PR DESCRIPTION
Resolves 4 of the 9 CodeQL alerts with real fixes that remove the tainted value from the sink at the source. The other 5 (shared.py path-injection #5-9) are a true false positive — read_skill_safe is a LOCAL CLI linter's read path (path always from user argv or a program tempfile) — dismissed in the dashboard (a root-confinement barrier would break the 'lint any file you name' core).

| Alert | File | Fix |
|---|---|---|
| #3, #4 (web-facing) | playground/api/score.py | Untrusted HTTP `filename` no longer flows into any path. Used only for format detection (detect_format, pure string op); temp file is a constant `skill.md`; format passed via `build_scores(fmt=...)`. Format detection preserved. |
| #1 | evolve/lineage.py | Drop the secret-category interpolation from the warning (contains_secrets returns redaction LABELS, never values). |
| #2 | tests/unit/test_drift.py | Replace the `'example.com' in str(...)` substring anti-pattern with a stronger `assert refs == []`. |

**Verified:** 1238 tests pass; ruff clean; determinism preserved. After merge + CodeQL re-scan, #5-9 are dismissed (false positive) → dashboard 0 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)