### PR TITLE
security: clear CodeQL alert #10 (detect_format path read)

### DIFF
--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -76,12 +76,11 @@ def _run_scoring(content: str, filename: str) -> dict:
     from skills.schliff.scripts.terminal_art import score_to_grade
 
     # The untrusted `filename` is used ONLY to pick the scoring format (SKILL.md
-    # vs AGENTS.md vs CLAUDE.md). detect_format reads only the basename via pure
-    # string ops — for the `.md`-only names this endpoint accepts it never touches
-    # the filesystem — so resolving the format up front lets us keep user data
-    # entirely out of any path expression. The file on disk uses a constant,
-    # non-user-derived name, which removes the path-injection sink at the source.
-    fmt = detect_format(filename)
+    # vs AGENTS.md vs CLAUDE.md). Pass the in-memory `content` so detect_format
+    # never reaches its `.txt` fallback that would read the path off disk — this
+    # keeps the untrusted filename out of every file-system sink (it stays a pure
+    # basename string op). The file on disk uses a constant, non-user-derived name.
+    fmt = detect_format(filename, content=content)
 
     tmp_dir = tempfile.mkdtemp()
     skill_path = os.path.join(tmp_dir, "skill.md")


### PR DESCRIPTION
Follow-up to #72. The path-injection fix in #72 inadvertently moved the taint sink: `detect_format(filename)` traced the untrusted HTTP `filename` into `formats.py:60`, which `read_text`'s the path in its `.txt` fallback (reachable only when `content is None`). In practice the endpoint's `_SAFE_FILENAME_RE` (.md-only) means a `.md` basename matches before that branch — it never reads — but CodeQL can't see that barrier, so it raised new alert **#10**.

**Fix:** pass the in-memory `content` → `detect_format(filename, content=content)`. The `.txt` read branch is now dead (content is non-None), severing the untrusted-filename → `read_text` data flow. Format detection is unchanged (`.md` names match by basename before the content branch; verified AGENTS.md→agents.md, SKILL.md→skill.md).

**Verified:** 1238 tests pass; ruff clean. After merge + CodeQL re-scan → 0 open alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)