### PR TITLE
security: harden composite Action against CWD module shadowing (audit SC-1, high)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,12 +88,16 @@ runs:
           RESULT=$(schliff score "$SKILL_FULL" --json 2>/tmp/schliff_stderr) || true
         fi
 
-        if [ -z "$RESULT" ] || ! echo "$RESULT" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+        # NOTE: every python3 -c below uses -P (PYTHONSAFEPATH) because this action
+        # runs in the consumer's checked-out workspace (GITHUB_WORKSPACE). Without it,
+        # CWD is on sys.path[0] and an attacker's PR could plant a json.py / shadow the
+        # skills.* package at the repo root to get code execution in the consumer's CI.
+        if [ -z "$RESULT" ] || ! echo "$RESULT" | python3 -P -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
           echo "::error::Schliff scorer produced invalid output. stderr: $(cat /tmp/schliff_stderr 2>/dev/null)"
           exit 1
         fi
 
-        COMPOSITE=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['composite_score'])" 2>/dev/null) || true
+        COMPOSITE=$(echo "$RESULT" | python3 -P -c "import sys,json; print(json.load(sys.stdin)['composite_score'])" 2>/dev/null) || true
         if [ -z "$COMPOSITE" ]; then
           echo "::error::Schliff output is missing composite_score. stderr: $(cat /tmp/schliff_stderr 2>/dev/null)"
           exit 1
@@ -102,7 +106,7 @@ runs:
 
         # Delegate grade mapping to Schliff's terminal_art.score_to_grade so
         # thresholds (incl. the E band 35-49) stay aligned with `schliff verify`.
-        GRADE=$(SCORE_VAL="$COMPOSITE" python3 -c "
+        GRADE=$(SCORE_VAL="$COMPOSITE" python3 -P -c "
         import os
         from skills.schliff.scripts.terminal_art import score_to_grade
         print(score_to_grade(float(os.environ['SCORE_VAL'])))
@@ -123,7 +127,7 @@ runs:
         COMPOSITE: ${{ steps.score.outputs.composite }}
         MINIMUM: ${{ inputs.minimum-score }}
       run: |
-        python3 -c "
+        python3 -P -c "
         import sys, os
         score = float(os.environ['COMPOSITE'])
         minimum = float(os.environ['MINIMUM'])

--- a/skills/schliff/tests/unit/test_action_security.py
+++ b/skills/schliff/tests/unit/test_action_security.py
@@ -1,0 +1,44 @@
+"""Regression guard for the composite GitHub Action's hardening.
+
+The action runs in the consumer's checked-out workspace (GITHUB_WORKSPACE), so
+every `python3 -c` MUST use -P (PYTHONSAFEPATH) — otherwise CWD is on sys.path[0]
+and an attacker's PR could plant a json.py / shadow the skills.* package at the
+repo root to get code execution in the consumer's CI (security audit SC-1).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ACTION_YML = Path(__file__).resolve().parents[4] / "action.yml"
+
+
+def test_action_yml_exists_at_repo_root():
+    # Marketplace eligibility + the path this guard inspects.
+    assert ACTION_YML.is_file(), "action.yml must live at the repo root"
+
+
+def test_every_python3_dash_c_uses_safepath():
+    text = ACTION_YML.read_text(encoding="utf-8")
+    # Find real invocations: `python3` followed (same line) by a `-c`, ignoring
+    # prose comments (lines whose first non-space char is '#').
+    offenders = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        # `python3 ... -c` on this line, but not `python3 -P ... -c`
+        if re.search(r"python3\s+-c\b", line) and not re.search(r"python3\s+-P\b", line):
+            offenders.append((i, line.strip()))
+    assert not offenders, (
+        "Every `python3 -c` in action.yml must use -P (PYTHONSAFEPATH) to avoid "
+        f"CWD module shadowing in consumer CI (SC-1). Offending lines: {offenders}"
+    )
+
+
+def test_action_has_at_least_the_known_python_steps():
+    # Sanity: the guard is actually looking at the scorer action, not an empty file.
+    text = ACTION_YML.read_text(encoding="utf-8")
+    assert text.count("python3 -P -c") >= 4, (
+        "Expected >=4 hardened python3 -P -c invocations; the action may have changed "
+        "shape — re-verify the SC-1 hardening still covers every python invocation."
+    )


### PR DESCRIPTION
**Severity: high — supply-chain RCE in *consumers'* CI.** Found by an adversarial security audit; the only finding crossing a real trust boundary (the web apps held — no XSS/SSRF/ReDoS/KV-injection).

## The vulnerability
The composite action runs every `python3 -c` from `GITHUB_WORKSPACE` (the consumer's checked-out repo). Without `PYTHONSAFEPATH`, CWD is `sys.path[0]`, so an attacker who opens a PR to **any** consumer repo using the documented `on: [pull_request]` + `actions/checkout` config could plant a `json.py` (or shadow the `skills.*` package) at the repo root → **arbitrary code execution in that consumer's CI runner**, with their `GITHUB_TOKEN` + secrets, before the action even posts its comment.

Verified locally: `python3 -c "import json"` from a dir with a hostile `json.py` runs it; `python3 -P -c` imports stdlib instead. **schliff's own infra is unaffected** (no own workflow runs the composite action on untrusted refs; no `pull_request_target`).

## Fix
`-P` on all four `python3 -c` invocations in `action.yml`. `-P` drops CWD from `sys.path` but keeps site-packages, so the legit `from skills.schliff.scripts.terminal_art import score_to_grade` (from the pip-installed schliff) still works — verified `grade(82.0)=B` with `-P`, and a CWD `skills/` shadow is blocked.

Adds `test_action_security.py` (regression guard: every `python3 -c` must carry `-P`).

**After merge:** re-point the `v1` float tag to this commit so all `uses: Zandereins/schliff@v1` consumers get the fix immediately.

1241 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)