### PR TITLE
docs: archive ShieldClaw case study, remove dead repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No model in the loop produced that number. Run it again on another laptop and yo
 
 ## A real catch
 
-A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/), a prompt-injection-defense plugin, scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions.
+A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/) — a real prompt-injection-defense skill, now archived — scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions.
 
 | | Score | Grade | Dimensions measured |
 |---|---|---|---|

--- a/docs/case-studies/shieldclaw/case-study.json
+++ b/docs/case-studies/shieldclaw/case-study.json
@@ -1,7 +1,7 @@
 {
   "title": "ShieldClaw: Security Skill Optimization with Schliff",
   "project": "openclaw-skill-shieldclaw",
-  "repo": "https://github.com/Zandereins/openclaw-skill-shieldclaw",
+  "status": "archived — the ShieldClaw skill is no longer maintained and its repository has been removed; these scoring artifacts are preserved as a real before/after Schliff example",
   "date": "2026-03-26",
   "schliff_version": "6.3.0",
   "skill_type": "OpenClaw prompt injection defense plugin",


### PR DESCRIPTION
ShieldClaw (`openclaw-skill-shieldclaw`) is discontinued and its repository is being deleted. This keeps Schliff's real before/after demonstration intact while removing every signal that ShieldClaw is a live, linkable project.

## Decision: archive in place

The case study is Schliff's strongest "real catch" — a genuine **68.3 [C] → 94.6 [A]** (+26.3) on a real skill, with self-contained artifacts (`SKILL-before/after`, score JSONs, eval suite) that all live inside this repo. The measurement is true regardless of the skill's retirement, so deleting it would throw away the best worked example. Anonymizing it would churn 7+ files and the security test fixture for a cosmetic name-scrub. So: **keep the proof, label it archived, fix the one real breakage.**

## Changes (2 files)

- **`docs/case-studies/shieldclaw/case-study.json`** — removed the now-404 `"repo"` link to `github.com/Zandereins/openclaw-skill-shieldclaw`; added a `"status": "archived …"` field. All scoring data unchanged.
- **`README.md`** — one-line wording change in the "A real catch" section: ShieldClaw is now described as "a real prompt-injection-defense skill, now archived". The internal case-study link is unchanged (it does not 404).

## Deliberately left untouched

- Test fixture `skills/schliff/tests/unit/test_security.py` (functional test data — renaming risks the 1,231-test suite).
- `CHANGELOG.md` and `docs/specs/*` (historical records — not rewritten).
- Playground / leaderboard data (self-contained, internal references — nothing 404s).

No external dead links remain after the `openclaw-skill-shieldclaw` repo is deleted.