### PR TITLE
chore(case-study): mark ShieldClaw as archived, fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No model in the loop produced that number. Run it again on another laptop and yo
 
 ## A real catch
 
-A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/), a prompt-injection-defense plugin, scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions.
+A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/), a prompt-injection-defense plugin, scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions. _(The ShieldClaw skill has since been archived; this result stands as a point-in-time scoring demonstration.)_
 
 | | Score | Grade | Dimensions measured |
 |---|---|---|---|

--- a/docs/case-studies/shieldclaw/case-study.json
+++ b/docs/case-studies/shieldclaw/case-study.json
@@ -1,7 +1,8 @@
 {
   "title": "ShieldClaw: Security Skill Optimization with Schliff",
   "project": "openclaw-skill-shieldclaw",
-  "repo": "https://github.com/Zandereins/openclaw-skill-shieldclaw",
+  "repo": "https://github.com/Zandereins/schliff/tree/main/docs/case-studies/shieldclaw",
+  "source_status": "The ShieldClaw skill was archived and decommissioned on 2026-06-25; its original repository is no longer public. This Schliff scoring demonstration is unaffected — the before/after SKILL.md, score artifacts, and eval suite are preserved in this case study.",
   "date": "2026-03-26",
   "schliff_version": "6.3.0",
   "skill_type": "OpenClaw prompt injection defense plugin",

--- a/docs/specs/plans/v7-week1-multiformat-plan.json
+++ b/docs/specs/plans/v7-week1-multiformat-plan.json
@@ -268,7 +268,7 @@
         {
           "step": 4,
           "action": "Test manually",
-          "run": "schliff score --url https://raw.githubusercontent.com/Zandereins/openclaw-skill-shieldclaw/main/SKILL.md",
+          "run": "schliff score --url https://raw.githubusercontent.com/Zandereins/schliff/main/docs/case-studies/shieldclaw/SKILL-after.md",
           "expected": "ShieldClaw scores ~94.6 [A]"
         },
         {


### PR DESCRIPTION
## Why
The ShieldClaw skill — the source of Schliff's flagship scoring case study — was archived and decommissioned on 2026-06-25, and its public repo (`openclaw-skill-shieldclaw`) no longer exists. The Schliff scoring demonstration stays valuable (Schliff genuinely took that real skill from **68.3 [C] → 94.6 [A]**), but two references now 404 — bad on a freshly-launched marketplace Action.

## Changes
- **`case-study.json`** — `repo` repointed from the deleted `openclaw-skill-shieldclaw` repo to the in-repo case-study folder (which preserves every before/after artifact); added a `source_status` field documenting the archival.
- **`v7-week1-multiformat-plan.json`** — the `schliff score --url …` step fetched the now-gone live `SKILL.md`; repointed to the preserved `SKILL-after.md` (the 94.6 [A] version, matching the expected score) so the example is runnable again.
- **`README.md`** — one-line _"since archived"_ note on the case study so the marketplace listing stays honest.

## Not changed (deliberately)
The case study itself, its before/after artifacts, the test fixtures (`test_security.py`), and the playground demo are kept — the scoring result is a true point-in-time demonstration and remains Schliff's strongest real-world proof. `action.yml` was already clean (no ShieldClaw reference).

## Verification
- Both edited JSON files validated (`json.load`).
- No `openclaw-skill-shieldclaw` **links** remain in the changed files (only the project *name* label, which is correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)