### PR TITLE
security: leaderboard identity hardening + JSON robustness (LB-1/2/3, PG-1) + council fixes

### DIFF
--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -175,7 +175,10 @@ class handler(BaseHTTPRequestHandler):
         try:
             raw_body = self.rfile.read(read_len)
             body = json.loads(raw_body)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+            # RecursionError: deeply-nested JSON exhausts the parser's stack (PG-1).
+            # Narrow tuple-broadening (not a blanket except) so genuinely unexpected
+            # errors still surface as 500.
             self._send_json(400, {"error": "Invalid JSON", "detail": str(exc)})
             return
 

--- a/skills/schliff/tests/unit/test_leaderboard_kv.py
+++ b/skills/schliff/tests/unit/test_leaderboard_kv.py
@@ -269,3 +269,18 @@ def test_is_reserved_identity_matches_canonical_variants():
     assert submit._is_reserved_identity("https://github.com/zandereins/schliff?x=1", "schliff")
     assert not submit._is_reserved_identity("https://github.com/Zandereins/schliff", "other")
     assert not submit._is_reserved_identity("https://gitlab.com/zandereins/schliff", "schliff")
+
+
+def test_dot_git_spelling_is_reserved():
+    # The .git spelling must not slip past the defense-in-depth _kv_upsert guard.
+    assert submit._is_reserved_identity("https://github.com/zandereins/schliff.git", "schliff")
+
+
+def test_real_seed_both_same_repo_rows_survive_union(kv, monkeypatch):
+    # Both shipped seed rows now canonicalize to the same repo (zandereins/schliff)
+    # but have distinct skill_names (schliff, shieldclaw); they must NOT collapse in
+    # the seed-union, or a repo_url-only dedup regression would silently drop one.
+    real_seed = Path(__file__).resolve().parents[4] / "web" / "leaderboard" / "data" / "submissions.json"
+    monkeypatch.setattr(query, "SEED_PATH", str(real_seed))
+    loaded = query._kv_load_all(query._kv_config())  # empty KV -> seed only
+    assert {"schliff", "shieldclaw"} <= {e["skill_name"] for e in loaded}

--- a/skills/schliff/tests/unit/test_leaderboard_kv.py
+++ b/skills/schliff/tests/unit/test_leaderboard_kv.py
@@ -179,7 +179,8 @@ def test_upsert_rejects_new_identity_when_full_but_allows_updates(kv, monkeypatc
 # --- cross-file sync guard -----------------------------------------------------
 
 @pytest.mark.parametrize("fn", ["_kv_config", "_kv_command", "_dedup_field",
-                                "_client_ip", "_kv_rate_limited"])
+                                "_client_ip", "_kv_rate_limited",
+                                "_canonical_repo_url"])
 def test_shared_kv_helpers_byte_identical_across_files(fn):
     """The two serverless files duplicate this block by hand (Vercel can't share a
     module). Guard against drift between the copies."""
@@ -188,3 +189,83 @@ def test_shared_kv_helpers_byte_identical_across_files(fn):
 
 def test_submissions_key_matches_across_files():
     assert submit.SUBMISSIONS_KEY == query.SUBMISSIONS_KEY
+
+
+# --- repo_url canonicalization (LB-1) -----------------------------------------
+def _valid_body(url):
+    return {"skill_name": "x", "repo_url": url, "format": "SKILL.md",
+            "composite": 50, "grade": "B",
+            "dimensions": {k: 50 for k in submit.REQUIRED_DIMENSIONS},
+            "version": "8.1.0"}
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/Owner/Repo",
+    "https://github.com/owner/repo/",
+    "https://github.com/owner/repo/tree/main",
+    "https://github.com/owner/repo?x=1",
+    "https://github.com/owner/repo#frag",
+    "https://github.com/owner/repo.git",
+])
+def test_validate_canonicalizes_repo_url(url):
+    body = _valid_body(url)
+    assert submit._validate(body) is None
+    assert body["repo_url"] == "https://github.com/owner/repo"
+
+
+def test_all_spellings_collapse_to_one_dedup_key():
+    keys = set()
+    for url in ("https://github.com/Owner/Repo", "https://github.com/owner/repo/",
+                "https://github.com/owner/repo/tree/main",
+                "https://github.com/owner/repo?x=1"):
+        body = _valid_body(url)
+        assert submit._validate(body) is None
+        keys.add(submit._dedup_field(body["repo_url"], body["skill_name"]))
+    assert len(keys) == 1
+
+
+@pytest.mark.parametrize("url", [
+    "http://github.com/owner/repo", "https://gitlab.com/o/r",
+    "https://github.com/owner", "https://github.com/", 123,
+])
+def test_validate_rejects_non_canonicalizable_repo_url(url):
+    assert submit._validate(_valid_body(url)) is not None
+
+
+def test_kv_load_dedups_noncanonical_seed_against_canonical_kv(kv, tmp_path, monkeypatch):
+    seed = [_entry(skill="shared", repo="https://github.com/U/Shared/")]
+    seed_file = tmp_path / "seed.json"
+    seed_file.write_text(json.dumps(seed), encoding="utf-8")
+    monkeypatch.setattr(query, "SEED_PATH", str(seed_file))
+    cfg = query._kv_config()
+    submit._kv_upsert(cfg, {**_entry(skill="shared", repo="https://github.com/u/shared"),
+                            "composite": 11.0})
+    loaded = query._kv_load_all(cfg)
+    assert [e["skill_name"] for e in loaded] == ["shared"]
+    assert loaded[0]["composite"] == 11.0
+
+
+# --- reserved-identity / IDOR (LB-3) ------------------------------------------
+def test_upsert_refuses_reserved_identity(kv):
+    cfg = submit._kv_config()
+    with pytest.raises(submit.ReservedIdentityError):
+        submit._kv_upsert(cfg, _entry(skill="schliff", repo="https://github.com/Zandereins/schliff"))
+    assert submit.SUBMISSIONS_KEY not in kv.hashes
+    for url in ("https://github.com/zandereins/schliff/",
+                "https://github.com/Zandereins/schliff/tree/main"):
+        with pytest.raises(submit.ReservedIdentityError):
+            submit._kv_upsert(cfg, _entry(skill="schliff", repo=url))
+
+
+def test_upsert_allows_non_reserved_identity(kv):
+    cfg = submit._kv_config()
+    assert submit._kv_upsert(cfg, _entry(skill="other", repo="https://github.com/Zandereins/schliff")) is False
+    assert submit._kv_upsert(cfg, _entry(skill="schliff", repo="https://github.com/someone/schliff")) is False
+    assert len(kv.hashes[submit.SUBMISSIONS_KEY]) == 2
+
+
+def test_is_reserved_identity_matches_canonical_variants():
+    assert submit._is_reserved_identity("https://github.com/Zandereins/schliff", "schliff")
+    assert submit._is_reserved_identity("https://github.com/zandereins/schliff?x=1", "schliff")
+    assert not submit._is_reserved_identity("https://github.com/Zandereins/schliff", "other")
+    assert not submit._is_reserved_identity("https://gitlab.com/zandereins/schliff", "schliff")

--- a/skills/schliff/tests/unit/test_leaderboard_storage.py
+++ b/skills/schliff/tests/unit/test_leaderboard_storage.py
@@ -75,3 +75,28 @@ def test_concurrent_writes_no_lost_update(submit):
     final = submit._load_submissions()
     names = sorted(e["skill_name"] for e in final)
     assert names == sorted(f"skill-{i}" for i in range(n)), "lost update under concurrency"
+
+
+# --- homograph / invisible-char identity defense (LB-2) -----------------------
+import unicodedata  # noqa: E402
+
+
+@pytest.mark.parametrize("cp", [
+    0xE0001,   # Unicode Tag char (category Cf) — escaped the old enumerated denylist
+    0x115F, 0x1160, 0x3164, 0xFFA0,  # blank-rendering Hangul fillers (category Lo)
+    0x180E,    # Mongolian vowel separator
+    0x200B,    # ZWSP (was in the old list — must still reject)
+    0x202E,    # RLO bidi override
+    0x09, 0x0A, 0x0D,  # TAB/CR/LF — a single-line identity field rejects these now
+])
+def test_has_unsafe_chars_rejects_invisible_and_homograph(submit, cp):
+    s = unicodedata.normalize("NFKC", "ok" + chr(cp) + "name")
+    assert submit._has_unsafe_chars(s) is True
+
+
+@pytest.mark.parametrize("name", [
+    "my-skill", "Code Reviewer", "skill_v2.1", "café-linter",
+    "日本語スキル", "skill 🚀", "a.b-c_d",
+])
+def test_has_unsafe_chars_allows_legit_identity_names(submit, name):
+    assert submit._has_unsafe_chars(unicodedata.normalize("NFKC", name)) is False

--- a/skills/schliff/tests/unit/test_leaderboard_storage.py
+++ b/skills/schliff/tests/unit/test_leaderboard_storage.py
@@ -87,6 +87,8 @@ import unicodedata  # noqa: E402
     0x180E,    # Mongolian vowel separator
     0x200B,    # ZWSP (was in the old list — must still reject)
     0x202E,    # RLO bidi override
+    0x034F,    # combining grapheme joiner (Mn) — invisible, look-identical (council)
+    0x2028, 0x2029,  # LINE / PARAGRAPH separator (Zl/Zp) — newline-class (council)
     0x09, 0x0A, 0x0D,  # TAB/CR/LF — a single-line identity field rejects these now
 ])
 def test_has_unsafe_chars_rejects_invisible_and_homograph(submit, cp):
@@ -100,3 +102,60 @@ def test_has_unsafe_chars_rejects_invisible_and_homograph(submit, cp):
 ])
 def test_has_unsafe_chars_allows_legit_identity_names(submit, name):
     assert submit._has_unsafe_chars(unicodedata.normalize("NFKC", name)) is False
+
+
+# --- reserved-identity gate on the live /tmp (cfg=None) path (LB-3) ------------
+import io  # noqa: E402
+import json as _json  # noqa: E402
+
+
+def _drive_post(submit_mod, body):
+    """Drive the real do_POST handler over the /tmp path (cfg=None, set by the
+    `submit` fixture which leaves KV env unset). Captures the JSON response."""
+    raw = _json.dumps(body).encode("utf-8")
+    captured = {}
+
+    class _H(submit_mod.handler):
+        def __init__(self):  # skip BaseHTTPRequestHandler socket setup
+            self.rfile = io.BytesIO(raw)
+            self.headers = {"Content-Length": str(len(raw))}
+            self.wfile = io.BytesIO()
+
+        def _send_json(self, status, payload):
+            captured["status"] = status
+            captured["payload"] = payload
+
+    _H().do_POST()
+    return captured
+
+
+def _full_body(skill, repo):
+    return {"skill_name": skill, "repo_url": repo, "format": "SKILL.md",
+            "composite": 90, "grade": "A",
+            "dimensions": {k: 90 for k in submit_module_required()},
+            "version": "8.1.0"}
+
+
+def submit_module_required():
+    mod = _load_module("lb_submit_req", "submit.py")
+    return mod.REQUIRED_DIMENSIONS
+
+
+@pytest.mark.parametrize("repo", [
+    "https://github.com/Zandereins/schliff",
+    "https://github.com/zandereins/schliff/",
+    "https://github.com/Zandereins/schliff.git",
+])
+def test_do_post_rejects_reserved_identity_on_tmp_path(submit, repo):
+    res = _drive_post(submit, _full_body("schliff", repo))
+    assert res["status"] == 403
+    # The reserved gate returns before any /tmp write.
+    assert not os.path.exists(submit.DATA_PATH)
+
+
+def test_do_post_allows_non_reserved_on_tmp_path(submit):
+    res = _drive_post(submit, _full_body("schliff", "https://github.com/someone/fork"))
+    assert res["status"] == 200
+    assert res["payload"]["ok"] is True
+    stored = submit._load_submissions()
+    assert [e["skill_name"] for e in stored] == ["schliff"]

--- a/skills/schliff/tests/unit/test_playground_score.py
+++ b/skills/schliff/tests/unit/test_playground_score.py
@@ -1,0 +1,42 @@
+"""Regression guards for the playground/leaderboard JSON parse robustness (PG-1).
+
+Deeply-nested JSON makes json.loads raise RecursionError, which is NOT a subclass
+of ValueError/JSONDecodeError, so it escaped the parse `except` and surfaced as a
+Vercel 500 instead of a clean 400. Both internet-facing parse sites must catch it.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[4]
+_SCORE_PY = _ROOT / "playground" / "api" / "score.py"
+_SUBMIT_PY = _ROOT / "web" / "leaderboard" / "api" / "submit.py"
+
+
+def test_json_loads_deep_nesting_raises_recursionerror_not_valueerror():
+    # Root-cause pin: confirms the broadened except is actually needed.
+    with pytest.raises(RecursionError):
+        json.loads("[" * 50000)
+    # And that it is NOT already caught by the narrow tuple.
+    assert not issubclass(RecursionError, (ValueError, json.JSONDecodeError))
+
+
+def _parse_except_lines(path: Path) -> list[str]:
+    return [
+        ln for ln in path.read_text(encoding="utf-8").splitlines()
+        if re.search(r"except\s*\(.*JSONDecodeError", ln)
+    ]
+
+
+@pytest.mark.parametrize("path", [_SCORE_PY, _SUBMIT_PY], ids=["playground", "leaderboard"])
+def test_json_parse_except_catches_recursionerror(path):
+    lines = _parse_except_lines(path)
+    assert lines, f"no JSONDecodeError parse-except found in {path.name}"
+    for ln in lines:
+        assert "RecursionError" in ln, (
+            f"{path.name} parse except must catch RecursionError (PG-1): {ln.strip()}"
+        )

--- a/web/leaderboard/api/query.py
+++ b/web/leaderboard/api/query.py
@@ -129,6 +129,31 @@ def _kv_command(cfg, *args):
     return payload.get("result") if isinstance(payload, dict) else payload
 
 
+def _canonical_repo_url(repo_url):
+    """Canonicalize a GitHub repo URL to its identity form
+    ``https://github.com/owner/repo`` (owner+repo lowercased), or return None when it
+    is not an https github.com URL with at least an owner and a repo path segment.
+
+    Query string, fragment, and any path beyond owner/repo (a trailing slash,
+    ``/tree/main``, ``.git``, ...) are dropped so every spelling of the same repo
+    maps to one (repo_url, skill_name) dedup key — otherwise one repo could mint
+    unlimited rows. Keep BYTE-IDENTICAL with the copy in query.py."""
+    if not isinstance(repo_url, str):
+        return None
+    parsed = urlparse(repo_url)
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    if len(segments) < 2:
+        return None
+    owner, repo = segments[0].lower(), segments[1].lower()
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    if not owner or not repo:
+        return None
+    return f"https://github.com/{owner}/{repo}"
+
+
 def _dedup_field(repo_url, skill_name):
     """Stable hash of the (repo_url, skill_name) identity — the submissions-hash
     field and the dedup key. Inputs are NFKC-normalized + invalid-char-rejected
@@ -179,6 +204,14 @@ def _kv_load_all(cfg):
     else:
         values = []
 
+    def _key(e):
+        # Canonicalize the repo_url before keying so a legacy non-canonical KV/seed
+        # row still dedups against the canonical form submit.py now stores (LB-1).
+        # Fall back to the raw value if it is not a canonicalizable github URL, so a
+        # malformed row keeps a stable, distinct key instead of collapsing.
+        repo = _canonical_repo_url(e.get("repo_url", "")) or e.get("repo_url", "")
+        return _dedup_field(repo, e.get("skill_name", ""))
+
     entries, seen = [], set()
     for v in values:
         try:
@@ -186,10 +219,10 @@ def _kv_load_all(cfg):
         except (ValueError, TypeError):
             continue
         entries.append(e)
-        seen.add(_dedup_field(e.get("repo_url", ""), e.get("skill_name", "")))
+        seen.add(_key(e))
 
     for e in _load_seed():
-        if _dedup_field(e.get("repo_url", ""), e.get("skill_name", "")) not in seen:
+        if _key(e) not in seen:
             entries.append(e)
     return entries
 

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -54,14 +54,20 @@ LOCK_PATH = os.path.join(DATA_DIR, ".lock")
 # Seed data path (bundled with deployment, read-only)
 SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "submissions.json")
 
-# Control characters that could cause visual spoofing
-_CONTROL_CHARS = set(range(0x00, 0x20)) - {0x0A, 0x0D, 0x09}  # allow \n \r \t
-_BIDI_CHARS = {0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x2066, 0x2067, 0x2068, 0x2069}
-# Zero-width / invisible characters. Visually undetectable, so they let an
-# attacker create homograph entries that pass validation but compare unequal in
-# the (repo_url, skill_name) dedup key — e.g. "my-skill" vs "my​skill" —
-# polluting the leaderboard with duplicate-looking rows. Reject them outright.
-_INVISIBLE_CHARS = {0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF, 0x061C}
+# Homograph / invisible-char defense for the (repo_url, skill_name) identity.
+# Invisible or blank-rendering code points are visually undetectable, so they let
+# an attacker mint entries that look identical but compare unequal in the dedup
+# key. We run AFTER NFKC (see do_POST) and reject by Unicode general category
+# rather than an enumerated list, so the whole class is covered and the rule
+# cannot silently rot:
+#   Cc control, Cf format (bidi overrides + zero-width + Tag chars U+E00xx),
+#   Cs surrogate, Co private-use, Cn unassigned.
+# skill_name is a single-line identity field: TAB/CR/LF (all category Cc) are
+# rejected, which also blocks newline-injection into the "repo_url\nskill_name"
+# dedup string. A few blank-rendering Hangul fillers carry category Lo and so
+# escape the category gate — list them explicitly.
+_DISALLOWED_CATEGORIES = {"Cc", "Cf", "Cs", "Co", "Cn"}
+_BLANK_FILLERS = {0x115F, 0x1160, 0x3164, 0xFFA0, 0x180E}
 
 # --- scoring-model epoch -----------------------------------------------------
 # v8.0 introduced the full-denominator composite (PR #41/#42): a breaking scale
@@ -84,10 +90,39 @@ def _score_model_for(version: str) -> int:
     return 2 if major >= 8 else 1
 
 
+def _canonical_repo_url(repo_url):
+    """Canonicalize a GitHub repo URL to its identity form
+    ``https://github.com/owner/repo`` (owner+repo lowercased), or return None when it
+    is not an https github.com URL with at least an owner and a repo path segment.
+
+    Query string, fragment, and any path beyond owner/repo (a trailing slash,
+    ``/tree/main``, ``.git``, ...) are dropped so every spelling of the same repo
+    maps to one (repo_url, skill_name) dedup key — otherwise one repo could mint
+    unlimited rows. Keep BYTE-IDENTICAL with the copy in query.py."""
+    if not isinstance(repo_url, str):
+        return None
+    parsed = urlparse(repo_url)
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    if len(segments) < 2:
+        return None
+    owner, repo = segments[0].lower(), segments[1].lower()
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    if not owner or not repo:
+        return None
+    return f"https://github.com/{owner}/{repo}"
+
+
 def _has_unsafe_chars(s: str) -> bool:
-    """Reject strings with control, bidi-override, or invisible characters."""
+    """Reject control, format (bidi/zero-width/Tag), surrogate, private-use, and
+    unassigned characters, plus blank-rendering Hangul fillers. Expects an
+    already-NFKC-normalized string so compatibility homographs are collapsed
+    first. Currently applied to skill_name (the identity field); it is equally
+    safe to apply to the already-host-validated repo_url."""
     return any(
-        ord(c) in _CONTROL_CHARS or ord(c) in _BIDI_CHARS or ord(c) in _INVISIBLE_CHARS
+        ord(c) in _BLANK_FILLERS or unicodedata.category(c) in _DISALLOWED_CATEGORIES
         for c in s
     )
 
@@ -105,13 +140,12 @@ def _validate(body):
         return "skill_name contains invalid characters"
 
     repo_url = body["repo_url"]
-    if not isinstance(repo_url, str):
+    canonical = _canonical_repo_url(repo_url)
+    if canonical is None:
         return "repo_url must be a valid GitHub repository URL"
-    parsed_url = urlparse(repo_url)
-    if parsed_url.scheme != "https" or parsed_url.hostname != "github.com":
-        return "repo_url must be a valid GitHub repository URL"
-    if len(parsed_url.path.strip("/").split("/")) < 2:
-        return "repo_url must point to a specific repository"
+    # Store the canonical identity form so every spelling of one repo dedups to a
+    # single (repo_url, skill_name) key (LB-1).
+    body["repo_url"] = canonical
 
     fmt = body["format"]
     if fmt not in VALID_FORMATS:
@@ -222,6 +256,50 @@ class LeaderboardFullError(Exception):
     submission is a brand-new identity. Updates to existing entries still pass."""
 
 
+class ReservedIdentityError(Exception):
+    """The submission targets a RESERVED_IDENTITY row (e.g. the project's own
+    canonical entry). The public, unauthenticated endpoint refuses to overwrite it.
+    This is an authorization refusal (-> 403), not a malformed request."""
+
+
+# --- reserved-identity guard (IDOR / unauthenticated-overwrite, LB-3) -----------
+# The board is unauthenticated and self-reported, so anyone can HSET-overwrite any
+# (repo_url, skill_name) row. Acceptable for community rows (all verified:false) but
+# NOT for identities we treat as canonical: the public endpoint must not let a
+# stranger replace the project's own row. Full proof-of-ownership is out of scope for
+# a demo board; this is a small, proportionate denylist of rows the public POST may
+# not write. The canonical row itself ships in the bundled seed (data/submissions.json)
+# and is unioned in by query.py, so display is guaranteed with zero KV/tmp writes —
+# this guard only PREVENTS overwrite, it does not seed. Keyed on
+# (owner_lower, repo_lower, skill_name) so it matches every canonical URL variant
+# (case, trailing slash, /tree/<ref>, ?query) regardless of LB-1 canonicalization.
+RESERVED_IDENTITY = frozenset({
+    ("zandereins", "schliff", "schliff"),
+})
+
+
+def _reserved_identity_key(repo_url, skill_name):
+    """Normalize (repo_url, skill_name) to the RESERVED_IDENTITY comparison key, or
+    None if not a github.com owner/repo URL. Uses the first two non-empty path
+    segments, lowercased, so it is independent of repo_url canonicalization."""
+    try:
+        parsed = urlparse(repo_url)
+    except (ValueError, AttributeError):
+        return None
+    if parsed.hostname != "github.com":
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    if len(segments) < 2:
+        return None
+    return (segments[0].lower(), segments[1].lower(), skill_name)
+
+
+def _is_reserved_identity(repo_url, skill_name):
+    """True if (repo_url, skill_name) names a RESERVED_IDENTITY row the public,
+    unauthenticated endpoint must not overwrite."""
+    return _reserved_identity_key(repo_url, skill_name) in RESERVED_IDENTITY
+
+
 def _kv_config():
     """(url, token) for the Upstash REST API, or None when not configured."""
     url = os.environ.get("KV_REST_API_URL") or os.environ.get("UPSTASH_REDIS_REST_URL")
@@ -277,7 +355,13 @@ def _kv_rate_limited(cfg, key, limit, window):
 def _kv_upsert(cfg, entry):
     """Atomic insert-or-update of one entry in the submissions hash. Returns True if
     an existing entry was updated, False if newly inserted. One HSET = no
-    read-modify-write race, durable across cold starts (issue #51)."""
+    read-modify-write race, durable across cold starts (issue #51).
+
+    Refuses RESERVED_IDENTITY rows (LB-3): the durable store must never be polluted
+    by an unauthenticated overwrite of a canonical identity, even via a direct call
+    that bypasses the do_POST gate."""
+    if _is_reserved_identity(entry["repo_url"], entry["skill_name"]):
+        raise ReservedIdentityError
     field = _dedup_field(entry["repo_url"], entry["skill_name"])
     # Bound growth: once the store is full, refuse brand-new identities but keep
     # accepting updates to existing rows. (HEXISTS->HLEN->HSET; the tiny TOCTOU
@@ -318,7 +402,8 @@ class handler(BaseHTTPRequestHandler):
             # Never read more than the cap even if Content-Length lies.
             raw = self.rfile.read(min(content_length, MAX_BODY_BYTES))
             body = json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RecursionError):
+            # RecursionError: deeply-nested JSON exhausts the parser's stack (PG-1).
             self._send_json(400, {"error": "invalid JSON body"})
             return
 
@@ -336,6 +421,14 @@ class handler(BaseHTTPRequestHandler):
         error = _validate(body)
         if error:
             self._send_json(400, {"error": error})
+            return
+
+        # LB-3: refuse to let an unauthenticated POST overwrite a reserved identity
+        # (e.g. the project's own canonical row). Compared against the already
+        # NFKC-normalized, validated values; placed before the cfg branch so it
+        # guards BOTH the KV upsert and the /tmp fallback path.
+        if _is_reserved_identity(body["repo_url"], body["skill_name"]):
+            self._send_json(403, {"error": "this entry is reserved and cannot be submitted"})
             return
 
         entry = {
@@ -390,6 +483,9 @@ class handler(BaseHTTPRequestHandler):
                         entries.append(entry)
 
                     _save_submissions(entries)
+        except ReservedIdentityError:
+            self._send_json(403, {"error": "this entry is reserved and cannot be submitted"})
+            return
         except LeaderboardFullError:
             self._send_json(429, {"error": "leaderboard is full"})
             return

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -62,12 +62,15 @@ SEED_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "submissions.j
 # cannot silently rot:
 #   Cc control, Cf format (bidi overrides + zero-width + Tag chars U+E00xx),
 #   Cs surrogate, Co private-use, Cn unassigned.
-# skill_name is a single-line identity field: TAB/CR/LF (all category Cc) are
-# rejected, which also blocks newline-injection into the "repo_url\nskill_name"
-# dedup string. A few blank-rendering Hangul fillers carry category Lo and so
-# escape the category gate — list them explicitly.
-_DISALLOWED_CATEGORIES = {"Cc", "Cf", "Cs", "Co", "Cn"}
-_BLANK_FILLERS = {0x115F, 0x1160, 0x3164, 0xFFA0, 0x180E}
+# skill_name is a single-line identity field: TAB/CR/LF (all category Cc) and the
+# Zl/Zp line/paragraph separators (U+2028/U+2029) are rejected, which also blocks
+# newline-injection into the "repo_url\nskill_name" dedup string. A few
+# blank-rendering or genuinely-invisible code points carry a category that escapes
+# the gate (Hangul fillers Lo, combining grapheme joiner U+034F Mn) — list them
+# explicitly. NOTE: we do NOT reject all of Mn — legitimate scripts use combining
+# marks — only the look-identical CGJ.
+_DISALLOWED_CATEGORIES = {"Cc", "Cf", "Cs", "Co", "Cn", "Zl", "Zp"}
+_BLANK_FILLERS = {0x115F, 0x1160, 0x3164, 0xFFA0, 0x180E, 0x034F}
 
 # --- scoring-model epoch -----------------------------------------------------
 # v8.0 introduced the full-denominator composite (PR #41/#42): a breaking scale
@@ -275,6 +278,7 @@ class ReservedIdentityError(Exception):
 # (case, trailing slash, /tree/<ref>, ?query) regardless of LB-1 canonicalization.
 RESERVED_IDENTITY = frozenset({
     ("zandereins", "schliff", "schliff"),
+    ("zandereins", "schliff", "shieldclaw"),  # the curated 94.6/A showcase seed row
 })
 
 
@@ -291,7 +295,10 @@ def _reserved_identity_key(repo_url, skill_name):
     segments = [s for s in parsed.path.split("/") if s]
     if len(segments) < 2:
         return None
-    return (segments[0].lower(), segments[1].lower(), skill_name)
+    repo = segments[1].lower()
+    if repo.endswith(".git"):  # match _canonical_repo_url so a .git spelling can't slip past
+        repo = repo[:-4]
+    return (segments[0].lower(), repo, skill_name)
 
 
 def _is_reserved_identity(repo_url, skill_name):

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -1,7 +1,7 @@
 [
   {
     "skill_name": "schliff",
-    "repo_url": "https://github.com/Zandereins/schliff",
+    "repo_url": "https://github.com/zandereins/schliff",
     "format": "SKILL.md",
     "composite": 99.0,
     "grade": "S",
@@ -20,7 +20,7 @@
   },
   {
     "skill_name": "shieldclaw",
-    "repo_url": "https://github.com/Zandereins/schliff/tree/main/docs/case-studies/shieldclaw",
+    "repo_url": "https://github.com/zandereins/schliff",
     "format": "SKILL.md",
     "composite": 94.6,
     "grade": "A",


### PR DESCRIPTION
Fixes the 4 low-severity findings from the adversarial security audit, then hardened further by a final adversarial **council review**. Proportionate to the untrusted, no-auth, self-reported (`verified:false`) demo trust model — anti-pollution + identity integrity + parse robustness. No new auth/endpoint/secret/dependency. Designed + verified via ultracode, implemented TDD, council-reviewed.

## Findings fixed
| # | Fix |
|---|-----|
| **LB-1** | `_canonical_repo_url()` (byte-identical in submit.py + query.py, in the byte-identity guard) maps every spelling → `https://github.com/owner/repo` before validation/storage; `query._kv_load_all` canonicalizes at load; 2 seed rows pre-canonicalized. One repo = one dedup key. |
| **LB-2** | `_has_unsafe_chars` now category-rejects (Cc/Cf/Cs/Co/Cn/Zl/Zp after NFKC) + blank Hangul fillers + U+180E + CGJ U+034F. Single-line identity rejects TAB/CR/LF + U+2028/9. Legit names (CJK, accents, emoji) stay allowed. |
| **LB-3** | `RESERVED_IDENTITY` denylist refuses public overwrite (403) of the canonical schliff + shieldclaw seed rows — at the do_POST gate **and** defense-in-depth in `_kv_upsert` (incl. `.git` spelling). |
| **PG-1** | `RecursionError` (deep-JSON) now caught → clean 400 (not Vercel 500) in **both** score.py and submit.py. |

## Council review (final, refute-by-default)
Verdict: **the 4 headline fixes are safe to ship — no reachable bypass, no new exception path** (independently reproduced). Surfaced 5 minor residuals, **all fixed in the 2nd commit**: `.git` defense-in-depth gap, shieldclaw row protection, CGJ/U+2028 invisibles, and the load-bearing **do_POST 403 regression test** on the cfg=None /tmp path (the deployed default — previously zero coverage). 2 findings refuted as false alarms (VS16/Braille = by-design-visible).

## Verification
Full suite **1288 passed**; ruff clean; byte-identity invariant + seed-union preserved; all behavior changes intended (no regression).

**Deploy note:** leaderboard + playground run on Vercel — these go live on the next `vercel deploy --prod` of `web/leaderboard` + `playground` (out-of-band, owner's step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)