### PR TITLE
fix(playground): apply the AGENTS.md profile (pass fmt to compute_composite)

### DIFF
--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -99,7 +99,10 @@ def _run_scoring(content: str, filename: str) -> dict:
         # (structural_score = composite / weight_coverage). The canonical
         # full-denominator composite is still returned for transparency.
         scores = build_scores(skill_path, eval_suite=None, include_runtime=False, fmt=fmt)
-        composite = compute_composite(scores)
+        # Pass fmt so the format's headline profile applies — e.g. AGENTS.md is
+        # scored on structure+efficiency (no eval-gated dims), not the SKILL.md
+        # rubric that would otherwise cap it and emit an "add an eval suite" warning.
+        composite = compute_composite(scores, fmt=fmt)
 
         coverage = composite.get("weight_coverage", 0) or 0
         full_score = composite["score"]
@@ -116,6 +119,7 @@ def _run_scoring(content: str, filename: str) -> dict:
             "measured_dimensions": composite.get("measured_dimensions", 0),
             "total_dimensions": composite.get("total_dimensions", 0),
             "weight_coverage": coverage,
+            "format": fmt,
             "engine_version": _ENGINE_VERSION,
         }
     finally:


### PR DESCRIPTION
Follow-up to the 8.3.0 engine bump. **Live verification caught a wiring bug:** the playground passed `fmt` to `build_scores` but not to `compute_composite` — where the per-format headline profile is applied. So even on engine 8.3.0 an `AGENTS.md` was scored on the SKILL.md rubric (eval-gated dims in the denominator) → capped + an `add an eval suite` warning.

**Verified live (post-8.3.0-deploy):** AGENTS.md returned `74.5 / C` + the warning.
**Fix:** `compute_composite(scores, fmt=fmt)` → the AGENTS.md headline (0.5·structure + 0.5·efficiency, full coverage) applies. Same file now scores `92.5 / A`, no warning (verified locally OLD 74.5/C vs NEW 92.5/A). Also surfaces the detected `format` in the response.

After merge: redeploy the playground → re-verify the live AGENTS.md score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)