### PR TITLE
docs: correct test count to 1,288 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Ruff lints your Python. Biome lints your JS. Schliff lints the instruction files
 > additionally folds in triggers, quality, and edges — which require an eval suite
 > (`schliff init`).
 
-Validated by **1,231 tests** (unit + integration) in `skills/schliff/tests`, with separate self and proof suites via `test-self.sh` and `test-integration.sh`.
+Validated by **1,288 tests** (unit + integration) in `skills/schliff/tests`, with separate self and proof suites via `test-self.sh` and `test-integration.sh`.
 
 ## License
 


### PR DESCRIPTION
The test suite now collects **1,288 tests** (`pytest --collect-only`), but the README still claimed `1,231`. This syncs the verifiable number to the real count.

Surfaced while refreshing the profile README, where the same stale number was carried over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016szw1VWjFASN7NHfJDXFJc