### PR TITLE
chore(release): v8.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Deterministic skill linter and scoring engine for Claude Code. 7-dimension scoring, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": "Zandereins",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.4.0] - 2026-07-03
+
+### Added
+- **`operational_coverage` dimension for AGENTS.md** (PR #83). Measures whether
+  an AGENTS.md actually equips a coding agent to operate the repo: real
+  setup/build/test commands (command-family classification, doc-wide, headings
+  never gate) plus code-style / gotchas / PR directive sections with concrete
+  code tokens. Surfaced in the CLI dimension table, the Action's PR comment,
+  and accepted by the leaderboard submit API.
+
+### Changed
+- **BREAKING (scores): AGENTS.md headline profile is now
+  `structure 0.40 / operational_coverage 0.40 / efficiency 0.20`** (was
+  0.5/0.5). `efficiency` was a validated gameable proxy — a junk-fence-stuffed
+  doc scored 92.5/A while the same real commands inline scored 70.0/C. All
+  AGENTS.md scores re-baseline: 30-file corpus mean 61.06, no file reaches S.
+  SKILL.md / CLAUDE.md / .cursorrules / system-prompt scoring is byte-identical.
+
+### Security
+- Fixed a ReDoS in the operational_coverage heading regex (quadratic on
+  whitespace-only heading lines; playground/Action/leaderboard take untrusted
+  input). Found and fixed pre-release by a 75-agent adversarial review, along
+  with a directive-gate homonym gaming hole, a fence-state desync on
+  info-string openers, and 12 command-recall bugs — see
+  `docs/specs/agents-md-operational-coverage.md` §11.
+
 ## [8.3.0] - 2026-06-25
 
 ### Added
@@ -502,7 +528,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.1.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.4.0...HEAD
+[8.4.0]: https://github.com/Zandereins/schliff/compare/v8.3.0...v8.4.0
+[8.3.0]: https://github.com/Zandereins/schliff/compare/v8.2.0...v8.3.0
+[8.2.0]: https://github.com/Zandereins/schliff/compare/v8.1.0...v8.2.0
 [8.1.0]: https://github.com/Zandereins/schliff/compare/v8.0.0...v8.1.0
 [8.0.0]: https://github.com/Zandereins/schliff/compare/v7.2.0...v8.0.0
 [7.2.0]: https://github.com/Zandereins/schliff/compare/v7.1.1...v7.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A deterministic quality scorer for AI instruction files.** Same input, same score — every time, on every machine. Think the [Ruff](https://github.com/astral-sh/ruff) for `SKILL.md`, `CLAUDE.md`, and `AGENTS.md`. It measures the things linters miss, the same way every time, so degradation shows up as a number that drops instead of a bug you chase.
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.3.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.4.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
@@ -17,7 +17,7 @@ schliff score path/to/SKILL.md
 ```
 
 ```text
-schliff v8.3.0
+schliff v8.4.0
 
   structure      ████████░░   78/100  good
   triggers       ███████░░░   72/100  good
@@ -174,7 +174,7 @@ Prefer not to depend on a third-party action? The dependency-light equivalent:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.3.0
+    rev: v8.4.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.2.0.**
+**Current version: 8.4.0.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.3.0"
+version = "8.4.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.3.0"
+__version__ = "8.4.0"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 95
     },
-    "version": "8.1.0",
+    "version": "8.4.0",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {


### PR DESCRIPTION
Version bump for the 8.4.0 release (operational_coverage dimension, PR #83).

- 3 lockstep version sources (gated by test_version_consistency): pyproject.toml, .claude-plugin/plugin.json, skills/schliff/__init__.py
- Secondary refs: README PyPI badge `&v=8.4.0` (camo cache-bust), README hero example, pre-commit `rev:` example, docs/README.md current version, leaderboard self-entry
- CHANGELOG: 8.4.0 entry (Added/Changed-BREAKING-scores/Security) + footer repair (missing 8.2.0/8.3.0 compare links, stale Unreleased link)

Release flow after merge: draft GitHub Release v8.4.0 → publish → OIDC test-gated publish.yml → PyPI → playground pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)