### PR TITLE
docs(readme): playground + structural-score note cover AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,14 +257,15 @@ Ruff lints your Python. Biome lints your JS. Schliff lints the instruction files
 
 - ⭐ **Star the repo:** [github.com/Zandereins/schliff](https://github.com/Zandereins/schliff)
 - 📖 **Docs:** [`docs/SCORING.md`](docs/SCORING.md)
-- 🧪 **Playground:** [schliff-playground.vercel.app](https://schliff-playground.vercel.app) — paste a SKILL.md, get a live structural score (or `schliff demo` in the CLI)
+- 🧪 **Playground:** [schliff-playground.vercel.app](https://schliff-playground.vercel.app) — paste a SKILL.md or AGENTS.md, get a live score (or `schliff demo` in the CLI)
 - 🏆 **Leaderboard:** [schliff-leaderboard.vercel.app](https://schliff-leaderboard.vercel.app)
 
 > **Structural score** = the composite renormalized over the dimensions Schliff can
 > measure deterministically without an eval suite (structure, efficiency, composability,
-> clarity). It is what the web playground reports. The full 7-dimension composite
-> additionally folds in triggers, quality, and edges — which require an eval suite
-> (`schliff init`).
+> clarity). It is what the web playground reports for SKILL.md. The full 7-dimension
+> composite additionally folds in triggers, quality, and edges — which require an eval
+> suite (`schliff init`). AGENTS.md needs no eval suite: its full 3-dimension headline
+> (structure, operational_coverage, efficiency) is always measurable.
 
 Validated by **1,347 tests** (unit + integration) in `skills/schliff/tests`, with separate self and proof suites via `test-self.sh` and `test-integration.sh`.
 


### PR DESCRIPTION
Post-v8.4.0 currency pass: the playground bullet and the structural-score explainer were still SKILL.md-only. AGENTS.md is scored on its full 3-dimension headline (structure / operational_coverage / efficiency) with no eval suite needed — the note now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)