### PR TITLE
docs: normalize table pipe style to compact (MD060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ No model in the loop produced that number. Run it again on another laptop and yo
 A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/) — a real prompt-injection-defense skill, now archived — scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions.
 
 | | Score | Grade | Dimensions measured |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Before | 68.3 | C | 4/7 (no eval suite) |
 | After | 94.6 | A | 7/7 |
 
@@ -75,7 +75,7 @@ Because the number is stable, it does real work:
 For the `SKILL.md` family, Schliff runs **8 scorers** per file. **7 of them form the headline composite**; `security` and `runtime` are reported as **separate opt-in signals** so a security warning never silently inflates or deflates your quality grade.
 
 | Dimension | Weight | In headline? |
-|---|---|---|
+| --- | --- | --- |
 | `structure` | 0.15 | ✅ |
 | `triggers` | 0.20 | ✅ |
 | `quality` | 0.20 | ✅ |
@@ -113,7 +113,7 @@ This is deliberate. A partial measurement is an honest partial score, never a fl
 One engine, five instruction-file formats — each with its own token budget and scorer set:
 
 | Format | Token budget | Scorers |
-|---|---|---|
+| --- | --- | --- |
 | `SKILL.md` | 1,000 | shared 8-scorer registry |
 | `CLAUDE.md` | 2,000 | shared 8-scorer registry |
 | `.cursorrules` | 500 | shared 8-scorer registry |
@@ -132,7 +132,7 @@ pip install "schliff[evolve,judge]"  # optional LLM-judge / evolve extras
 ```
 
 | Install | Pulls in | When you need it |
-|---|---|---|
+| --- | --- | --- |
 | `schliff` | stdlib only | Scoring, verify, badge, CI — everything that gates a release |
 | `schliff[judge]` | LLM client | Opt-in exploratory LLM-judge smoke-test (never scoring) |
 | `schliff[evolve]` | LLM client | Opt-in autonomous-improvement extras |
@@ -189,7 +189,7 @@ schliff <command> [path] [options]
 ```
 
 | Command | What it does |
-|---|---|
+| --- | --- |
 | `score` | Score a file and print the grade bar |
 | `verify` | CI gate — exit 0/1 based on a minimum score |
 | `doctor` | Scan and grade every installed skill |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,17 +127,17 @@ the same 8 scorers **plus `operational_coverage`** and has its own headline prof
 (`structure` 0.40 / `operational_coverage` 0.40 / `efficiency` 0.20 — see
 `docs/SCORING.md` and `docs/specs/agents-md-operational-coverage.md`).
 
-| Dimension       | Weight | Role in skill.md headline                                   |
-|-----------------|--------|-------------------------------------------------------------|
-| `structure`     | 0.15   | headline                                                    |
-| `triggers`      | 0.20   | headline                                                    |
-| `quality`       | 0.20   | headline                                                    |
-| `edges`         | 0.15   | headline                                                    |
-| `efficiency`    | 0.10   | headline                                                    |
-| `composability` | 0.10   | headline                                                    |
-| `clarity`       | 0.05   | headline                                                    |
-| `security`      | 0.05   | **separate signal** (opt-in; excluded from skill.md headline, reported in `signals`/`security`) |
-| `runtime`       | n/a    | **separate signal** (no profile weight; never in any headline) |
+| Dimension | Weight | Role in skill.md headline |
+| --- | --- | --- |
+| `structure` | 0.15 | headline |
+| `triggers` | 0.20 | headline |
+| `quality` | 0.20 | headline |
+| `edges` | 0.15 | headline |
+| `efficiency` | 0.10 | headline |
+| `composability` | 0.10 | headline |
+| `clarity` | 0.05 | headline |
+| `security` | 0.05 | **separate signal** (opt-in; excluded from skill.md headline, reported in `signals`/`security`) |
+| `runtime` | n/a | **separate signal** (no profile weight; never in any headline) |
 
 The 7 headline weights are renormalized to sum to 1.0 once `security` and `runtime` are
 removed from the basis (`get_headline_excluded`).
@@ -153,13 +153,13 @@ agents.md family**.
 
 ### Format token budgets (`formats.py`)
 
-| Format          | Budget (tokens) |
-|-----------------|-----------------|
-| skill.md        | 1000            |
-| claude.md       | 2000            |
-| cursorrules     | 500             |
-| agents.md       | 3000            |
-| system_prompt   | 1500            |
+| Format | Budget (tokens) |
+| --- | --- |
+| skill.md | 1000 |
+| claude.md | 2000 |
+| cursorrules | 500 |
+| agents.md | 3000 |
+| system_prompt | 1500 |
 
 Token estimation is the stdlib-only `len(content) // 4` heuristic.
 
@@ -227,14 +227,14 @@ default canonical weights so cross-machine decisions never depend on a process e
 ### Grade scale (`terminal_art.score_to_grade` / `_GRADE_THRESHOLDS`)
 
 | Grade | Threshold |
-|-------|-----------|
-| S     | ≥ 95      |
-| A     | ≥ 85      |
-| B     | ≥ 75      |
-| C     | ≥ 65      |
-| D     | ≥ 50      |
-| E     | ≥ 35      |
-| F     | < 35      |
+| --- | --- |
+| S | ≥ 95 |
+| A | ≥ 85 |
+| B | ≥ 75 |
+| C | ≥ 65 |
+| D | ≥ 50 |
+| E | ≥ 35 |
+| F | < 35 |
 
 ---
 

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -50,7 +50,7 @@ Eight scorers run per file. Seven of them form the **headline composite**; `secu
 is reported as a separate signal and `runtime` is opt-in (and also a separate signal).
 
 | Dimension | Weight | Role | What it measures |
-|-----------|--------|------|------------------|
+| --- | --- | --- | --- |
 | **structure** | 0.15 | headline | Frontmatter (name, description), headers, examples, progressive disclosure, file length, dead content, referenced-file existence |
 | **triggers** | 0.20 | headline | TF-IDF keyword overlap between description and eval prompts, with stemming, synonym expansion, domain-signal detection, negation handling; reports precision and recall |
 | **quality** | 0.20 | headline | Eval-suite coverage: assertion-type diversity, feature breadth, descriptions, instruction-assertion coherence |
@@ -77,7 +77,7 @@ headline is a 3-dimension operational profile (the eval-gated dimensions — tri
 quality, edges — are excluded, and the remaining scorers stay separate signals):
 
 | Dimension | Weight | What it measures |
-|-----------|--------|------------------|
+| --- | --- | --- |
 | **structure** | 0.40 | Same structural scorer as the skill.md family |
 | **operational_coverage** | 0.40 | Whether the doc equips an agent to operate the repo: real setup/build/test commands (junk-, read-only- and prose-hardened command classification) plus code-style / gotcha / PR directive sections with concrete code tokens |
 | **efficiency** | 0.20 | Information density — deliberately demoted: fenced-code density is a gameable proxy for operational value |
@@ -91,7 +91,7 @@ headline dimension** (weight 0.15) that stays in the composite — only `runtime
 excluded.
 
 | Dimension | Weight |
-|-----------|--------|
+| --- | --- |
 | structure_prompt | 0.15 |
 | output_contract | 0.15 |
 | efficiency | 0.15 |
@@ -109,7 +109,7 @@ excluded.
 Each format carries a recommended token budget (`scoring/formats.py`):
 
 | Format | Budget (tokens) |
-|--------|-----------------|
+| --- | --- |
 | skill.md | 1000 |
 | claude.md | 2000 |
 | cursorrules | 500 |
@@ -123,7 +123,7 @@ Each format carries a recommended token budget (`scoring/formats.py`):
 Grades come from `terminal_art.score_to_grade` (`_GRADE_THRESHOLDS`):
 
 | Grade | Threshold | Meaning |
-|-------|-----------|---------|
+| --- | --- | --- |
 | **S** | >= 95 | Exceptional — near-perfect on measured dimensions |
 | **A** | >= 85 | Strong — minor polish remains |
 | **B** | >= 75 | Good — clear improvement paths exist |
@@ -197,7 +197,7 @@ First, the headline basis is built (security + runtime excluded). The seven raw 
 sum to 0.95, so Stage 2 renormalizes each by dividing by 0.95:
 
 | Dimension | Raw weight | Canonical weight (÷0.95) | Score | Contribution |
-|-----------|-----------|--------------------------|-------|--------------|
+| --- | --- | --- | --- | --- |
 | structure | 0.15 | 0.1579 | 90 | 14.21 |
 | triggers | 0.20 | 0.2105 | 80 | 16.84 |
 | quality | 0.20 | 0.2105 | *(unmeasured)* | 0 |
@@ -293,7 +293,7 @@ under the top-level `security` field), never folded into the skill.md-family hea
 ## Source-of-truth map
 
 | Concern | File |
-|---------|------|
+| --- | --- |
 | Canonical weights, scorer lists, headline-exclusion, aliases | `scoring/registry.py` |
 | Composite computation (full-denominator model) | `scoring/composite.py` |
 | Grade thresholds, gauges | `terminal_art.py` |


### PR DESCRIPTION
Editor markdownlint flagged 74 MD060 (table-column-style) errors across README.md, docs/SCORING.md and docs/ARCHITECTURE.md: content rows were compact (`| x |`) while delimiter rows were tight (`|---|`) — a mix that matches none of MD060's styles (aligned/compact/tight), so even the default "any" setting reports it.

**Fix chosen (root cause, no suppression):** normalize all tables in the user-facing docs to one consistent compact style. Verified empirically:
- `markdownlint-cli2`: 74 → **0** MD060 errors on the four files
- Diff asserted to be purely cosmetic (whitespace/dashes only — no content changes, identical GitHub rendering)

**Deliberately not done:** no `.markdownlint` config (pinning one style would wrongly flag valid future tables; with internally-consistent tables the default passes), no MD060-disable (would suppress future genuinely broken tables), and no churn on historical documents (docs/specs/, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)