### PR TITLE
feat(dogfood): own AGENTS.md + badge self-embed + action self-test + badge generator UI

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -1,0 +1,57 @@
+name: Action self-test
+
+# Dogfoods the local composite action (`uses: ./`) against this repo's own
+# AGENTS.md. Exists because dependency bumps to action.yml (setup-python,
+# github-script) otherwise merge on green CI without the action's code path
+# ever executing — PR #82 (github-script 7->9) shipped exactly that way and
+# had to be compatibility-verified by hand against release notes.
+#
+# comment-on-pr stays off: the PR-comment step needs `github-script`, which is
+# exercised... only on pull_request events with the input enabled. We enable it
+# on PRs so the full path (score -> gate -> comment) runs; the comment lands on
+# the PR itself, doubling as a live output preview.
+
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - 'AGENTS.md'
+      - '.github/workflows/action-selftest.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # the action's comment step posts/updates a PR comment
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run the local action against our own AGENTS.md
+        id: selftest
+        uses: ./
+        with:
+          minimum-score: '85'
+          comment-on-pr: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+
+      - name: Assert outputs are well-formed
+        env:
+          COMPOSITE: ${{ steps.selftest.outputs.composite }}
+          GRADE: ${{ steps.selftest.outputs.grade }}
+          RESULT_B64: ${{ steps.selftest.outputs.result_b64 }}
+        run: |
+          set -euo pipefail
+          python3 -P -c "
+          import base64, json, os
+          composite = float(os.environ['COMPOSITE'])
+          assert 0 <= composite <= 100, composite
+          assert os.environ['GRADE'] in list('SABCDEF'), os.environ['GRADE']
+          result = json.loads(base64.b64decode(os.environ['RESULT_B64']))
+          assert result['format'] == 'agents.md', result.get('format')
+          assert 'operational_coverage' in result['dimensions'], 'opcov missing'
+          print(f'self-test OK: {composite} [{os.environ[\"GRADE\"]}]')
+          "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# Schliff — agent instructions
+
+Deterministic quality scorer for AI instruction files (Python, stdlib-only core,
+zero runtime dependencies). The engine lives in `skills/schliff/scripts/`; the
+web playground in `playground/`; the GitHub Action in `action.yml`.
+
+## Setup
+
+```bash
+pip install -e .
+pip install pytest ruff
+```
+
+Optional extras: `pip install -e ".[judge]"` (LLM-judge smoke-test only — core
+scoring must stay zero-dependency).
+
+## Build
+
+```bash
+pip install build
+python -m build
+```
+
+Pure-Python wheel; nothing to compile.
+
+## Test
+
+```bash
+make test-unit          # pytest suite (1,347 tests) — run this before every commit
+make lint               # ruff check skills/schliff/scripts/
+make test-all           # unit + integration + self + proof suites
+```
+
+A single scorer test file runs fast: `python3 -m pytest skills/schliff/tests/unit/test_operational_coverage.py -q`.
+
+Example: verify a scorer change end-to-end (score a real file with your edit):
+
+```bash
+python3 skills/schliff/scripts/cli.py score AGENTS.md --json
+```
+
+Expected output: JSON with `composite_score`, per-dimension scores, and
+`format: agents.md`. If `operational_coverage` is missing, your registry
+wiring is broken — check `SCORER_REGISTRY["agents.md"]`.
+
+## Code style
+
+- Ruff is the authority (`pyproject.toml`: E, F, W, I; line length 120). Run `make lint` before pushing.
+- Core engine code (`skills/schliff/scripts/`) is stdlib-only — never add a runtime dependency there, because "pip install schliff, zero deps" is the product promise CI and the README both make.
+- Scorers must be deterministic: no `time`, `random`, `os.environ` reads, or network in any scoring path, because same-input-same-score is the core guarantee. Tests pin this (`test_purity_no_forbidden_imports`).
+- Prefer explicit error handling; no silent `except: pass` in scoring code.
+
+## Gotchas
+
+- **Never run blanket `ruff --fix`** on existing modules: F401 "unused" imports in `skills/schliff/scripts/` are real re-exports — removing them breaks the CLI (23 tests). Fix only files you authored.
+- The version lives in **three lockstep sources** (`pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`), gated by `test_version_consistency.py`. Bump all three together.
+- Changing any scorer re-baselines the corpus golden tests (`test_agents_md_profile.py` pins mean/median/band counts on 30 real files). Re-derive the numbers from the engine — never hand-tweak them.
+- `playground/public/index.html` has its inline `<script>` pinned by a CSP `sha256-…` hash in `playground/vercel.json`. Any edit to the inline script requires recomputing the hash, or the deployed page breaks silently.
+- Playground deploys are manual (`cd playground && vercel --prod`); the committed `playground/uv.lock` is the deploy source of truth. A daily drift workflow asserts live engine == pinned version.
+
+## Pull requests
+
+- Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `security:`, `spec:`), present tense, English.
+- Never push to `main` — feature branches only; PRs are squash-merged behind branch protection (lint + tests 3.10–3.13 + macOS + CodeQL must be green).
+- Non-trivial changes need a spec in `docs/specs/` first; update the spec with what you learned after implementing.
+- Before claiming done: run `make test-unit` and `make lint` and show the output.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
+[![AGENTS.md quality](https://img.shields.io/endpoint?url=https%3A%2F%2Fschliff-playground.vercel.app%2Fapi%2Fbadge%3Frepo%3DZandereins%2Fschliff)](https://schliff-playground.vercel.app)
 
 Schliff scores the instruction files that drive your AI agents — skills, system prompts, project memory — against an explicit, versioned rubric, so you can gate a release on the number in CI. No LLM judge in the critical path. No network. No randomness. Just a rule engine you can read, pin, and trust.
 

--- a/playground/public/index.html
+++ b/playground/public/index.html
@@ -570,6 +570,41 @@
   }
 
   /* Footer */
+  /* ── Badge generator bar ── */
+  .badge-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 24px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-card);
+    font-size: 12px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .badge-bar label { white-space: nowrap; }
+
+  .badge-bar input[type="text"] {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 12px;
+    padding: 5px 8px;
+    width: 220px;
+  }
+
+  .badge-bar input[type="text"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  .badge-bar img { height: 20px; display: none; }
+  .badge-bar img.visible { display: inline-block; }
+
   footer {
     padding: 10px 24px;
     border-top: 1px solid var(--border);
@@ -731,6 +766,15 @@ Instructions go here..." spellcheck="false"></textarea>
       <div class="results-inner" id="results" aria-live="polite"></div>
     </div>
   </main>
+
+  <!-- Badge generator -->
+  <div class="badge-bar">
+    <label for="badgeRepo">README badge:</label>
+    <input type="text" id="badgeRepo" placeholder="owner/repo" spellcheck="false"
+           aria-label="GitHub repository (owner/repo) for the AGENTS.md quality badge">
+    <button class="btn" id="btnBadgeCopy" disabled>Copy Markdown</button>
+    <img id="badgePreview" alt="AGENTS.md quality badge preview">
+  </div>
 
   <!-- Footer -->
   <footer>
@@ -1070,6 +1114,45 @@ Instructions go here..." spellcheck="false"></textarea>
       toastEl.classList.remove('show');
     }, 2000);
   }
+
+  // ── Badge generator ──
+  var badgeRepo = document.getElementById('badgeRepo');
+  var btnBadgeCopy = document.getElementById('btnBadgeCopy');
+  var badgePreview = document.getElementById('badgePreview');
+  var BADGE_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+  var badgeDebounce = null;
+
+  function badgeMarkdown(repo) {
+    var endpoint = window.location.origin + '/api/badge?repo=' + repo;
+    return '![AGENTS.md quality](https://img.shields.io/endpoint?url=' + encodeURIComponent(endpoint) + ')';
+  }
+
+  badgeRepo.addEventListener('input', function() {
+    clearTimeout(badgeDebounce);
+    badgeDebounce = setTimeout(function() {
+      var repo = badgeRepo.value.trim();
+      var valid = BADGE_REPO_RE.test(repo);
+      btnBadgeCopy.disabled = !valid;
+      if (valid) {
+        badgePreview.src = 'https://img.shields.io/endpoint?url=' +
+          encodeURIComponent(window.location.origin + '/api/badge?repo=' + repo);
+        badgePreview.classList.add('visible');
+      } else {
+        badgePreview.classList.remove('visible');
+        badgePreview.removeAttribute('src');
+      }
+    }, 400);
+  });
+
+  btnBadgeCopy.addEventListener('click', function() {
+    var repo = badgeRepo.value.trim();
+    if (!BADGE_REPO_RE.test(repo)) return;
+    navigator.clipboard.writeText(badgeMarkdown(repo)).then(function() {
+      showToast('Badge Markdown copied!');
+    }).catch(function() {
+      showToast('Copy failed');
+    });
+  });
 
   // ── Score ──
   var scoring = false;

--- a/playground/vercel.json
+++ b/playground/vercel.json
@@ -21,7 +21,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'sha256-60tTVH1/SwHKJfZN/b3lGmizKH4wkA3clpclTZYQtbo='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'sha256-jOQiAXvVo/lAhWZumJeH5pKD9SIXYGm+6sNrx9p73GQ='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://img.shields.io; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" }
       ]
     }
   ]


### PR DESCRIPTION
Dogfooding sweep (the remaining internal items from the distribution ranking):

1. **Own AGENTS.md** — engine-verified **91.6/A** (operational_coverage 100/100), above the 30-file corpus maximum, with honest content: real `make` targets, the F401-re-export trap, the CSP-hash pin rule, version lockstep, PR conventions.
2. **Badge self-embed** — README hero now carries our own `/api/badge` badge.
3. **Action self-test** (`uses: ./`) — runs the local action against our AGENTS.md on PRs touching `action.yml`/`AGENTS.md`, asserts composite/grade/JSON outputs incl. `operational_coverage`, and exercises the PR-comment path (github-script) that #82 merged without ever running.
4. **Playground badge generator** — owner/repo input → copyable badge Markdown + live shields.io preview; CSP `img-src` extended to img.shields.io only, inline-script hash recomputed.

Verified: 1347 tests green, ruff clean, inline JS `node --check` clean, AGENTS.md scored with the real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)