### PR TITLE
fix(plugin): drop dependencies field (declares marketplace plugins, not system requirements)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,10 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/Zandereins/schliff",
-  "skills": ["./skills/schliff"],
-  "commands": ["./commands/schliff"],
-  "dependencies": ["python3", "bash", "git"]
+  "skills": [
+    "./skills/schliff"
+  ],
+  "commands": [
+    "./commands/schliff"
+  ]
 }


### PR DESCRIPTION
Pre-submission verification caught this: `claude plugin validate` passes (syntax), but a **fresh install failed to load** — plugin.json's `dependencies` field declares other *marketplace plugins*, so the loader demanded `python3@schliff`. Field removed; fresh install in an isolated `CLAUDE_CONFIG_DIR` sandbox now shows `Status: ✔ enabled`.

Lesson recorded: validator green ≠ install works — always test the fresh-install path before submitting to the marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)