### PR TITLE
docs: ground-truth all showcased scores against the current engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,37 +14,41 @@ Schliff scores the instruction files that drive your AI agents — skills, syste
 
 ```bash
 pip install schliff
-schliff score path/to/SKILL.md
+schliff score AGENTS.md      # or any SKILL.md / CLAUDE.md / .cursorrules
 ```
+
+This is the real, current output of `schliff score AGENTS.md` on this repo's own
+[`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
 schliff v8.4.0
 
-  structure      ████████░░   78/100  good
-  triggers       ███████░░░   72/100  good
-  quality        ██████░░░░   64/100  fair
-  edges          █████░░░░░   55/100  fair
-  efficiency     ████████░░   80/100  good
-  composability  ███████░░░   70/100  good
-  clarity        ██████████  100/100  perfect
+  structure             █████████░   90/100  great
+  operational_coverage  ██████████  100/100  perfect
+  efficiency            ████████░░   78/100  good
+  composability         ████░░░░░░   45/100  poor
+  clarity               ██████████  100/100  perfect
 
-  Structural Score  ██████████████░░░░░░  71.2/100  [C]
+  Structural Score  ██████████████████░░  91.6/100  [A]
 
-  Tokens: 740 / 1,000 (ok)
+  Tokens: 837 / 3,000 (ok)
+  Format: agents.md (normalized)
 ```
 
-No model in the loop produced that number. Run it again on another laptop and you get 71.2 again. That is the whole point.
+No model in the loop produced that number. Run it again on another laptop and you get 91.6 again. That is the whole point.
 
 ---
 
 ## A real catch
 
-A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/) — a real prompt-injection-defense skill, now archived — scored **68.3 [C]** — and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **94.6 [A]** on all 7 dimensions.
+A SKILL.md for [ShieldClaw](docs/case-studies/shieldclaw/) — a real prompt-injection-defense skill, now archived — scored **83.7 [B]**, and Schliff showed exactly why: composability **20/100** (no scope boundaries, no I/O contract, no handoffs), efficiency 60/100, and **3 of 7 dimensions unmeasurable** because there was no eval suite. After adding the missing scope section and an eval suite, the same file scored **93.8 [A]** on all 7 dimensions, with composability at 86.
 
 | | Score | Grade | Dimensions measured |
 | --- | --- | --- | --- |
-| Before | 68.3 | C | 4/7 (no eval suite) |
-| After | 94.6 | A | 7/7 |
+| Before | 83.7 | B | 4/7 (no eval suite) |
+| After | 93.8 | A | 7/7 |
+
+*(Both files ship in [`docs/case-studies/shieldclaw/`](docs/case-studies/shieldclaw/) — the numbers above are the current engine's output, reproducible with `schliff score`.)*
 
 Defects you'd otherwise ship caught as a number that's too low — see the [full case study](docs/case-studies/shieldclaw/).
 

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -3,17 +3,17 @@
     "skill_name": "schliff",
     "repo_url": "https://github.com/zandereins/schliff",
     "format": "SKILL.md",
-    "composite": 99.0,
+    "composite": 98.9,
     "grade": "S",
     "dimensions": {
       "structure": 100,
       "triggers": 100,
-      "quality": 96,
+      "quality": 99,
       "edges": 100,
-      "efficiency": 100,
+      "efficiency": 92,
       "composability": 100,
       "clarity": 100,
-      "security": 95
+      "security": 100
     },
     "version": "8.4.0",
     "submitted_at": "2026-03-25T10:00:00Z"
@@ -22,17 +22,17 @@
     "skill_name": "shieldclaw",
     "repo_url": "https://github.com/zandereins/schliff",
     "format": "SKILL.md",
-    "composite": 94.6,
+    "composite": 93.8,
     "grade": "A",
     "dimensions": {
       "structure": 95,
-      "triggers": 92,
-      "quality": 94,
-      "edges": 96,
-      "efficiency": 93,
-      "composability": 95,
-      "clarity": 96,
-      "security": 90
+      "triggers": 100,
+      "quality": 90,
+      "edges": 100,
+      "efficiency": 83,
+      "composability": 86,
+      "clarity": 100,
+      "security": 75
     },
     "version": "2.1.0",
     "submitted_at": "2026-03-24T15:30:00Z"


### PR DESCRIPTION
Triggered by a sharp user catch: the README hero score "71.2/C" was a fabricated illustration — inconsistent labeling (Structural Score with eval-gated dims shown), non-reproducing math, and no command that produces it, directly under the determinism promise "run it again and you get 71.2 again".

**Fixed with ground-truth discipline (every number from a real engine run):**
- Hero block = actual `schliff score AGENTS.md` output on this repo's AGENTS.md (**91.6/A**), verified byte-identical against the released `schliff==8.4.0` from PyPI, with a "clone and run it yourself" note
- ShieldClaw case study re-derived on the current engine: **83.7/B → 93.8/A** (the old 68.3/94.6 predate the #41 composite re-baseline) + reproducibility note
- Leaderboard seed entries re-derived (schliff 98.9/S with real dims incl. security 100; shieldclaw 93.8/A)
- Playground example labels audited and verified **correct as-is** (their inlined contents score exactly 66.7/90.7)

1347 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)