### PR TITLE
fix(scoring): positional negation — contrastive sentences keep the recommended command

### DIFF
--- a/skills/schliff/scripts/scoring/operational_coverage.py
+++ b/skills/schliff/scripts/scoring/operational_coverage.py
@@ -446,12 +446,17 @@ def _extract_commands(lines):
                         results.append((fam, _norm(seg)))
             continue
         # §4.2.5: the negation guard is SENTENCE-scoped — "Never commit to
-        # main. Run `pnpm test` before pushing." must keep the test credit.
+        # main. Run `pnpm test` before pushing." must keep the test credit —
+        # and POSITIONAL within the sentence: a contrastive construction
+        # ("Always run `bun typecheck` …, never `tsc` directly") positively
+        # recommends the command BEFORE the cue and negates only what follows.
         for sent in _SENT_SPLIT_RE.split(ln):
-            if _is_negated(sent):
-                continue
-            for span in _INLINE_RE.findall(sent):
-                for seg in _split_segments(span):
+            neg = _NEG_RE.search(sent)
+            neg_at = len(sent) if (neg is None or _NEG_POSITIVE_RE.search(sent)) else neg.start()
+            for m in _INLINE_RE.finditer(sent):
+                if m.start() > neg_at:
+                    continue
+                for seg in _split_segments(m.group(1)):
                     fam = _classify(seg, inline=True)
                     if fam:
                         results.append((fam, _norm(seg)))

--- a/skills/schliff/tests/unit/test_operational_coverage.py
+++ b/skills/schliff/tests/unit/test_operational_coverage.py
@@ -633,6 +633,27 @@ pnpm install
     assert "pnpm install" in r["details"]["commands"]
 
 
+def test_negation_is_positional_within_sentence(tmp_path):
+    """Field finding (schliff#95, from scoring sst/opencode): a contrastive
+    sentence positively recommends the command BEFORE the negation cue and
+    negates only what follows — 'Always run `bun typecheck` …, never `tsc`
+    directly' must credit typecheck and suppress tsc."""
+    r = _op(
+        tmp_path,
+        """# P
+
+## Testing
+
+- Always run `bun typecheck` from package directories, never `tsc` directly.
+- never use `npm audit fix` here
+""",
+    )
+    cmds = r["details"]["commands"]
+    assert "bun typecheck" in cmds
+    assert not any("tsc" in c for c in cmds)
+    assert not any("audit" in c for c in cmds)
+
+
 def test_negation_is_sentence_scoped(tmp_path):
     """§4.2.5: 'Never commit to main. Run `pnpm test` before pushing.' keeps
     the test credit; 'don't forget to run X' is a positive instruction; and


### PR DESCRIPTION
Fixes #95 (found by field study #2 on sst/opencode): the sentence-scoped negation guard suppressed the *positively recommended* command in contrastive constructions ("Always run `bun typecheck` …, never `tsc` directly"), zeroing opencode's real test command (opcov 45 → 65 after the fix).

The guard is now **positional within the sentence**: only inline commands starting after the first negation cue are suppressed. "Never run `X`" still suppresses (cue precedes); "run `X`, never `Y`" credits X and suppresses Y. Strictly fewer false negatives, no reopened gaming surface.

- New regression test pinning the opencode pattern
- Corpus goldens **unchanged** — verified by the suite itself (no contrastive constructions in the 30-file corpus), so no re-baseline needed
- 1348 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)