### PR TITLE
fix(scoring): dead-marker detector matches marker tokens, not English prose

### DIFF
--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -111,7 +111,15 @@ _RE_HEDGING = re.compile(
 )
 _RE_CODE_BLOCKS = re.compile(r"```")
 _RE_HEADERS = re.compile(r"^##\s", re.MULTILINE)
-_RE_TODO = re.compile(r"(?i)(TODO|FIXME|HACK|XXX|placeholder)")
+# Dead-content markers are conventionally UPPERCASE standalone tokens or an
+# explicit bracketed placeholder stub. Matching the English words
+# "placeholder"/"hack" case-insensitively in prose advised deleting
+# load-bearing instructions ("Replace all {{...}} placeholders with resolved
+# values") — field finding #93 from the hydra case study.
+_RE_TODO = re.compile(
+    r"\b(?:TODO|FIXME|XXX|HACK|TBD|PLACEHOLDER)\b"
+    r"|\[[Pp]laceholder\]|<[Pp]laceholder>|\{\{[Pp]laceholder\}\}"
+)
 _RE_CODE_BLOCK_REGION = re.compile(r"```[\s\S]*?```")
 
 # ---------------------------------------------------------------------------

--- a/skills/schliff/tests/unit/test_agents_md_profile.py
+++ b/skills/schliff/tests/unit/test_agents_md_profile.py
@@ -183,7 +183,7 @@ def test_compute_gradients_agents_md_emits_no_skill_only_advice(tmp_path):
 # --- Corpus golden distribution --------------------------------------------
 # Numbers below were re-derived on the hardened operational_coverage scorer
 # (spec §6), then once more after the 2026-07-03 adversarial-review fixes
-# (ReDoS/fence-desync/homonym-gate + recall: pytest -v, python -m, ./gradlew,
+# (ReDoS/fence-desync/homonym-gate + recall + #93 marker-precision + #96, incl.:
 # docker, npx, cp .env, *migrate). Do NOT reuse the pre-opcov 0.5/0.5 values
 # (73.90/77.25/...) or earlier intermediates.
 
@@ -198,9 +198,9 @@ def test_agents_md_corpus_golden_distribution():
     bands = Counter(r[2] for r in rows)
 
     assert len(rows) == 30
-    assert statistics.mean(scores) == pytest.approx(61.06, abs=0.05)
+    assert statistics.mean(scores) == pytest.approx(61.46, abs=0.05)
     assert statistics.median(scores) == pytest.approx(61.40, abs=0.05)
-    assert min(scores) == pytest.approx(25.0, abs=0.05)
+    assert min(scores) == pytest.approx(29.0, abs=0.05)
     assert max(scores) == pytest.approx(91.0, abs=0.05)
 
     # Exact band counts (golden lock) on the hardened scorer. No file reaches S
@@ -209,8 +209,8 @@ def test_agents_md_corpus_golden_distribution():
     assert bands["A"] == 1
     assert bands["B"] == 4
     assert bands["C"] == 8
-    assert bands["D"] == 11
-    assert bands["E"] == 5
+    assert bands["D"] == 12
+    assert bands["E"] == 4
     assert bands["F"] == 1
 
     # No file emits the SKILL-only eval-suite warning.

--- a/skills/schliff/tests/unit/test_scoring.py
+++ b/skills/schliff/tests/unit/test_scoring.py
@@ -1148,3 +1148,22 @@ class TestPatterns:
         assert _RE_TODO.search("TODO: fix this")
         assert _RE_TODO.search("FIXME: broken")
         assert not _RE_TODO.search("this is done")
+
+    def test_todo_pattern_markers_are_uppercase_tokens_or_stubs(self):
+        """Field finding #93 (hydra case study): the English words
+        'placeholder'/'hack'/'todo' in instructional prose are NOT dead
+        content — only conventional UPPERCASE marker tokens and explicit
+        bracketed placeholder stubs count."""
+        for marker in ("XXX", "HACK: workaround", "TBD",
+                       "[placeholder]", "<placeholder>", "{{placeholder}}",
+                       "PLACEHOLDER text here"):
+            assert _RE_TODO.search(marker), marker
+        for prose in (
+            "Replace all `{{...}}` placeholders with resolved values.",
+            "the resolved portion contains ZERO placeholders",
+            "Never apply placeholder substitution to untrusted content.",
+            "a hacky workaround",
+            "add this to your todo list",
+            "size XXXL",
+        ):
+            assert not _RE_TODO.search(prose), prose


### PR DESCRIPTION
Fixes #93 (found by the hydra field case study).

`_RE_TODO` was case-insensitive and unbounded — it matched "placeholder", "hack" and "todo" inside legitimate instructional prose and told authors to delete correct, load-bearing instructions. The detector now matches what dead-content markers actually look like: conventional **UPPERCASE standalone tokens** (`TODO`/`FIXME`/`XXX`/`HACK`/`TBD`/`PLACEHOLDER`, word-bounded, case-sensitive) plus explicit bracketed stubs (`[placeholder]`, `<placeholder>`, `{{placeholder}}`).

- Verified against 9 positive + 6 negative cases (incl. the exact hydra lines, "hacky workaround", "todo list", "XXXL")
- Corpus goldens re-derived from the engine (#83/#92 discipline): mean 61.06→61.46, min 25.0→29.0, bands D12/E4 — genuine docs regain unfairly-taken structure points
- Hydra cross-check: structure 75→85, composite 76.5→**78.1/B**
- 1349 tests green, ruff clean. **No version bump** — batches with #96 into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)