### PR TITLE
feat: notify profile repo on new stars for instant badge recount

### DIFF
--- a/.github/workflows/notify-star-count.yml
+++ b/.github/workflows/notify-star-count.yml
@@ -1,0 +1,30 @@
+name: Notify star counter
+
+# Fires the moment someone stars this repo and asks the profile repo
+# (Zandereins/Zandereins) to recount immediately, instead of waiting for
+# its hourly schedule. Un-stars don't emit an event; the hourly cron in
+# the profile repo catches those.
+on:
+  watch:
+    types: [started]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger star recount in profile repo
+        env:
+          TOKEN: ${{ secrets.PROFILE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "PROFILE_DISPATCH_TOKEN is not configured — skipping."
+            echo "The hourly Star Count schedule in Zandereins/Zandereins will pick this up instead."
+            exit 0
+          fi
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/Zandereins/Zandereins/dispatches \
+            -d '{"event_type":"star-update"}'


### PR DESCRIPTION
## What
Adds a `watch`-triggered workflow (`notify-star-count.yml`) that sends a `repository_dispatch` (`star-update`) to Zandereins/Zandereins the moment someone stars this repo.

## Why
The profile README's total-stars badge was stale for up to a day (daily cron). With this hook it updates within minutes of a new star; the hourly cron in the profile repo remains the fallback (and catches un-stars, which emit no event). No-ops gracefully when the `PROFILE_DISPATCH_TOKEN` secret is not configured. Companion to Zandereins/Zandereins#13.

## Checklist
- [x] `make test-all` passes (all test suites green) — CI on this PR; change is workflow-only, no Python code touched
- [x] `bash test-self.sh` passes (all self-tests green) — CI on this PR; change is workflow-only
- [x] `python3 score-skill.py SKILL.md --json` composite >= 90 — SKILL.md not modified
- [x] No new security issues introduced — job runs with `permissions: {}`; the fine-grained PAT stays in an org/repo secret, never in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzJRuwBtCpSz7wxXgCctud

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzJRuwBtCpSz7wxXgCctud)_