### PR TITLE
fix(verify): score under the detected format profile, not the SKILL profile

### DIFF
--- a/skills/schliff/scripts/verify.py
+++ b/skills/schliff/scripts/verify.py
@@ -32,35 +32,22 @@ _DEFAULT_MIN_SCORE = 75.0
 def _score_skill(skill_path: str, eval_suite: Optional[dict] = None) -> dict:
     """Run the full scorer on a skill. Returns composite dict + per-dim scores.
 
-    Reuses the same scoring functions as `schliff score`.
+    Reuses the same scoring path as `schliff score`: format detection +
+    per-format scorer registry + per-format headline profile. Hand-rolling
+    the SKILL scorer set here scored AGENTS.md under the wrong profile
+    (issue #101: 27.7/F on a file `score` grades 91.6/A).
     """
-    from scoring import (
-        compute_composite,
-        score_clarity,
-        score_composability,
-        score_edges,
-        score_efficiency,
-        score_quality,
-        score_runtime,
-        score_structure,
-        score_triggers,
-    )
+    from scoring import compute_composite
+    from scoring.formats import detect_format
+    from shared import build_scores
 
-    scores = {
-        "structure": score_structure(skill_path),
-        "triggers": score_triggers(skill_path, eval_suite),
-        "quality": score_quality(skill_path, eval_suite),
-        "edges": score_edges(skill_path, eval_suite),
-        "efficiency": score_efficiency(skill_path),
-        "composability": score_composability(skill_path),
-        "clarity": score_clarity(skill_path),
-        "runtime": score_runtime(skill_path, eval_suite, enabled=False),
-    }
+    fmt = detect_format(skill_path)
+    scores = build_scores(skill_path, eval_suite, fmt=fmt)
 
     # The CI gate is a cross-machine comparison surface: never opt into ambient
     # calibrated weights here (use_calibrated defaults False), so the pass/fail
     # decision is reproducible and cannot be flipped by an env var.
-    composite = compute_composite(scores)
+    composite = compute_composite(scores, fmt=fmt)
 
     return {
         "composite": composite["score"],

--- a/skills/schliff/tests/unit/test_verify.py
+++ b/skills/schliff/tests/unit/test_verify.py
@@ -433,6 +433,98 @@ class TestRunVerifyRegression:
 
 
 # ---------------------------------------------------------------------------
+# Format profiles: verify must score under the detected format, not the
+# SKILL profile (issue #101 — AGENTS.md verified at 27.7/F vs score's 91.6/A)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def agents_md(tmp_path):
+    """A well-formed AGENTS.md that scores high under the agents.md profile."""
+    content = '''# Agent Instructions
+
+## Setup
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Build & Test
+
+```bash
+make build
+pytest tests/ -x
+```
+
+Always run the full test suite before opening a PR.
+
+## Code Style
+
+- Run `ruff check src/` before committing; the CI lint gate is blocking.
+- Type hints are required on public functions.
+
+## PR Conventions
+
+- Conventional commits (`feat:`, `fix:`, `docs:`).
+- One reviewer approval required before merge.
+
+## Gotchas
+
+- `make build` must run before `pytest` — the fixtures are generated.
+- Never edit `src/generated/` by hand; it is overwritten on build.
+'''
+    path = tmp_path / "AGENTS.md"
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+class TestVerifyFormatProfile:
+    def test_agents_md_verdict_matches_score_path(self, agents_md, history_file):
+        """run_verify on AGENTS.md must produce the same composite as the
+        `schliff score` path (agents.md profile), not the SKILL profile."""
+        from scoring import compute_composite
+        from scoring.formats import detect_format
+        from shared import build_scores
+
+        fmt = detect_format(agents_md)
+        assert fmt == "agents.md"
+        expected = compute_composite(
+            build_scores(agents_md, None, fmt=fmt), fmt=fmt
+        )["score"]
+
+        verdict = verify_mod.run_verify(
+            agents_md, min_score=75.0, history_path=history_file
+        )
+        assert verdict["composite"] == expected
+
+    def test_agents_md_full_coverage_no_eval_suite(self, agents_md, history_file):
+        """AGENTS.md's 3-dim headline is always measurable — verify must not
+        cap it at the SKILL profile's 42% no-eval-suite ceiling."""
+        verdict = verify_mod.run_verify(
+            agents_md, min_score=75.0, history_path=history_file
+        )
+        assert verdict["coverage"] == 1.0
+        assert verdict["effective_min"] == 75.0
+
+    def test_skill_md_verdict_unchanged_by_format_wiring(self, good_skill, history_file):
+        """SKILL.md verdicts must equal the score path under the skill profile
+        (regression guard for the format wiring)."""
+        from scoring import compute_composite
+        from scoring.formats import detect_format
+        from shared import build_scores
+
+        fmt = detect_format(good_skill)
+        assert fmt == "skill.md"
+        expected = compute_composite(
+            build_scores(good_skill, None, fmt=fmt), fmt=fmt
+        )["score"]
+
+        verdict = verify_mod.run_verify(
+            good_skill, min_score=50.0, history_path=history_file
+        )
+        assert verdict["composite"] == expected
+
+
+# ---------------------------------------------------------------------------
 # format_verdict
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
Closes #101. `schliff verify` now scores under the detected format profile (detect_format → build_scores(fmt) → compute_composite(fmt=fmt)) instead of a hand-rolled SKILL scorer set.

## Red repro (before)
```
$ schliff score AGENTS.md      →  91.6/100 [A]
$ schliff verify AGENTS.md --min-score 75
FAIL: 27.7/100 [F] < effective minimum 31.5 (min 75.0 x coverage 42%)
```

## After
```
$ schliff verify AGENTS.md --min-score 75
PASS: 91.6/100 [A] >= effective minimum 75.0 (min 75.0 x coverage 100%)
```

## Verification
- 3 new tests (agents.md verdict == score-path composite; coverage 1.0 without eval suite; SKILL.md parity guard — the parity test passes on BOTH sides of the fix, proving SKILL verdicts unchanged)
- Full suite 1356 passed, ruff clean on touched code (I001 in the test file pre-exists at HEAD, outside CI lint scope)
- End-to-end CLI runs above on the main engine; sibling commands (badge/suggest/compare/score) swept on released 8.4.0 — verify was the only affected surface

Same bug class as the playground fmt-wiring fix (#79); this closes the last known consumer surface that bypassed the format profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)