### PR TITLE
chore(deps): bump codeql-action to 4.36.3 in lockstep + group action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # One PR per update round: split bumps of lockstep actions
+    # (codeql-action/init + /analyze) fail CI when versions mix.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pinned (matches other workflows)
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: python
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:python"


### PR DESCRIPTION
## What
Supersedes #103 and #104. Bumps **both** `codeql-action/init` and `codeql-action/analyze` to 4.36.3 in one commit, and adds a `groups` config to dependabot.yml so github-actions bumps arrive as a single PR from now on.

## Why the Dependabot PRs failed
CodeQL's init and analyze steps must run the same action version. Dependabot opened one PR per step, so each PR produced a mixed 4.36.2/4.36.3 pair — `##[error] Loaded a configuration file for version '4.36.3', but running version '4.36.2'`. Neither PR could ever pass on its own.

## Verification
- New SHA `54f647b7…` verified against the upstream `v4.36.3` tag (annotated tag dereferences to exactly this commit)
- Both pins byte-identical; dependabot groups syntax per docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)