### PR TITLE
chore(release): v8.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.5.0] - 2026-07-07
+
+### Fixed
+- **`verify` scores under the detected format profile** (#102, closes #101).
+  It previously hand-rolled the SKILL scorer set, so `schliff verify AGENTS.md`
+  scored the file under the wrong profile and failed spuriously (27.7/F on a
+  file `score` grades 91.6/A). Now wired like `score`/`badge`:
+  `detect_format → build_scores(fmt) → compute_composite(fmt=fmt)`. SKILL.md
+  verdicts are unchanged.
+- **Positional negation in `operational_coverage`** (#96): contrastive
+  sentences ("run X, never Y directly") keep the recommended command instead
+  of discarding both.
+- **Dead-marker detector matches marker tokens, not English prose** (#97,
+  closes #93): UPPERCASE tokens/stubs count; words like "placeholder" in
+  prose no longer false-positive. Corpus goldens re-derived.
+
+### Security
+- **Runtime scorer prompt hardened** (#99): skill content is nonce-wrapped
+  (`<skill_context_NONCE>`) so crafted files cannot forge the prompt
+  structure. Defense-in-depth — the dimension remains opt-in and gated off.
+
+### Added
+- Instant star-count notify workflow for the profile-repo badge (#98).
+- Theme-aware README hero (light/dark SVG) + social-preview asset (#106).
+- Dependabot now groups github-actions bumps into one PR — split bumps of
+  lockstep actions (codeql init/analyze) could never pass CI (#107).
+
+### Docs
+- **README redesigned** (#100): AGENTS.md-first, every number ground-truthed
+  against the released engine, ShieldClaw case-study table disambiguated
+  (ceiling vs quality), hydra field study added, new "What the score does not
+  measure" section, Marketplace listing linked.
+
 ## [8.4.0] - 2026-07-03
 
 ### Added
@@ -528,7 +561,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.4.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.5.0...HEAD
+[8.5.0]: https://github.com/Zandereins/schliff/compare/v8.4.0...v8.5.0
 [8.4.0]: https://github.com/Zandereins/schliff/compare/v8.3.0...v8.4.0
 [8.3.0]: https://github.com/Zandereins/schliff/compare/v8.2.0...v8.3.0
 [8.2.0]: https://github.com/Zandereins/schliff/compare/v8.1.0...v8.2.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.4.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.5.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.4.0
+schliff v8.5.0
 
   structure             █████████░   90/100  great
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.4.0
 
 No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
 
-*Every number in this README comes from released `schliff==8.4.0` (`pip install schliff==8.4.0` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*Every number in this README comes from released `schliff==8.5.0` (`pip install schliff==8.5.0` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -186,26 +186,23 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.4.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.5.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
 
-Prefer not to depend on a third-party action? The dependency-light equivalent —
-the same check the Action runs internally:
+Prefer not to depend on a third-party action? The dependency-light equivalent:
 
 ```yaml
       - run: pip install schliff
-      - run: >
-          schliff score AGENTS.md --json |
-          python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin)['composite_score'] >= 75 else 1)"
+      - run: schliff verify AGENTS.md --min-score 75
 ```
 
-For `SKILL.md`-family files there is a one-liner: `schliff verify SKILL.md --min-score 75`
-exits non-zero when the score falls short (the minimum is scaled by measurement
-coverage, so files without an eval suite aren't auto-failed). `verify` scores
-under the SKILL profile — don't point it at `AGENTS.md`; use the `score --json`
-check above instead.
+`schliff verify` exits non-zero when the score falls short and works for every
+supported format — the minimum is scaled by measurement coverage, so `SKILL.md`
+files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
+`AGENTS.md`: older engines scored it under the SKILL profile
+([#101](https://github.com/Zandereins/schliff/issues/101)).
 
 ### README badge
 
@@ -225,13 +222,13 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.4.0
+    rev: v8.5.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']
 ```
 
-The hook fires on `SKILL.md` files (its `files` filter); gate `AGENTS.md` with the Action or the `schliff score --json` check above.
+The hook fires on `SKILL.md` files (its `files` filter); gate `AGENTS.md` with the Action or `schliff verify AGENTS.md` in CI.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ Run through this list before creating a new tag. Skipping a step has burned us b
 5. **Run full test suite locally:** `pytest -q` — all tests green.
 6. **Run build locally:** `python3 -m build && twine check dist/*`.
 7. **Commit on a release branch** (`chore/release-X.Y.Z`), open PR, merge to `main`.
-8. **Tag:** `git tag -a vX.Y.Z -m "vX.Y.Z" && git push --tags` — `publish.yml` fires.
+8. **Create the GitHub Release** (tag `vX.Y.Z`, e.g. `gh release create vX.Y.Z`) — `publish.yml` fires on `release: published`, NOT on a bare tag push.
 9. **Verify PyPI release** — check `pip install schliff==X.Y.Z` works.
 10. **Post-release:** close milestone, update memory entries that reference version.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.4.0.**
+**Current version: 8.5.0.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.4.0"
+version = "8.5.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.4.0"
+__version__ = "8.5.0"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.4.0",
+    "version": "8.5.0",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {


### PR DESCRIPTION
## What
Release train for v8.5.0 — ships the three engine fixes batched since 8.4.0 (#96 negation, #97 marker precision, #102 verify format profile) plus #99 hardening, the README redesign and assets.

## Lockstep + secondary refs
- 3 version sources (pyproject, plugin.json, `__init__`) — gated by `test_version_consistency`
- README: badge cache-bust, sample-output header, `schliff==8.5.0` reproducibility footnote, `schliff-version` pin example, pre-commit `rev`
- docs/README "Current version", leaderboard seed self-entry (score 98.9 re-verified byte-identical on the new engine before bumping its version field)
- README CI-gate section: restores the `schliff verify AGENTS.md --min-score 75` one-liner (works from this release), with the #101 version caveat
- RELEASING.md step 8 corrected (publish fires on `release: published`)

## Pre-release verification
- 1356 tests green
- `python -m build` + `twine check`: schliff-8.5.0 sdist+wheel both PASSED
- Zero score drift 8.4.0→8.5.0 on every README-showcased number (verified during the README redesign; corpus goldens re-derived in #97)

## After merge
GitHub Release v8.5.0 → publish.yml (test-gate + OIDC) → PyPI → playground pin bump + deploy + drift-check → v1 tag re-point → live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)