### PR TITLE
chore(playground): pin engine to schliff 8.5.0

### DIFF
--- a/playground/pyproject.toml
+++ b/playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "app"
 version = "0.1.0"
-dependencies = [ "schliff==8.4.0" ]
+dependencies = [ "schliff==8.5.0" ]
 requires-python = "~=3.12.0"

--- a/playground/uv.lock
+++ b/playground/uv.lock
@@ -11,13 +11,13 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "schliff", specifier = "==8.4.0" }]
+requires-dist = [{ name = "schliff", specifier = "==8.5.0" }]
 
 [[package]]
 name = "schliff"
-version = "8.4.0"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/a6/ccbbf13acaecfa21ab06ac49492760e36d2968056e07656960cb0005d9fa/schliff-8.4.0.tar.gz", hash = "sha256:14d1600a4c5abe9e397b0791289142038b8163f42ac4299c6fc811cac28bb09d", size = 239768, upload-time = "2026-07-03T11:50:14.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ff/ef7883f990757bf879104431340965ee078cae6b05bb86398489a0807b0f/schliff-8.5.0.tar.gz", hash = "sha256:849808263cced363acde3f1ead9c621b4d1f4fd1aa50779cbe5e0435484ba441", size = 242874, upload-time = "2026-07-07T07:05:49.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/f3/5d8bb3f99238f9abf139358ec5445f4b66635844808f9d303907e5540c73/schliff-8.4.0-py3-none-any.whl", hash = "sha256:0cbade341dd8d70d72a4e02d24ff17f2245f3113cbb9497113f457a9f1beb94c", size = 277144, upload-time = "2026-07-03T11:50:13.158Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/73/cd9be0bc80b98a4ed68665d6d44ab359690b174906d9e30c4bd0c9ff775c/schliff-8.5.0-py3-none-any.whl", hash = "sha256:cfb2bd74972307d5748796789b6e54462b82f1baf2c3ce70437dffea3e4028f1", size = 280048, upload-time = "2026-07-07T07:05:47.859Z" },
 ]


### PR DESCRIPTION
Bumps the playground engine pin to the just-published 8.5.0 (PyPI-verified). Lockfile regenerated hash-pinned, `uv lock --check` clean. Manual `vercel --prod` + drift-check dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)