### PR TITLE
fix: council findings — object-first prohibitions, badge temp-dir leak, badge error caching

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,13 @@ Run through this list before creating a new tag. Skipping a step has burned us b
 7. **Commit on a release branch** (`chore/release-X.Y.Z`), open PR, merge to `main`.
 8. **Create the GitHub Release** (tag `vX.Y.Z`, e.g. `gh release create vX.Y.Z`) — `publish.yml` fires on `release: published`, NOT on a bare tag push.
 9. **Verify PyPI release** — check `pip install schliff==X.Y.Z` works.
-10. **Post-release:** close milestone, update memory entries that reference version.
+10. **Redeploy the web surfaces** — their bundles carry engine/seed state:
+    playground (bump `playground/pyproject.toml` pin + `uv lock --upgrade-package schliff`,
+    then `vercel --prod` + dispatch `playground-pin-drift.yml`) AND leaderboard
+    (`vercel --prod` from `web/leaderboard/` — its bundled seed shows the
+    self-entry version; skipping this left the live row on 8.1.0 until 2026-07-07).
+11. **Re-point the `v1` float tag** to the release commit (`git tag -f v1 <sha> && git push origin v1 --force`).
+12. **Post-release:** close milestone, update memory entries that reference version.
 
 ## Dry-run
 

--- a/playground/api/badge.py
+++ b/playground/api/badge.py
@@ -20,6 +20,7 @@ grey badge, not a broken image). Security posture:
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import urllib.error
@@ -51,6 +52,11 @@ MAX_FETCH_BYTES = 512 * 1024
 # s-maxage lets Vercel's edge absorb shields/camo refetches; SWR keeps badges
 # instant while revalidating in the background.
 CACHE_CONTROL = "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800"
+# Fallback badges (fetch errors, no AGENTS.md yet, invalid input) must not be
+# pinned in the edge cache for a day: a transient GitHub 5xx would freeze
+# "unavailable", and a user who just added their AGENTS.md would stare at
+# "no AGENTS.md" — the onboarding moment. Only real scores cache long.
+CACHE_CONTROL_FALLBACK = "public, max-age=60, s-maxage=300"
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -126,20 +132,19 @@ def _score(content: str) -> dict:
         grade = score_to_grade(score)
         return _badge(f"{score:g} · {grade}", _color(score), label="AGENTS.md quality")
     finally:
-        try:
-            os.unlink(skill_path)
-            os.rmdir(tmp_dir)
-        except OSError:
-            pass
+        # rmtree, not unlink+rmdir: if the file write itself failed (e.g.
+        # ENOSPC), unlink would raise and leak the mkdtemp dir on a warm
+        # instance's persistent /tmp.
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 class handler(BaseHTTPRequestHandler):
-    def _send(self, body: dict):
+    def _send(self, body: dict, cache_control: str = CACHE_CONTROL_FALLBACK):
         # Always 200: shields renders the payload; non-200 shows a broken badge.
         payload = json.dumps(body).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Cache-Control", CACHE_CONTROL)
+        self.send_header("Cache-Control", cache_control)
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
@@ -158,6 +163,6 @@ class handler(BaseHTTPRequestHandler):
             self._send(err)
             return
         try:
-            self._send(_score(content))
+            self._send(_score(content), cache_control=CACHE_CONTROL)
         except Exception:
             self._send(_badge("scoring error", "lightgrey"))

--- a/skills/schliff/scripts/scoring/operational_coverage.py
+++ b/skills/schliff/scripts/scoring/operational_coverage.py
@@ -46,11 +46,18 @@ _ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
 # Spec §4.2.5 cue list is exactly do-not/don't/never/avoid — `instead of` is
 # NOT a negation ("Use `pnpm test` instead of `npm test`" positively recommends
 # the first command).
-_NEG_RE = re.compile(r"\b(do not|don'?t|dont|never|avoid)\b", re.IGNORECASE)
+_NEG_RE = re.compile(r"\b(do not|don'?t|dont|never|avoid(?:ed|ing|s)?)\b", re.IGNORECASE)
 # Positive idioms that carry a negation word but INSTRUCT running the command:
 # "don't forget to run X", "never skip X".
 _NEG_POSITIVE_RE = re.compile(
     r"\b(?:do not|don'?t|dont|never)\s+(?:forget|skip)\b", re.IGNORECASE
+)
+# Base-form recommendation verbs that mark a sentence as CONTRASTIVE when they
+# appear before the negation cue ("Always run `x` …, never `y` directly").
+# Deliberately base forms only: "Running `x` is something you must never do"
+# is an object-first prohibition, and \brun\b does not match "Running".
+_POS_RECO_RE = re.compile(
+    r"\b(?:always|prefer|use|run|call|invoke|execute)\b", re.IGNORECASE
 )
 # Sentence boundary for the §4.2.5 negation guard: punctuation followed by
 # whitespace, so dots inside tokens (`.env.example`, `e.g.`-misfires aside)
@@ -452,7 +459,16 @@ def _extract_commands(lines):
         # recommends the command BEFORE the cue and negates only what follows.
         for sent in _SENT_SPLIT_RE.split(ln):
             neg = _NEG_RE.search(sent)
-            neg_at = len(sent) if (neg is None or _NEG_POSITIVE_RE.search(sent)) else neg.start()
+            if neg is None or _NEG_POSITIVE_RE.search(sent):
+                neg_at = len(sent)
+            elif _POS_RECO_RE.search(sent[: neg.start()]):
+                # Contrastive: a recommendation verb precedes the cue, so
+                # spans before the cue are positively recommended.
+                neg_at = neg.start()
+            else:
+                # Plain prohibition — even object-first ("`pnpm test` should
+                # never be run"): nothing in this sentence is recommended.
+                continue
             for m in _INLINE_RE.finditer(sent):
                 if m.start() > neg_at:
                     continue

--- a/skills/schliff/tests/unit/test_operational_coverage.py
+++ b/skills/schliff/tests/unit/test_operational_coverage.py
@@ -654,6 +654,51 @@ def test_negation_is_positional_within_sentence(tmp_path):
     assert not any("audit" in c for c in cmds)
 
 
+def test_negation_object_first_prohibition_not_credited(tmp_path):
+    """Adversarial-review finding (2026-07-07): a prohibition that names the
+    command BEFORE the negation cue ('`pnpm test` should never be run in CI')
+    must NOT credit the command — the positional guard only keeps before-cue
+    spans when the sentence is genuinely contrastive (a positive
+    recommendation verb precedes the cue)."""
+    r = _op(
+        tmp_path,
+        """# P
+
+## Testing
+
+- The `pnpm test` command should never be run in CI.
+- Running `pnpm build` is something you must never do here.
+- `pnpm install` should be avoided in this repo.
+""",
+    )
+    cmds = r["details"]["commands"]
+    assert not any("pnpm test" in c for c in cmds)
+    assert not any("pnpm build" in c for c in cmds)
+    assert not any("pnpm install" in c for c in cmds)
+
+
+def test_negation_contrastive_and_positive_paths_unaffected(tmp_path):
+    """Regression guards around the object-first fix: the contrastive keep
+    (#96), the plain positive credit, and the don't-forget positive idiom
+    must all survive."""
+    r = _op(
+        tmp_path,
+        """# P
+
+## Testing
+
+- Run `pnpm test`, never `npx jest` directly.
+- Use `make build` before packaging.
+- Don't forget to run `cargo fmt` before committing.
+""",
+    )
+    cmds = r["details"]["commands"]
+    assert "pnpm test" in cmds
+    assert not any("npx jest" in c for c in cmds)
+    assert "make build" in cmds
+    assert "cargo fmt" in cmds
+
+
 def test_negation_is_sentence_scoped(tmp_path):
     """§4.2.5: 'Never commit to main. Run `pnpm test` before pushing.' keeps
     the test credit; 'don't forget to run X' is a positive instruction; and


### PR DESCRIPTION
## What
Fixes all 3 confirmed findings from the closing adversarial review (24 agents, diverse-lens discovery → 3-skeptic refute-by-default verify → completeness critic) over everything shipped since v8.4.0.

| Finding | Severity | Fix |
| --- | --- | --- |
| Positional negation credits object-first prohibitions (`` `pnpm test` should never be run``) — regression from #96 | medium (proven, reproduced by hand) | before-cue spans credit only in genuinely contrastive sentences (base-form recommendation verb before the cue); plain prohibitions skip the sentence. Cue set extended to `avoid(ed/ing/s)` |
| badge.py leaks mkdtemp dir when the file write fails (unlink-before-rmdir in shared try) | low | `shutil.rmtree(ignore_errors=True)` |
| badge.py pins fallback badges ("unavailable", "no AGENTS.md") in the 24h+7d edge cache | low | fallback badges cache 60s/300s, only real scores cache long (short cache is now the `_send` default) |

Plus RELEASING.md: post-release web-surface redeploys (playground AND leaderboard — the live leaderboard seed sat on 8.1.0 until today) + v1 re-point are now checklist steps.

## Verification
- 2 new tests: object-first prohibitions not credited; contrastive/positive/don't-forget paths guarded — red first, green after
- Full suite **1358 green** — corpus goldens UNCHANGED, own AGENTS.md stays 91.6/A
- ruff clean
- Badge cache/leak fixes are web code → playground redeploy after merge, headers live-verified

Engine change batches unreleased on main per release policy (next release ships it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)