### PR TITLE
chore(release): v8.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.6.0] - 2026-07-20
+
 ### Added
 - **`check-commands`** — a deterministic CI gate that flags setup/build/test
   commands in an `AGENTS.md`/`CLAUDE.md` that don't resolve to a real make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **`check-commands`** — a deterministic CI gate that flags setup/build/test
+  commands in an `AGENTS.md`/`CLAUDE.md` that don't resolve to a real make
+  target, npm script, or path in the repo (exit 1 if dangling). Reuses the
+  `operational_coverage` command extractor (no scoring impact); false-positive
+  safe (unprovable absence → `unknown`, never `dangling`); live-hardened against
+  ~70 real repos. schliff dogfoods it against its own `AGENTS.md` in CI. (#112)
+
+### Fixed
+- **`operational_coverage` object-first prohibitions**, badge temp-dir leak, and
+  badge error caching (#110).
+
 ## [8.5.0] - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.5.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.5.0
+schliff v8.6.0
 
   structure             █████████░   90/100  great
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.5.0
 
 No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
 
-*Every number in this README comes from released `schliff==8.5.0` (`pip install schliff==8.5.0` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*Every number in this README comes from released `schliff==8.6.0` (`pip install schliff==8.6.0` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -186,7 +186,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.5.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.6.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -200,7 +200,7 @@ Prefer not to depend on a third-party action? The dependency-light equivalent:
 
 `schliff verify` exits non-zero when the score falls short and works for every
 supported format — the minimum is scaled by measurement coverage, so `SKILL.md`
-files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
+files without an eval suite aren't auto-failed. Requires schliff ≥ 8.6.0 for
 `AGENTS.md`: older engines scored it under the SKILL profile
 ([#101](https://github.com/Zandereins/schliff/issues/101)).
 
@@ -222,7 +222,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.5.0
+    rev: v8.6.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.5.0.**
+**Current version: 8.6.0.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.5.0"
+version = "8.6.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.5.0"
+__version__ = "8.6.0"


### PR DESCRIPTION
## What

**v8.6.0** — ships `check-commands` (the dangling-command CI gate, #112) plus the
`operational_coverage` object-first fix and badge fixes (#110), which have been
sitting unreleased on main.

## Why release now

`check-commands` is on main but not in PyPI 8.5.0 (verified: the shipping 8.5.0
wheel has no `command_resolution`), and the README already documents it — so
`pip install schliff` currently under-delivers what the README promises. This
release closes that drift and makes the feature real for users, the Action, and
outreach.

## Contents

- `check-commands` CLI — deterministic dangling-command gate, live-hardened
  against ~70 real repos, dogfooded against schliff's own AGENTS.md in CI.
- `operational_coverage` object-first prohibitions + badge temp-dir/error-caching
  fixes (#110).
- 3 version sources bumped in lockstep → 8.6.0 (`test_version_consistency` green).
- README/docs version refs + badge cache-bust; CHANGELOG rolled `[Unreleased]` → `[8.6.0]`.

## Verification

- `test_version_consistency` + `test_install_version` green; full suite **1371** green.
- README hero score re-verified **byte-identical** against the shipping engine —
  no number changed (the #110 fix didn't move schliff's own AGENTS.md score).

## Release steps (after merge — yours)

1. Create a GitHub Release, tag `v8.6.0` → triggers `publish.yml` → PyPI 8.6.0.
2. I repoint the `v1` float tag to the release commit so `uses: @v1` gets 8.6.0.
3. Post-release web maintenance (separate): playground engine-pin bump + deploy,
   leaderboard self-entry version.

## Deliberately NOT in this release

Integrating `check-commands` into the GitHub Action. `action.yml` is security-
hardened (every inline python uses `-P` against consumer-workspace attacker PRs);
that integration deserves its own spec + security review, and it needs
`check-commands` in PyPI first — which this release provides. It follows as a
separate, focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
