### PR TITLE
chore(version): finish 8.6.0 rollover (changelog links + leaderboard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,7 +575,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.5.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.0...HEAD
+[8.6.0]: https://github.com/Zandereins/schliff/compare/v8.5.0...v8.6.0
 [8.5.0]: https://github.com/Zandereins/schliff/compare/v8.4.0...v8.5.0
 [8.4.0]: https://github.com/Zandereins/schliff/compare/v8.3.0...v8.4.0
 [8.3.0]: https://github.com/Zandereins/schliff/compare/v8.2.0...v8.3.0

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.5.0",
+    "version": "8.6.0",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {


### PR DESCRIPTION
Backfills CHANGELOG footer compare-links the release bump missed + leaderboard self-entry version 8.5.0→8.6.0. No stale current-version reference remains repo-wide (only legitimate CHANGELOG history). Docs-only.