### PR TITLE
fix(check-commands): harden against false positives + DoS (v8.6.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.6.1] - 2026-07-21
+
+### Fixed
+- **`check-commands` false positives on real repos.** An adversarial review plus a
+  field sweep of real monorepos (palantir/blueprint, remotion, remix, swc) found
+  the 8.6.0 check reporting working commands as `dangling` — the exact
+  credibility-fatal error its conservative contract exists to prevent. All are now
+  correctly `resolved`/`unknown`; every fix only demotes `dangling`→`unknown`, so
+  the check can never gain a false claim, and `operational_coverage` is untouched
+  (scoring unchanged). Classes fixed:
+  - `cd sub/dir && npm run x` — the extractor drops the `cd`, so the script
+    resolved against the repo-root manifest (standard monorepo idiom).
+  - `(cd x && npm run build)` — the trailing paren clung to the token.
+  - `bun run index.ts` / `bun run dist/out.js` — bun resolves scripts, then files,
+    then binaries; absence is unprovable, so bun never yields `dangling`.
+  - `yarn tsc` / `yarn run x` — every yarn form falls back to `node_modules/.bin`.
+  - `make -C dir target` — the directory was read as the target.
+  - `pnpm run -r build` — the flag was read as the script name.
+  - `$(TARGETS):` and `%.o: %.c` — variable/pattern targets are not enumerable, so
+    the target set is treated as incomplete.
+- **`check-commands` denial-of-service on attacker-authored build files.** Parsing
+  a consumer's `Makefile`/`package.json` in CI is untrusted input:
+  - `include` fan-out had no visited-set (N**5 file opens; 15s at N=12) → iterative
+    worklist, O(files).
+  - the `include` regex backtracked quadratically on long whitespace (15.7s on one
+    800KB line) → linear.
+  - `include ../../outside` was opened (a read primitive outside the checkout) →
+    realpath-contained to the repo root.
+  - a deeply-nested `package.json` raised `RecursionError` (a `RuntimeError`, not
+    caught) and crashed the check → now degrades to `unknown`.
+
 ## [8.6.0] - 2026-07-20
 
 ### Added
@@ -575,7 +606,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.1...HEAD
+[8.6.1]: https://github.com/Zandereins/schliff/compare/v8.6.0...v8.6.1
 [8.6.0]: https://github.com/Zandereins/schliff/compare/v8.5.0...v8.6.0
 [8.5.0]: https://github.com/Zandereins/schliff/compare/v8.4.0...v8.5.0
 [8.4.0]: https://github.com/Zandereins/schliff/compare/v8.3.0...v8.4.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.1)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.6.0
+schliff v8.6.1
 
   structure             █████████░   90/100  great
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.6.0
 
 No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
 
-*Every number in this README comes from released `schliff==8.6.0` (`pip install schliff==8.6.0` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*Every number in this README comes from released `schliff==8.6.1` (`pip install schliff==8.6.1` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -186,7 +186,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.6.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.6.1'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -222,7 +222,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.6.0
+    rev: v8.6.1
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.6.0.**
+**Current version: 8.6.1.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/docs/specs/2026-07-19-command-resolution.md
+++ b/docs/specs/2026-07-19-command-resolution.md
@@ -75,7 +75,17 @@ pebble-navi `npm run debug`, fizzbuzz `npm run evals`, Orvion `make test`.
 3. **Conservative / false-positive-safe.** Report a command as `dangling` ONLY when
    resolution is unambiguous:
    - `make <target>` → a `Makefile`/`makefile` exists AND `<target>` is not a defined target.
-   - `npm run <script>` / `pnpm <script>` / `yarn <script>` → `package.json` exists AND `<script>` is not in its `scripts`.
+   - `npm run <script>`, bare npm lifecycle words, and `pnpm run <script>` →
+     `package.json` exists AND `<script>` is not in its `scripts`. **These are the
+     only dangling-capable package-manager forms** (amended 2026-07-20): they are
+     the ones whose manager hard-errors on a missing script (`npm error Missing
+     script`, `ERR_PNPM_NO_SCRIPT`). Every `yarn` form falls back to
+     `node_modules/.bin` (`yarn tsc` runs the typescript binary, and the binary
+     name need not match the package name), and `bun` resolves scripts, then
+     files, then binaries — for those, absence from `scripts` proves nothing, so
+     they are `unknown`. The original wording claimed `pnpm <script>` / `yarn
+     <script>` were dangling-capable; that was verified false and produced live
+     false positives.
    - explicit path/script reference (e.g. `./scripts/foo.sh`, `bash tools/x.sh`) → the path does not exist on disk.
    Everything else → `unknown` (NOT a defect). A false dangling claim burns the
    whole artifact, so silence beats a marginal call (ReDoS-report discipline).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.6.0"
+version = "8.6.1"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.6.0"
+__version__ = "8.6.1"

--- a/skills/schliff/scripts/scoring/command_resolution.py
+++ b/skills/schliff/scripts/scoring/command_resolution.py
@@ -32,7 +32,18 @@ _MAKE_TARGET_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9_.\-/]*)[ \t]*:(?!=)")
 # is still real — not following includes caused a false `make start` dangling on
 # authgear (start lives in makefiles/common.mk). We follow static relative
 # includes and fall back to `unknown` on any include we cannot resolve.
-_INCLUDE_RE = re.compile(r"^[ \t]*-?include[ \t]+(.+?)[ \t]*$")
+# The capture is greedy-to-end and stripped in Python. A lazy `(.+?)[ \t]*$`
+# backtracks quadratically on a long whitespace run (measured: 15.7s on one
+# 800KB line, vs 0.25ms here) — an attacker-authored Makefile is untrusted input
+# in CI, so the ReDoS shape must not survive. Verified byte-identical on every
+# include form (`include a.mk`, `  -include a.mk b.mk  `, tabs, `includefoo`).
+_INCLUDE_RE = re.compile(r"^[ \t]*-?include[ \t]+(.*)")
+# Hard bounds for parsing untrusted build files. `_make_targets` follows includes;
+# without a visited-set the depth cap alone allowed N**5 fan-out (measured 15.0s
+# at N=12 through the real CLI). Budgets bound work even when the graph is legal.
+_MAX_INCLUDE_FILES = 64
+_MAX_MAKEFILE_BYTES = 1_048_576
+_MAX_PKG_JSON_BYTES = 2_097_152
 # Leading `VAR=value` env-assignments precede the real command
 # (`BASE_PATH=/x npm run build`) — skip them so the value is not read as a path.
 _ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
@@ -63,44 +74,84 @@ def _find_makefile(repo_root: str) -> str | None:
     return None
 
 
-def _make_targets(makefile: str, _depth: int = 0) -> tuple[set[str], bool]:
+def _make_targets(makefile: str, repo_root: str) -> tuple[set[str], bool]:
     """Return (defined targets, unresolved_include). ``unresolved_include`` is
     True when the makefile pulls in an include we cannot statically follow
-    (variable/glob path, missing file, or too-deep nesting) — in that case a
-    target we did not find may still exist, so the caller must not claim dangling.
+    (variable/glob path, missing file, escaping path, or an exhausted budget) —
+    in that case a target we did not find may still exist, so the caller must not
+    claim dangling.
+
+    Iterative worklist with a realpath visited-set: every Makefile is parsed at
+    most once, so include diamonds and cycles cost O(files), not O(N**depth).
+    Includes are contained to ``repo_root`` — before this, `include ../../etc/x`
+    was opened, giving attacker-authored build files a read primitive outside the
+    checkout.
     """
     targets: set[str] = set()
     unresolved = False
     try:
-        with open(makefile, encoding="utf-8", errors="replace") as fh:
-            lines = fh.readlines()
+        root = os.path.realpath(repo_root)
+        queue = [os.path.realpath(makefile)]
     except OSError:
         return set(), True
-    for line in lines:
-        m = _MAKE_TARGET_RE.match(line)
-        if m:
-            targets.add(m.group(1).lower())
-        inc = _INCLUDE_RE.match(line)
-        if inc:
-            for part in inc.group(1).split():
-                if "$" in part or "*" in part or "?" in part or _depth >= 5:
+    visited: set[str] = set()
+    while queue:
+        path = queue.pop()
+        if path in visited:
+            continue
+        if len(visited) >= _MAX_INCLUDE_FILES:
+            return targets, True
+        visited.add(path)
+        try:
+            if os.path.getsize(path) > _MAX_MAKEFILE_BYTES:
+                unresolved = True
+                continue
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                lines = fh.readlines()
+        except OSError:
+            unresolved = True
+            continue
+        for line in lines:
+            m = _MAKE_TARGET_RE.match(line)
+            if m:
+                targets.add(m.group(1).lower())
+            inc = _INCLUDE_RE.match(line)
+            if not inc:
+                continue
+            for part in inc.group(1).strip().split():
+                if "$" in part or "*" in part or "?" in part:
                     unresolved = True
                     continue
-                inc_path = os.path.normpath(os.path.join(os.path.dirname(makefile), part))
-                if os.path.isfile(inc_path):
-                    sub, sub_unresolved = _make_targets(inc_path, _depth + 1)
-                    targets |= sub
-                    unresolved = unresolved or sub_unresolved
+                try:
+                    inc_path = os.path.realpath(
+                        os.path.normpath(os.path.join(os.path.dirname(path), part))
+                    )
+                    contained = os.path.commonpath([root, inc_path]) == root
+                except (OSError, ValueError):
+                    unresolved = True
+                    continue
+                if not contained:
+                    # Never open it: an escaping include is unprovable *and* a
+                    # read primitive. realpath first, so symlinks cannot escape.
+                    unresolved = True
+                elif os.path.isfile(inc_path):
+                    if inc_path not in visited:
+                        queue.append(inc_path)
                 else:
                     unresolved = True
     return targets, unresolved
 
 
 def _pkg_scripts(package_json: str) -> set[str] | None:
+    # RecursionError is a RuntimeError, NOT a ValueError, so it used to escape
+    # this handler: a ~20KB deeply-nested package.json crashed the whole check.
+    # Size alone does not bound it (the payload is tiny), hence both guards.
     try:
+        if os.path.getsize(package_json) > _MAX_PKG_JSON_BYTES:
+            return None
         with open(package_json, encoding="utf-8") as fh:
             data = json.load(fh)
-    except (OSError, ValueError):
+    except (OSError, ValueError, RecursionError):
         return None
     if not isinstance(data, dict):
         return None
@@ -115,15 +166,39 @@ def _pm_script(verb: str, args: list[str]) -> str | None:
     script invocation (or too ambiguous to claim)."""
     if verb not in ("npm", "pnpm", "yarn", "bun"):
         return None
-    if args and args[0] == "run" and len(args) >= 2:
-        return args[1]
+    if args and args[0] == "run":
+        # The script is the first NON-FLAG token after `run`; `pnpm run -r build`
+        # and `pnpm run --silent build` used to read the flag as the script name
+        # and report `script '-r' is not defined`.
+        for a in args[1:]:
+            if not a.startswith("-"):
+                return a
+        return None
     if not args or args[0].startswith("-"):
         return None
     first = args[0]
     if verb == "npm":
         return first if first in _NPM_LIFECYCLE else None
-    # pnpm / yarn / bun: an unknown (non-builtin) word runs the matching script.
+    # pnpm / yarn / bun: an unknown (non-builtin) word MAY run the matching
+    # script — but yarn/bun also fall back to a node_modules/.bin binary, so
+    # absence is not provable here. See `_pm_absence_provable`.
     return first if first not in _PM_BUILTINS else None
+
+
+def _pm_absence_provable(verb: str, args: list[str]) -> bool:
+    """True only for invocation forms where a missing script is a *hard error*,
+    so 'not in package.json' proves the command is broken.
+
+    `npm run X` (npm error Missing script) and `pnpm run X` (ERR_PNPM_NO_SCRIPT)
+    qualify. Every yarn form falls back to `node_modules/.bin` (`yarn tsc` runs
+    the typescript binary), and bun resolves scripts, then files, then binaries —
+    for those, absence from `scripts` proves nothing. The bare pnpm/yarn/bun
+    shorthand has the same fallback, so it is unprovable too.
+    """
+    if args and args[0] == "run":
+        return verb in ("npm", "pnpm")
+    # bare lifecycle word: only npm maps these to scripts with a hard error.
+    return verb == "npm"
 
 
 def _clean_tokens(cmd: str) -> list[str]:
@@ -134,6 +209,12 @@ def _clean_tokens(cmd: str) -> list[str]:
         if t.startswith("#"):  # inline comment starts here
             toks = toks[:j]
             break
+    # Subshell punctuation clings to the tokens after segment splitting:
+    # `(cd pkg && npm run build)` yields a segment whose last token is `build)`,
+    # which resolved as a script literally named "build)". Strip the grouping
+    # characters so the real name surfaces.
+    toks = [t.strip("()") for t in toks]
+    toks = [t for t in toks if t]
     k = 0
     while k < len(toks) and _ENV_ASSIGN_RE.match(toks[k]):
         k += 1
@@ -174,6 +255,12 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
 
     # 1) make <target>
     if verb == "make":
+        # `-C dir` / `-f file` retarget make at a different directory or makefile.
+        # The extractor lowercases, so `-C` arrives as `-c`. Without this guard the
+        # directory was read as the target: `make -C build test` reported
+        # "target 'build' is not defined" — a false dangling on a standard form.
+        if any(a in ("-c", "-f") or a.startswith(("-c", "-f", "--directory", "--file", "--makefile")) for a in args):
+            return "unknown", "make runs against another directory/makefile (-C/-f)"
         targets = [a for a in args if not a.startswith("-") and "=" not in a]
         if not targets:
             return "unknown", "make with no explicit target"
@@ -183,7 +270,7 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
         makefile = _find_makefile(repo_root)
         if makefile is None:
             return "unknown", "no Makefile in repo root"
-        defined, unresolved_include = _make_targets(makefile)
+        defined, unresolved_include = _make_targets(makefile, repo_root)
         if target.lower() in defined:
             return "resolved", f"make target '{target}' defined in {os.path.basename(makefile)}"
         if unresolved_include:
@@ -195,8 +282,11 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
     if script is not None:
         if _is_placeholder(script):
             return "unknown", f"'{script}' is a placeholder, not a concrete script"
-        if any(a == "-w" or a.startswith("--workspace") for a in args):
-            return "unknown", "workspace-scoped script (-w); resolves in a sub-package"
+        if any(
+            a in ("-w", "-r", "--recursive") or a.startswith(("--workspace", "--filter"))
+            for a in args
+        ):
+            return "unknown", "workspace-scoped script; resolves in a sub-package"
         package_json = os.path.join(repo_root, "package.json")
         if not os.path.isfile(package_json):
             return "unknown", "no package.json in repo root"
@@ -205,6 +295,22 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
             return "unknown", "package.json is unparseable"
         if script.lower() in scripts:
             return "resolved", f"npm script '{script}' defined in package.json"
+        # bun resolves scripts, then FILES, then binaries: `bun run index.ts` and
+        # bare `bun index.ts` execute the file. Codegen'd targets (`bun run
+        # dist/index.js`, built earlier in the same doc) mean a missing file
+        # proves nothing either — so bun never yields dangling here.
+        if verb == "bun":
+            if os.path.exists(os.path.normpath(os.path.join(repo_root, script))):
+                return "resolved", f"file '{script}' exists"
+            return "unknown", (
+                f"'{script}' is neither a package.json script nor a file on a clean "
+                "checkout; bun also resolves node_modules binaries"
+            )
+        if not _pm_absence_provable(verb, args):
+            return "unknown", (
+                f"script '{script}' is not in package.json scripts; {verb} may fall "
+                "back to a node_modules/.bin binary"
+            )
         return "dangling", f"script '{script}' is not defined in package.json scripts"
 
     # 3) explicit interpreter-run script / `./` executable
@@ -219,6 +325,49 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
         return "dangling", f"path '{path}' does not exist on a clean checkout"
 
     return "unknown", "no resolver for this command"
+
+
+_CD_VERBS = frozenset({"cd", "pushd", "popd"})
+
+
+def _cd_tainted_lines(lines: list[str]) -> set[int]:
+    """1-based line numbers whose commands run in a working directory we cannot
+    statically prove.
+
+    The extractor splits on `&&`/`;`/`|` and discards the `cd`, so
+    `cd packages/api && npm run lint` reaches resolution as a bare `npm run lint`
+    and was resolved against the ROOT manifest — a false dangling on the standard
+    monorepo idiom. We do not try to reconstruct the working directory (a design
+    that does *resolve* the cd target leaks context across subshells and creates
+    fresh false positives); we only mark the affected lines unprovable.
+
+    Inside a shell fence a `cd` persists for the rest of that fence. Outside, it
+    only affects its own line. Fence boundaries reset the state.
+    """
+    tainted: set[int] = set()
+    in_fence = False
+    fence_tainted = False
+    for i, raw in enumerate(lines, 1):
+        if raw.lstrip().startswith("```"):
+            in_fence = not in_fence
+            fence_tainted = False
+            continue
+        if in_fence and fence_tainted:
+            tainted.add(i)
+        line_tainted = False
+        for seg in re.split(r"&&|\|\||\||;", raw):
+            toks = [t for t in seg.strip().lstrip("$>#").strip().split() if t]
+            toks = [t.strip("()") for t in toks]
+            toks = [t for t in toks if t]
+            if line_tainted:
+                tainted.add(i)
+            if toks and toks[0].lower() in _CD_VERBS:
+                line_tainted = True
+                if in_fence:
+                    fence_tainted = True
+        if line_tainted:
+            tainted.add(i)
+    return tainted
 
 
 def _find_line(cmd: str, lines: list[str]) -> int | None:
@@ -237,6 +386,7 @@ def resolve_commands(text: str, repo_root: str) -> list[dict]:
     where status is ``resolved`` | ``dangling`` | ``unknown``.
     """
     lines = text.splitlines()
+    tainted = _cd_tainted_lines(lines)
     results: list[dict] = []
     seen: set[str] = set()
     for family, cmd in _extract_commands(lines):
@@ -244,11 +394,17 @@ def resolve_commands(text: str, repo_root: str) -> list[dict]:
             continue
         seen.add(cmd)
         status, evidence = _resolve_one(cmd, repo_root)
+        line = _find_line(cmd, lines)
+        # Demote only — a cd context makes absence unprovable, but a target we
+        # DID find is still real, so `resolved` is never downgraded.
+        if status == "dangling" and line in tainted:
+            status = "unknown"
+            evidence = "runs after a 'cd'; the working directory is not statically resolvable"
         results.append({
             "command": cmd,
             "family": family,
             "status": status,
             "evidence": evidence,
-            "line": _find_line(cmd, lines),
+            "line": line,
         })
     return results

--- a/skills/schliff/scripts/scoring/command_resolution.py
+++ b/skills/schliff/scripts/scoring/command_resolution.py
@@ -28,6 +28,13 @@ _MAKEFILE_NAMES = ("Makefile", "makefile", "GNUmakefile")
 # `name =`). The negative lookahead `(?!=)` rejects `:=`; assignments with a
 # space (`NAME = v`) have no colon so never match.
 _MAKE_TARGET_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9_.\-/]*)[ \t]*:(?!=)")
+# A rule whose target name is variable- or pattern-expanded (`$(TARGETS):`,
+# `%.o: %.c`, `$(BIN)/foo:`) defines targets we cannot enumerate statically. If a
+# Makefile contains ANY such rule its target set is incomplete, so absence of a
+# queried target is unprovable -> the caller must not claim dangling. Matches a
+# non-recipe (not tab-indented) line whose left-hand side before a `:` (not `:=`)
+# contains `$` or `%`. Assignments (`VAR := $(X)`) are excluded by the `(?!=)`.
+_MAKE_DYNAMIC_TARGET_RE = re.compile(r"^(?![\t#])[^:#]*[$%][^:#]*:(?!=)")
 # `include foo.mk` / `-include foo.mk`. A target defined in an included makefile
 # is still real — not following includes caused a false `make start` dangling on
 # authgear (start lives in makefiles/common.mk). We follow static relative
@@ -115,6 +122,9 @@ def _make_targets(makefile: str, repo_root: str) -> tuple[set[str], bool]:
             m = _MAKE_TARGET_RE.match(line)
             if m:
                 targets.add(m.group(1).lower())
+            elif _MAKE_DYNAMIC_TARGET_RE.match(line):
+                # Variable/pattern target: the target set is not fully knowable.
+                unresolved = True
             inc = _INCLUDE_RE.match(line)
             if not inc:
                 continue

--- a/skills/schliff/tests/unit/test_command_resolution.py
+++ b/skills/schliff/tests/unit/test_command_resolution.py
@@ -279,3 +279,74 @@ def test_include_regex_has_no_quadratic_backtracking(tmp_path):
     start = time.monotonic()
     resolve_commands(agents, str(tmp_path))
     assert time.monotonic() - start < 5.0
+
+
+def test_variable_expanded_make_target_is_unknown(tmp_path):
+    """`$(TARGETS): build test lint` defines targets via variable expansion; the
+    target regex cannot see them, so `make test` was falsely dangling."""
+    (tmp_path / "Makefile").write_text("TARGETS := build test lint\n$(TARGETS):\n\t@echo $@\n")
+    agents = "# Agents\n\n```bash\nmake test\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "make test") == "unknown"
+
+
+def test_pattern_rule_makefile_is_unknown(tmp_path):
+    """A Makefile with a `%.o: %.c` pattern rule has non-enumerable targets."""
+    (tmp_path / "Makefile").write_text("%.o: %.c\n\t@echo compile\nbuild:\n\t@echo hi\n")
+    agents = "# Agents\n\n```bash\nmake test\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "make test") == "unknown"
+
+
+def test_static_makefile_still_reports_dangling(tmp_path):
+    """The dynamic-target guard must not over-trigger: a purely static Makefile
+    (even with `:=` assignments containing `$` and `:`) still proves absence."""
+    (tmp_path / "Makefile").write_text(
+        "VAR := $(shell echo hi)\nURL := http://example.com\nbuild:\n\t@echo hi\n"
+    )
+    agents = "# Agents\n\n```bash\nmake test\nmake build\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "make test") == "dangling"
+    assert _status(results, "make build") == "resolved"
+
+
+# --- Field regressions: real repos where shipped 8.6.0 emitted false danglings.
+# Per feedback_field_test_over_fixtures, each real-world false positive is pinned
+# by a test named after the repo that produced it. Verified 2026-07-21 against
+# fresh clones: 8.6.0 reported these dangling, the hardened engine does not.
+
+
+def test_field_blueprint_pnpm_nx_binary_is_unknown(tmp_path):
+    """palantir/blueprint AGENTS.md: `pnpm nx compile @blueprintjs/core`. `nx` is
+    a node_modules/.bin workspace tool, not a package.json script — 8.6.0 reported
+    "script 'nx' is not defined" (false)."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = "# Agents\n\n```bash\npnpm nx compile @blueprintjs/core\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "pnpm nx compile") == "unknown"
+
+
+def test_field_remotion_bun_run_dev_is_unknown(tmp_path):
+    """remotion-dev/remotion AGENTS.md: `bun run dev`. bun resolves scripts, then
+    files, then binaries — 8.6.0 reported "script 'dev' is not defined" (false)."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = "# Agents\n\n```bash\nbun run dev\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "bun run dev") == "unknown"
+
+
+def test_field_swc_subshell_cd_path_is_unknown(tmp_path):
+    """swc-project/swc AGENTS.md: `(cd crates/... && ./scripts/test.sh)`. 8.6.0
+    reported "path './scripts/test.sh)' does not exist" — wrong name (glued paren)
+    AND a false claim. The paren strip removes the `)`; the `cd` then makes the
+    path's location unprovable, so it degrades to unknown, not a false dangling."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "test.sh").write_text("#!/bin/sh\necho hi\n")
+    agents = "# Agents\n\n```bash\n(cd crates/swc && ./scripts/test.sh)\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    # The credibility-critical property: the path must NOT be a false dangling.
+    # (It resolves to the root script; the cd only demotes dangling->unknown, never
+    # resolved->dangling, so the safe direction is preserved either way.)
+    assert not any(r["status"] == "dangling" for r in results)
+    assert _status(results, "test.sh") in ("resolved", "unknown")

--- a/skills/schliff/tests/unit/test_command_resolution.py
+++ b/skills/schliff/tests/unit/test_command_resolution.py
@@ -123,3 +123,159 @@ def test_duplicate_command_reported_once(tmp_path):
     agents = "# A\n\n```bash\nnpm run dev\n```\n\n## Again\n\n```bash\nnpm run dev\n```\n"
     results = resolve_commands(agents, str(tmp_path))
     assert sum(1 for r in results if "dev" in r["command"]) == 1
+
+
+# --- Hardening regressions (2026-07-20) -------------------------------------
+# Each test below pins a defect class that was verified live against the shipped
+# 8.6.0 engine during an adversarial review. All five false-positive classes made
+# the check claim a working command was broken — the exact failure the spec's
+# conservative contract exists to prevent.
+
+
+def test_compound_cd_is_unknown_not_dangling(tmp_path):
+    """`cd pkg && npm run x` — the extractor drops the cd, so the script used to
+    be resolved against the ROOT manifest and reported dangling. Standard
+    monorepo idiom; a false claim here would be published on a consumer's PR."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    api = tmp_path / "packages" / "api"
+    api.mkdir(parents=True)
+    (api / "package.json").write_text('{"scripts": {"lint": "eslint ."}}')
+    agents = "# Agents\n\n```bash\ncd packages/api && npm run lint\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run lint") == "unknown"
+
+
+def test_fence_scoped_cd_taints_following_lines(tmp_path):
+    """A bare `cd` persists for the rest of the shell fence."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n\n```bash\ncd packages/api\nnpm run lint\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run lint") == "unknown"
+
+
+def test_cd_never_downgrades_a_resolved_command(tmp_path):
+    """The cd demotion is one-directional: a target we DID find is still real."""
+    (tmp_path / "package.json").write_text('{"scripts": {"lint": "eslint ."}}')
+    agents = "# Agents\n\n```bash\ncd packages/api && npm run lint\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run lint") == "resolved"
+
+
+def test_subshell_parens_stripped(tmp_path):
+    """`(cd x && npm run build)` left `build)` glued to the segment, which
+    resolved as a script literally named "build)" and was reported dangling."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = "# Agents\n\n```bash\n(cd packages/api && npm run build)\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "build") == "resolved"
+
+
+def test_bun_run_file_is_resolved(tmp_path):
+    """bun resolves scripts, then FILES: `bun run index.ts` executes the file."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    (tmp_path / "index.ts").write_text("console.log(1)\n")
+    agents = "# Agents\n\n```bash\nbun run index.ts\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "bun run index.ts") == "resolved"
+
+
+def test_bun_missing_target_is_never_dangling(tmp_path):
+    """Codegen'd outputs (`bun run dist/index.js`) make absence unprovable."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n\n```bash\nbun run dist/index.js\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "dist/index.js") == "unknown"
+
+
+def test_yarn_bareword_is_unknown(tmp_path):
+    """`yarn tsc` runs node_modules/.bin/tsc — absence from `scripts` proves
+    nothing, and the bin name need not match the package name."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n\n```bash\nyarn tsc\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "yarn tsc") == "unknown"
+
+
+def test_yarn_run_is_unknown_but_pnpm_run_is_dangling(tmp_path):
+    """pnpm run hard-errors (ERR_PNPM_NO_SCRIPT) so absence is provable; every
+    yarn form falls back to node_modules/.bin, so it is not."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n\n```bash\nyarn run build\n```\n"
+    assert _status(resolve_commands(agents, str(tmp_path)), "yarn run build") == "unknown"
+    agents = "# Agents\n\n```bash\npnpm run build\n```\n"
+    assert _status(resolve_commands(agents, str(tmp_path)), "pnpm run build") == "dangling"
+
+
+def test_pm_run_flag_is_not_the_script_name(tmp_path):
+    """`pnpm run -r build` read `-r` as the script and reported
+    "script '-r' is not defined"."""
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n\n```bash\npnpm run -r build\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "pnpm run -r build") == "unknown"
+
+
+def test_make_dash_c_directory_is_not_a_target(tmp_path):
+    """`make -C build test` read the DIRECTORY as the target and reported
+    "target 'build' is not defined"."""
+    (tmp_path / "Makefile").write_text("test:\n\t@echo root\n")
+    agents = "# Agents\n\n```bash\nmake -C build test\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "build") == "unknown"
+
+
+def test_make_include_fanout_is_bounded(tmp_path):
+    """No visited-set meant N-way includes fanned out N**5: measured 15.0s at
+    N=12 through the real CLI. Bounds the work, and pins the correct targets."""
+    import time
+
+    inc = "include " + " ".join(["a.mk"] * 20) + "\n"
+    (tmp_path / "Makefile").write_text(inc + "build:\n\t@echo hi\n")
+    (tmp_path / "a.mk").write_text(inc + "lint:\n\t@echo x\n")
+    agents = "# Agents\n\n```bash\nmake lint\n```\n"
+    start = time.monotonic()
+    results = resolve_commands(agents, str(tmp_path))
+    assert time.monotonic() - start < 5.0
+    assert _status(results, "make lint") == "resolved"  # target from the include
+
+
+def test_make_include_cycle_terminates(tmp_path):
+    (tmp_path / "Makefile").write_text("include a.mk\nbuild:\n\t@echo hi\n")
+    (tmp_path / "a.mk").write_text("include Makefile\nlint:\n\t@echo x\n")
+    agents = "# Agents\n\n```bash\nmake lint\n```\n"
+    assert _status(resolve_commands(agents, str(tmp_path)), "make lint") == "resolved"
+
+
+def test_make_include_outside_repo_is_not_followed(tmp_path):
+    """`include ../outside.mk` was opened, giving an attacker-authored Makefile a
+    read primitive outside the checkout. Now contained -> unresolved -> unknown."""
+    (tmp_path / "outside.mk").write_text("lint:\n\t@echo leak\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Makefile").write_text("include ../outside.mk\nbuild:\n\t@echo hi\n")
+    agents = "# Agents\n\n```bash\nmake lint\n```\n"
+    results = resolve_commands(agents, str(repo))
+    # The out-of-tree target must NOT be ingested, and absence is unprovable.
+    assert _status(results, "make lint") == "unknown"
+
+
+def test_deeply_nested_package_json_does_not_crash(tmp_path):
+    """RecursionError is a RuntimeError, not a ValueError, so it escaped the
+    handler: a ~20KB nested package.json crashed the whole check."""
+    (tmp_path / "package.json").write_text("[" * 5000 + "]" * 5000)
+    agents = "# Agents\n\n```bash\nnpm run build\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run build") == "unknown"
+
+
+def test_include_regex_has_no_quadratic_backtracking(tmp_path):
+    """A lazy `(.+?)[ \\t]*$` backtracked quadratically on a long whitespace run:
+    15.7s for one 800KB line of attacker-authored Makefile."""
+    import time
+
+    payload = "include " + ("a" + " " * 4000) * 200 + "\n"
+    (tmp_path / "Makefile").write_text("lint:\n\t@echo hi\n" + payload)
+    agents = "# Agents\n\n```bash\nmake lint\n```\n"
+    start = time.monotonic()
+    resolve_commands(agents, str(tmp_path))
+    assert time.monotonic() - start < 5.0


### PR DESCRIPTION
## Summary

Patch release **v8.6.1** hardening the `check-commands` gate shipped in 8.6.0.
An adversarial multi-agent review plus a **field sweep of real monorepos** found
8.6.0 reporting working commands as `dangling` — the exact credibility-fatal error
its conservative contract exists to prevent — and two DoS vectors when parsing an
attacker-authored `Makefile`/`package.json` in a consumer's CI.

**No API or scoring change.** `operational_coverage` is untouched; golden scores are
byte-identical. Every fix only demotes `dangling`→`unknown`, so the check can never
*gain* a false claim from this change.

## Field proof (real repos, verified 2026-07-21)

Shipped 8.6.0 vs this branch, `check-commands` on 4 real root-`AGENTS.md` monorepos:

| Repo | 8.6.0 | this branch |
|------|------:|------------:|
| palantir/blueprint | **5 false danglings** (`pnpm nx …`, `pnpm test:vitest:run`) | 0 |
| remotion-dev/remotion | **2** (`bun run dev/start`) | 0 |
| swc-project/swc | **1** (`(cd … && ./scripts/test.sh)`) | 0 |
| remix-run/remix | 0 | 0 |

`resolved` counts stay healthy (6/11/3/2) — the check is not merely degrading
everything to `unknown`. Each real-world FP is pinned as a repo-named regression test.

## False positives fixed

- `cd sub/dir && npm run x` — extractor drops the `cd`; script resolved against the
  repo-root manifest (standard monorepo idiom).
- `(cd x && npm run build)` — trailing paren clung to the token.
- `bun run index.ts` / `bun run dist/out.js` — bun resolves scripts→files→binaries;
  absence unprovable, so bun never yields `dangling`.
- `yarn tsc` / `yarn run x` — every yarn form falls back to `node_modules/.bin`.
- `make -C dir target` — the directory was read as the target.
- `pnpm run -r build` — the flag was read as the script name.
- `$(TARGETS):` / `%.o: %.c` — variable/pattern targets aren't enumerable.

## DoS / containment fixed (attacker-authored build files in CI)

- `include` fan-out: no visited-set → N**5 file opens (15s at N=12). Now an
  iterative worklist, O(files); 0.13s at N=20.
- `include` regex backtracked quadratically on long whitespace (15.7s on one 800KB
  line). Now linear (0.14s), byte-identical on every include form.
- `include ../../outside` was opened (read primitive outside the checkout). Now
  realpath-contained to the repo root.
- deeply-nested `package.json` raised `RecursionError` (a `RuntimeError`, uncaught)
  and crashed the check. Now degrades to `unknown`.

## Verification

- `pytest`: **1392 passed** (1371 baseline + 21 new: hardening + field regressions).
- `ruff==0.15.8`: clean.
- Dogfood gate (own `AGENTS.md`): 0 dangling, exit 0.
- Wheel builds as `schliff-8.6.1`, all three fixes bundled.
- 3 version sources in lockstep (gated by `test_version_consistency`); CHANGELOG +
  compare link + secondary display refs updated.

Merge + PyPI release (GitHub Release → OIDC publish) intentionally left to the
maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)