### PR TITLE
docs(readme): correct AGENTS.md verify floor to >= 8.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Prefer not to depend on a third-party action? The dependency-light equivalent:
 
 `schliff verify` exits non-zero when the score falls short and works for every
 supported format — the minimum is scaled by measurement coverage, so `SKILL.md`
-files without an eval suite aren't auto-failed. Requires schliff ≥ 8.6.0 for
+files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
 `AGENTS.md`: older engines scored it under the SKILL profile
 ([#101](https://github.com/Zandereins/schliff/issues/101)).
 


### PR DESCRIPTION
One-line README accuracy fix. Line 203 said `schliff verify AGENTS.md` requires `>= 8.6.0`, but the #101 SKILL-profile bug it cites was fixed in **8.5.0** (#102).

**Verified empirically** against real PyPI installs — no guessing from the changelog:

| Version | `score AGENTS.md` | `verify AGENTS.md` |
|---|---|---|
| 8.4.0 | 91.6 | **27.7 [F]** ← SKILL-profile bug |
| 8.5.0 | 91.6 | **91.6 [A]** ← #101 fixed here |
| 8.6.0 | 91.6 | 91.6 [A] |
| 8.6.1 | 91.6 | 91.6 [A] |

The score is stable at 91.6 from 8.4.0 on (8.6.0's #110 did not move it), and `verify` starts matching `score` at 8.5.0. Both put the floor at **8.5.0**. The `#101` citation stays correct; only the version number was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)