### PR TITLE
fix(command-resolution): harden dangling check against workspace FPs + DoS

### DIFF
--- a/docs/specs/2026-07-21-command-resolution-hotfix.md
+++ b/docs/specs/2026-07-21-command-resolution-hotfix.md
@@ -1,0 +1,209 @@
+# Spec: Command Resolution Hotfix (post-review hardening)
+
+**Status:** implemented — PR open, not yet merged
+**Branch:** `fix/command-resolution-hotfix`
+**Date:** 2026-07-21
+**Supersedes decisions in:** `2026-07-19-command-resolution.md` §"Technical decisions"
+(the `_find_line` post-hoc line scan is retired here — see Fix 4).
+
+## Outcome (verified 2026-07-21)
+
+All 6 fixes shipped in `command_resolution.py` (Fixes 1–5) + `operational_coverage.py`
+(Fix 4 extractor widening). Fix 6 was a no-op (already shipped). 11 new tests, all
+red-first then green. **Full suite 1392 → 1403 green; golden opcov/profile 28
+byte-identical (hard gate held); ruff clean; CLI dogfood gate 0 dangling.**
+
+**Field verification (the load-bearing evidence)** — OLD (main `2387838`) vs NEW over
+the sweep corpus (**140 repos / 170 instruction files / 0 crashes**): OLD = 17
+danglings, NEW = 4. **All 13 demotions are WORKSPACE-justified** (1× Chainlit
+pnpm-workspace, 12× kmarkussen workspaces-key); zero accidental demotions via
+cd/budget/threading, so no real dangling was masked outside genuine workspace repos
+(the deliberate false-positive-safe posture). The 4 remaining are unchanged: 3 TRUE
+(cervellone `npm run install-all`; SuperClaude `make dev`, `test:coverage` — stale
+docs) + 1 deferred prose-FALSE (SuperClaude `npm run build`, "inside pm/" — the
+out-of-scope fast-follow). The memory's "~8 FALSE" estimate was per-repo; the true
+instance count is 13, same class.
+
+## Goal
+
+Harden the v8.6.1 dangling-command check (`scripts/scoring/command_resolution.py`)
+against the defects surfaced by a large adversarial review + council + field sweep
+(2026-07-21) — **without** a redesign and **without** touching golden scores. The
+single load-bearing outcome is: eliminate the one **real** false-positive class the
+field sweep found, and close the two council-CATASTROPHIC availability defects.
+
+## Context / why now
+
+Review pipeline (single source of truth: memory `project_command_resolution_review.md`):
+
+- **60-agent adversarial review → 12 reproduced defect classes**, all 14/14 red
+  against the real engine.
+- **hydra deep (82% HIGH, 2 REJECT / 4 CONCERN)** verdict: *BLOCK a broader
+  distribution push; ship a cheap-wins hotfix (days, no redesign); the allowlist
+  invert is a corpus-validated fast-follow, not a release blocker.*
+- **Field sweep over 135 real repos (177 instruction files, 0 crashes)** corrected
+  the council's priority ordering — see below.
+
+### The field-sweep finding (drives the priority order)
+
+17 dangling claims across 135 real repos → **~8 FALSE, ~9 TRUE** (each verified
+against source). **None of the ~8 real FALSE positives is one of the 12 fixture
+classes.** grouped-make / `--if-present` / quoted / `sinclude` / mixed-case fired
+**zero** times as a real FALSE. The real FALSE positives are all the **same deeper
+class**:
+
+> `npm/pnpm run <script>` where the script lives in a **workspace child / subdir**
+> and the directory context sits in a table column or "inside X/" prose (no `cd`).
+> The engine only checks the **root** manifest — it knows nothing about workspaces.
+
+So the fixtures are real defects but **not** the field FP source. The engine-level
+fix for this class outranks the five cheap edge fixes in real-world relevance.
+
+### Δ found during verify (refute-by-default)
+
+Council fix #1 was "`fail-on-dangling` default → `false` (opt-in)". Verified against
+the shipped code: `action.yml:29` already has `default: 'false'`, introduced opt-in
+in **#118 (4ba6c2c)**. **Fix #1 is a no-op** — already satisfied. But the PR comment
+renders the dangling table **independently of the gate** (`action.yml:287-304`), so
+FALSE danglings no longer fail CI yet remain **visible** in every consumer PR
+comment. The only lever that closes this at the root is the engine fix (Fix 1
+below), not `action.yml`.
+
+## Requirements (unchanged invariants)
+
+1. **Additive, zero scoring impact.** MUST NOT change `score_operational_coverage`,
+   dimension weights, or any golden score. `_extract_commands` may gain a widened
+   return contract (Fix 4) **only if** the corpus goldens stay byte-identical
+   (gated by the golden test after the change).
+2. **Conservative / false-positive-safe.** A command is `dangling` ONLY when absence
+   is provable. Every new rule here **demotes** `dangling → unknown`; it never
+   creates a new `dangling` and never downgrades a `resolved`.
+3. **Deterministic + stdlib-only.** No clock/entropy/network. Same file+repo → same
+   result.
+4. **Field-tested, not fixture-tested.** Every new FP fix is verified against the
+   real repo that motivates it and pinned as a repo-named regression test; the TRUE
+   repos are pinned as "stays-dangling" tests so the new rule masks no real defect.
+
+## Fixes (priority order = real-world relevance, not council numbering)
+
+### Fix 1 — Workspace-aware demotion (the real FP source) — [core]
+
+In `_resolve_one`, immediately before the terminal `return "dangling"` in the
+package-manager block (`command_resolution.py:324`): if the script is not in the
+**root** `package.json` scripts **and** the repo declares workspaces, return
+`unknown` instead of `dangling`.
+
+"Repo declares workspaces" =
+- root `package.json` has a `workspaces` key (array, or `{ "packages": [...] }`), **or**
+- `pnpm-workspace.yaml` / `pnpm-workspace.yml` exists in the repo root.
+
+Rationale: with workspaces the script may legitimately live in a child package; the
+root manifest is not authoritative, so absence is unprovable → `unknown`. This is
+the exact conservative posture the module already takes for `-w`/`--filter`
+(`command_resolution.py:295-299`); it just also fires when the workspace context is
+declared by the manifest rather than by an explicit flag.
+
+**Scope decision (Franz, 2026-07-21):** *manifest signal only.* The second field
+sub-class — directory context in a table column / "inside X/" prose with no `cd`
+(SuperClaude_Framework case) — is a fragile heuristic and is **deferred** to a
+separate fast-follow with its own field sweep. It is out of scope here.
+
+Empirically fixes Chainlit (`pnpm run dev`, has pnpm workspace) and
+kmarkussen/vs-code-work-share-plugin (`npm run compile/watch/dev`, ws=True).
+SuperClaude_Framework stays FALSE until the deferred prose fix.
+
+### Fix 2 — DoS input-budget guard + manifest memoization — [council CATASTROPHIC]
+
+At the top of `resolve_commands`, one global budget guard. Caps (field-validated:
+observed MAX over 177 files = 56 cmds / 926 lines / 964 line-len → these clip no
+real repo):
+
+- lines per doc: **5000**
+- bytes per line: **2048**
+- distinct commands: **256**
+
+On overflow, every extracted command is reported `unknown` (evidence: input budget
+exceeded) **without** calling `_resolve_one` — i.e. no manifest parsing, no
+per-command filesystem work. This bounds the compound DoS (a tiny attacker-authored
+doc driving ~6h of CI work through the resolver).
+
+Plus **memoize** the manifest parses (`_pkg_scripts`, `_make_targets`,
+`_repo_has_workspaces`) via a per-call cache dict threaded into `_resolve_one` — no
+process-global state (temp-repo reuse across tests must not cross-contaminate).
+
+### Fix 3 — realpath containment for the interpreter path check — [edge]
+
+`command_resolution.py:331` uses `os.path.abspath` for repo-root containment on the
+interpreter-run script path. `abspath` does not resolve symlinks, so a symlinked
+path inside the checkout is an existence oracle / weak escape. Use `os.path.realpath`
+(matching `_make_targets`, which already realpaths — `command_resolution.py:100`).
+
+### Fix 4 — Retire `_find_line`; thread the real line from `_extract_commands` — [correctness, golden-touching]
+
+`_find_line` (`command_resolution.py:383-389`) recovers the report line by scanning
+for a substring match. Three defects:
+- **quadratic DoS** — O(distinct-cmds × lines) substring scan.
+- **cd-taint puncture** — a command that appears on two lines resolves the line to
+  the *first* match, which may not be the tainted one, so the `dangling → unknown`
+  cd demotion (`command_resolution.py:410`) can be bypassed.
+- **`line` field corruption** — the reported line can point at a prose mention
+  rather than the extracted command's real line.
+
+Fix: widen `_extract_commands` to return `(family, norm, lineno)` (additive third
+element), and thread the real line through `resolve_commands`. Retires all three
+defects at once.
+
+**Scope decision (Franz, 2026-07-21):** *full additive threading* (not the
+conservative inline-demote fallback). This reverses the deliberate
+`2026-07-19-command-resolution.md:105-107` choice to keep the extractor
+`(family, command)`-shaped. That choice is safe to reverse **because** the only
+other consumer (`operational_coverage.py:604-607`) uses value-only comprehensions
+(`{norm for _fam, norm in cmds}`) — the widened arity changes unpacking, not values.
+**Gate:** the golden opcov/profile test MUST stay byte-identical after this change;
+if it drifts, the change is wrong.
+
+### Fix 5 — Dequote script token + handle `--if-present` — [edge]
+
+- Dequote the script token in `_pm_script` (`npm run "build"` → `build`) so a quoted
+  script name is not read literally.
+- `npm run <script> --if-present` is **not** a hard error on a missing script
+  (npm exits 0), so it is not dangling → treat as `unknown` in
+  `_pm_absence_provable`.
+
+### Fix 6 — `fail-on-dangling` default (already satisfied) — [no-op, document only]
+
+Verified: `action.yml:29` already ships `default: 'false'` (opt-in, #118). No code
+change. Documented here so the council checklist is closed against the real code.
+
+## Regression-test plan (field-named, per Franz's field-test rule)
+
+New FP fixes pinned against the real repos that motivate them:
+
+- **FALSE → now `unknown`:** Chainlit/chainlit `pnpm run dev`;
+  kmarkussen/vs-code-work-share-plugin `npm run compile|watch|dev`.
+- **TRUE → stays `dangling`** (guards against over-demotion): Orsati/cervellone-game
+  `npm run install-all` (no workspaces); a non-workspace repo whose `npm run X` is a
+  genuine typo must still be caught.
+
+Each new rule gets a synthetic unit test **and** a field-shaped test (mini-repo with
+the real manifest shape). Fixtures alone are not field-ready.
+
+## Verification gates (after every step)
+
+- full suite green (baseline to be re-measured on branch before first edit);
+- **golden opcov/profile byte-identical** (hard gate for Fix 4);
+- `ruff` clean;
+- new rules field-verified against the named real repos.
+
+## Non-goals
+
+- No redesign, no allowlist invert (council: corpus-validated fast-follow, separate).
+- No prose/table directory-context heuristic (deferred fast-follow — see Fix 1).
+- No `action.yml` behavior change (Fix 6 is already shipped).
+- No new `dangling` verdicts — this hotfix only demotes and hardens.
+
+## Open questions / fast-follows
+
+- Prose/"inside X/" directory-context demotion (SuperClaude_Framework class) — needs
+  its own field sweep before it is safe.
+- Allowlist invert — separate corpus-validated change.

--- a/skills/schliff/scripts/scoring/command_resolution.py
+++ b/skills/schliff/scripts/scoring/command_resolution.py
@@ -171,6 +171,39 @@ def _pkg_scripts(package_json: str) -> set[str] | None:
     return {str(k).lower() for k in scripts}
 
 
+_PNPM_WORKSPACE_NAMES = ("pnpm-workspace.yaml", "pnpm-workspace.yml")
+
+
+def _repo_has_workspaces(repo_root: str) -> bool:
+    """True when the repo declares a workspace/monorepo layout, so a `<pm> run
+    <script>` may legitimately live in a child package the root manifest does not
+    list. The field sweep (135 real repos) found this is the ONLY real source of
+    false danglings: the engine checks only the root manifest.
+
+    Signals: a ``pnpm-workspace.yaml``/``.yml`` (pnpm), or a truthy ``workspaces``
+    key in the root ``package.json`` (npm/yarn/bun — an array, or a
+    ``{"packages": [...]}`` object). An empty/false value is not a workspace.
+    """
+    for name in _PNPM_WORKSPACE_NAMES:
+        if os.path.isfile(os.path.join(repo_root, name)):
+            return True
+    package_json = os.path.join(repo_root, "package.json")
+    try:
+        if os.path.getsize(package_json) > _MAX_PKG_JSON_BYTES:
+            return False
+        with open(package_json, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError, RecursionError):
+        return False
+    return isinstance(data, dict) and bool(data.get("workspaces"))
+
+
+def _dequote(tok: str) -> str:
+    """Strip matching surrounding quotes: `npm run "build"` names the `build`
+    script, not a literal `"build"`."""
+    return tok.strip("'\"")
+
+
 def _pm_script(verb: str, args: list[str]) -> str | None:
     """The package.json script a `<pm> ...` invocation runs, or None if not a
     script invocation (or too ambiguous to claim)."""
@@ -182,11 +215,11 @@ def _pm_script(verb: str, args: list[str]) -> str | None:
         # and report `script '-r' is not defined`.
         for a in args[1:]:
             if not a.startswith("-"):
-                return a
+                return _dequote(a)
         return None
     if not args or args[0].startswith("-"):
         return None
-    first = args[0]
+    first = _dequote(args[0])
     if verb == "npm":
         return first if first in _NPM_LIFECYCLE else None
     # pnpm / yarn / bun: an unknown (non-builtin) word MAY run the matching
@@ -205,6 +238,10 @@ def _pm_absence_provable(verb: str, args: list[str]) -> bool:
     for those, absence from `scripts` proves nothing. The bare pnpm/yarn/bun
     shorthand has the same fallback, so it is unprovable too.
     """
+    # `--if-present` makes a missing script exit 0 (npm/pnpm/yarn all honor it),
+    # so absence is not an error -> not provable.
+    if "--if-present" in args:
+        return False
     if args and args[0] == "run":
         return verb in ("npm", "pnpm")
     # bare lifecycle word: only npm maps these to scripts with a hard error.
@@ -257,7 +294,18 @@ def _is_placeholder(name: str) -> bool:
     return any(c in name for c in "*<>$?") or name in ("...", "…")
 
 
-def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
+def _memo(cache: dict, key: str, producer):
+    """Per-call memo: repo_root is constant across all commands in one
+    ``resolve_commands`` call, so each manifest is parsed at most once instead of
+    once per command (the compound-DoS multiplier the council flagged). The cache
+    is call-scoped (never process-global) so tests reusing a repo path can't
+    cross-contaminate."""
+    if key not in cache:
+        cache[key] = producer()
+    return cache[key]
+
+
+def _resolve_one(cmd: str, repo_root: str, cache: dict) -> tuple[str, str]:
     tokens = _clean_tokens(cmd)
     if not tokens:
         return "unknown", "empty command"
@@ -277,10 +325,12 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
         target = targets[0]
         if _is_placeholder(target):
             return "unknown", f"'{target}' is a placeholder, not a concrete target"
-        makefile = _find_makefile(repo_root)
+        makefile = _memo(cache, "makefile", lambda: _find_makefile(repo_root))
         if makefile is None:
             return "unknown", "no Makefile in repo root"
-        defined, unresolved_include = _make_targets(makefile, repo_root)
+        defined, unresolved_include = _memo(
+            cache, "make_targets", lambda: _make_targets(makefile, repo_root)
+        )
         if target.lower() in defined:
             return "resolved", f"make target '{target}' defined in {os.path.basename(makefile)}"
         if unresolved_include:
@@ -300,7 +350,7 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
         package_json = os.path.join(repo_root, "package.json")
         if not os.path.isfile(package_json):
             return "unknown", "no package.json in repo root"
-        scripts = _pkg_scripts(package_json)
+        scripts = _memo(cache, "pkg_scripts", lambda: _pkg_scripts(package_json))
         if scripts is None:
             return "unknown", "package.json is unparseable"
         if script.lower() in scripts:
@@ -321,6 +371,14 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
                 f"script '{script}' is not in package.json scripts; {verb} may fall "
                 "back to a node_modules/.bin binary"
             )
+        if _memo(cache, "workspaces", lambda: _repo_has_workspaces(repo_root)):
+            # Root manifest is not authoritative in a monorepo — the script may
+            # live in a workspace child. Absence is unprovable -> unknown, never
+            # dangling. (The field sweep's one real false-positive class.)
+            return "unknown", (
+                f"script '{script}' is not in the root package.json, but the repo "
+                "declares workspaces; it may be defined in a workspace package"
+            )
         return "dangling", f"script '{script}' is not defined in package.json scripts"
 
     # 3) explicit interpreter-run script / `./` executable
@@ -328,7 +386,17 @@ def _resolve_one(cmd: str, repo_root: str) -> tuple[str, str]:
     if path is not None:
         full = os.path.normpath(os.path.join(repo_root, path))
         # Only claim on paths that stay inside the repo; escapes are unprovable.
-        if os.path.commonpath([os.path.abspath(repo_root), os.path.abspath(full)]) != os.path.abspath(repo_root):
+        # realpath (not abspath) resolves symlinks first, so a symlinked path that
+        # points outside the checkout escapes here instead of turning os.path.exists
+        # into an existence oracle for external files. Matches _make_targets, which
+        # already realpaths its include containment.
+        try:
+            root_real = os.path.realpath(repo_root)
+            full_real = os.path.realpath(full)
+            contained = os.path.commonpath([root_real, full_real]) == root_real
+        except (OSError, ValueError):
+            return "unknown", f"path '{path}' is not statically resolvable"
+        if not contained:
             return "unknown", f"path '{path}' escapes repo root"
         if os.path.exists(full):
             return "resolved", f"path '{path}' exists"
@@ -380,13 +448,17 @@ def _cd_tainted_lines(lines: list[str]) -> set[int]:
     return tainted
 
 
-def _find_line(cmd: str, lines: list[str]) -> int | None:
-    toks = [t for t in cmd.lower().split() if t]
-    for i, ln in enumerate(lines, 1):
-        low = ln.lower()
-        if all(t in low for t in toks):
-            return i
-    return None
+# Input-budget caps for untrusted docs (the resolver runs on attacker-authored
+# AGENTS.md in CI). Field-validated: observed MAX over 177 real instruction files
+# = 56 distinct commands / 926 lines / 964 line-length — these clip no real repo.
+# On overflow every command degrades to `unknown` with NO per-command resolution
+# (no manifest parsing / filesystem walk), bounding the compound DoS the council
+# flagged (a ~60-byte doc driving hours of CI work).
+_MAX_DOC_LINES = 5000
+_MAX_LINE_BYTES = 2048
+_MAX_DISTINCT_CMDS = 256
+
+_BUDGET_EVIDENCE = "input exceeds the resolver's budget; not resolved (unknown)"
 
 
 def resolve_commands(text: str, repo_root: str) -> list[dict]:
@@ -396,20 +468,36 @@ def resolve_commands(text: str, repo_root: str) -> list[dict]:
     where status is ``resolved`` | ``dangling`` | ``unknown``.
     """
     lines = text.splitlines()
-    tainted = _cd_tainted_lines(lines)
+    # Budget guard (cheap, pre-resolution): oversized input degrades to all-unknown
+    # rather than driving unbounded resolver work.
+    over_budget = len(lines) > _MAX_DOC_LINES or any(
+        len(ln) > _MAX_LINE_BYTES for ln in lines
+    )
+    extracted = _extract_commands(lines)
+    if not over_budget and len({norm for _f, norm, _l in extracted}) > _MAX_DISTINCT_CMDS:
+        over_budget = True
+
+    # Skip the (regex-per-line) cd scan when nothing will be resolved anyway.
+    tainted = set() if over_budget else _cd_tainted_lines(lines)
+    cache: dict = {}  # per-call manifest memo (see _memo)
     results: list[dict] = []
     seen: set[str] = set()
-    for family, cmd in _extract_commands(lines):
+    # ``_extract_commands`` yields the real 1-based extraction line, so the report
+    # line is the actual source line (not a substring guess) and the cd demotion
+    # keys on the line the command was truly extracted from.
+    for family, cmd, line in extracted:
         if cmd in seen:  # same command listed twice — report once
             continue
         seen.add(cmd)
-        status, evidence = _resolve_one(cmd, repo_root)
-        line = _find_line(cmd, lines)
-        # Demote only — a cd context makes absence unprovable, but a target we
-        # DID find is still real, so `resolved` is never downgraded.
-        if status == "dangling" and line in tainted:
-            status = "unknown"
-            evidence = "runs after a 'cd'; the working directory is not statically resolvable"
+        if over_budget:
+            status, evidence = "unknown", _BUDGET_EVIDENCE
+        else:
+            status, evidence = _resolve_one(cmd, repo_root, cache)
+            # Demote only — a cd context makes absence unprovable, but a target we
+            # DID find is still real, so `resolved` is never downgraded.
+            if status == "dangling" and line in tainted:
+                status = "unknown"
+                evidence = "runs after a 'cd'; the working directory is not statically resolvable"
         results.append({
             "command": cmd,
             "family": family,

--- a/skills/schliff/scripts/scoring/operational_coverage.py
+++ b/skills/schliff/scripts/scoring/operational_coverage.py
@@ -431,11 +431,16 @@ def _classify(seg: str, inline: bool):
 
 
 def _extract_commands(lines):
-    """Return list of (family, normalized_segment) for real commands, doc-wide."""
+    """Return list of (family, normalized_segment, lineno) for real commands,
+    doc-wide. ``lineno`` is 1-based and points at the source line the segment came
+    from (all segments split from one line share its lineno). The line is additive:
+    the scoring consumer ignores it; the dangling-check threads it so the report
+    line is the real extraction line, not a substring guess (retires ``_find_line``).
+    """
     results = []
     in_fence = False
     lang = ""
-    for ln in lines:
+    for lineno, ln in enumerate(lines, 1):
         fm = _FENCE_RE.match(ln)
         if fm:
             if not in_fence:
@@ -450,7 +455,7 @@ def _extract_commands(lines):
                 for seg in _split_segments(ln):
                     fam = _classify(seg, inline=False)
                     if fam:
-                        results.append((fam, _norm(seg)))
+                        results.append((fam, _norm(seg), lineno))
             continue
         # §4.2.5: the negation guard is SENTENCE-scoped — "Never commit to
         # main. Run `pnpm test` before pushing." must keep the test credit —
@@ -475,7 +480,7 @@ def _extract_commands(lines):
                 for seg in _split_segments(m.group(1)):
                     fam = _classify(seg, inline=True)
                     if fam:
-                        results.append((fam, _norm(seg)))
+                        results.append((fam, _norm(seg), lineno))
     return results
 
 
@@ -602,9 +607,9 @@ def score_operational_coverage(skill_path: str) -> dict:
 
     lines = content.split("\n")
     cmds = _extract_commands(lines)
-    distinct_norms = {norm for _fam, norm in cmds}
+    distinct_norms = {norm for _fam, norm, _ln in cmds}
     distinct = len(distinct_norms)
-    families = {fam for fam, _norm in cmds}
+    families = {fam for fam, _norm, _ln in cmds}
 
     # Diversity (§4.2.4): a single distinct command resolves to a single family,
     # so the spec's ">=2 distinct before crediting all three" reduces to crediting

--- a/skills/schliff/tests/unit/test_command_resolution.py
+++ b/skills/schliff/tests/unit/test_command_resolution.py
@@ -350,3 +350,147 @@ def test_field_swc_subshell_cd_path_is_unknown(tmp_path):
     # resolved->dangling, so the safe direction is preserved either way.)
     assert not any(r["status"] == "dangling" for r in results)
     assert _status(results, "test.sh") in ("resolved", "unknown")
+
+
+# --- Hotfix 2026-07-21 (spec 2026-07-21-command-resolution-hotfix.md) ---
+
+
+def test_find_line_puncture_uses_real_extraction_line(tmp_path):
+    """`_find_line`'s loose substring scan matched an EARLIER prose line whose text
+    happens to contain the command tokens ("We make tests pass"), which was not
+    cd-tainted — bypassing the cd demotion and reporting a false dangling. The real
+    extraction is inside a fence after `cd`, so the threaded line must be tainted
+    and the command `unknown`, and the reported `line` must point at the real line."""
+    (tmp_path / "Makefile").write_text("lint:\n\truff check .\n")  # no `test` target
+    agents = (
+        "# Agents\n"
+        "We make tests pass here.\n"  # prose decoy: contains 'make' + 'test' substrings
+        "\n"
+        "```bash\n"
+        "cd subdir\n"
+        "make test\n"
+        "```\n"
+    )
+    results = resolve_commands(agents, str(tmp_path))
+    r = next(r for r in results if "make test" in r["command"])
+    assert r["status"] == "unknown"  # real line (6) is tainted, not the decoy (2)
+    assert r["line"] == 6
+
+
+# --- Field regressions: the REAL false-positive class (workspace/subdir scripts).
+# The field sweep over 135 real repos found every real FALSE dangling was the same
+# class: `npm/pnpm run <script>` where the script lives in a workspace child, not
+# the root manifest. Manifest shapes below are the real ones (verified against
+# fresh clones, 2026-07-21). The engine only checks the root manifest, so it must
+# demote to `unknown` when the repo declares workspaces.
+
+
+def test_field_kmarkussen_workspaces_npm_run_is_unknown(tmp_path):
+    """kmarkussen/vs-code-work-share-plugin: `npm run compile`. Root package.json
+    declares `workspaces` (as a `{packages: [...]}` object) and the script lives in
+    a workspace child, not root scripts — 8.6.1 reported it dangling (false)."""
+    (tmp_path / "package.json").write_text(
+        '{"workspaces": {"packages": ["@m/extension", "@m/server"]},'
+        ' "scripts": {"build": "tsc", "dev:extension": "x"}}'
+    )
+    agents = "# Agents\n\n```bash\nnpm run compile\nnpm run watch\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run compile") == "unknown"
+    assert _status(results, "npm run watch") == "unknown"
+
+
+def test_field_chainlit_pnpm_workspace_yaml_is_unknown(tmp_path):
+    """Chainlit/chainlit: `pnpm run dev`. The repo has a pnpm-workspace.yaml and
+    `dev` lives in the frontend/ workspace, not the root scripts — 8.6.1 reported it
+    dangling (false)."""
+    (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - frontend/\n")
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc", "lint": "x"}}')
+    agents = "# Agents\n\n```bash\npnpm run dev\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "pnpm run dev") == "unknown"
+
+
+def test_field_cervellone_no_workspaces_stays_dangling(tmp_path):
+    """Orsati/cervellone-game: `npm run install-all` — a genuine dangling (the doc
+    names a script the root package.json does not define, and the repo has NO
+    workspaces). The workspace demotion must NOT over-fire and mask this."""
+    (tmp_path / "package.json").write_text(
+        '{"scripts": {"start": "x", "dev": "y", "dev-admin": "z"}}'
+    )
+    agents = "# Agents\n\n```bash\nnpm run install-all\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run install-all") == "dangling"
+
+
+# --- DoS input-budget guard (council CATASTROPHIC: a tiny attacker-authored doc
+# driving unbounded resolver work). On overflow every command degrades to
+# `unknown` with no per-command resolution. Caps are field-validated (observed MAX
+# over 177 files = 56 cmds / 926 lines / 964 line-len) and clip no real repo.
+
+
+def test_dos_budget_line_count_overflow_is_all_unknown(tmp_path):
+    (tmp_path / "package.json").write_text('{"scripts": {}}')  # would be dangling
+    agents = "# Agents\n" + ("\n" * 5001) + "```bash\nnpm run build\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert results and all(r["status"] == "unknown" for r in results)
+
+
+def test_dos_budget_long_line_overflow_is_all_unknown(tmp_path):
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    agents = "# Agents\n" + ("x" * 3000) + "\n```bash\nnpm run build\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert results and all(r["status"] == "unknown" for r in results)
+
+
+def test_dos_budget_distinct_command_overflow_is_all_unknown(tmp_path):
+    (tmp_path / "package.json").write_text('{"scripts": {}}')
+    body = "\n".join(f"npm run build{i}" for i in range(300))  # 300 distinct > 256
+    agents = f"# Agents\n\n```bash\n{body}\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert results and all(r["status"] == "unknown" for r in results)
+
+
+def test_within_budget_still_resolves(tmp_path):
+    # A normal-sized doc must still resolve dangling — the guard must not over-fire.
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = "# Agents\n\n```bash\nnpm run build\nnpm run missing\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "npm run build") == "resolved"
+    assert _status(results, "npm run missing") == "dangling"
+
+
+# --- Edge hardening (council cheap-wins) ---
+
+
+def test_symlinked_path_escaping_repo_is_unknown_not_an_oracle(tmp_path):
+    """A symlinked dir pointing outside the checkout turns `os.path.exists` into an
+    existence oracle for external files. `abspath` containment did not resolve the
+    symlink, so the escape looked contained; `realpath` closes it -> unknown."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "setup.sh").write_text("#!/bin/sh\n")  # setup.* is a classified family
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "link").symlink_to(outside)  # repo/link -> ../outside
+    agents = "# Agents\n\n```bash\nbash link/setup.sh\n```\n"
+    results = resolve_commands(agents, str(repo))
+    r = next(r for r in results if "setup.sh" in r["command"])
+    assert r["status"] == "unknown"  # escapes the repo via symlink; not an oracle
+
+
+def test_quoted_script_name_is_dequoted(tmp_path):
+    """`npm run "build"` — the quoted token was read literally as `"build"` and
+    reported dangling. Dequote so it resolves to the real script."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = '# Agents\n\n```bash\nnpm run "build"\n```\n'
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "build") == "resolved"
+
+
+def test_npm_run_if_present_is_not_dangling(tmp_path):
+    """`npm run <script> --if-present` exits 0 when the script is missing (not a
+    hard error), so absence proves nothing -> unknown, never dangling."""
+    (tmp_path / "package.json").write_text('{"scripts": {"build": "tsc"}}')
+    agents = "# Agents\n\n```bash\nnpm run coverage --if-present\n```\n"
+    results = resolve_commands(agents, str(tmp_path))
+    assert _status(results, "coverage") == "unknown"


### PR DESCRIPTION
## Summary

Post-review hotfix for the v8.6.1 dangling-command check (`command_resolution.py`), following the 2026-07-21 adversarial review + hydra-deep council (82% HIGH: *block a broader push, ship a cheap-wins hotfix, no redesign*) + a **135-repo field sweep**. Spec: `docs/specs/2026-07-21-command-resolution-hotfix.md`.

**Every rule here demotes `dangling → unknown`. None creates a new `dangling` or downgrades a `resolved`.**

The field sweep's key correction: the *real* false-positive class is **workspace/subdir scripts**, not the 12-class fixture catalog (which fired **zero** real FALSE positives across 135 repos). The engine only checks the root manifest.

## Fixes (priority = field relevance)

1. **Workspace-aware demotion** — `<pm> run <script>` missing from the root `package.json` is `unknown`, not dangling, when the repo declares workspaces (`pnpm-workspace.yaml` or a truthy `workspaces` key). Fixes Chainlit / kmarkussen.
2. **DoS input-budget guard** — 5000 lines / 2048 bytes-per-line / 256 distinct commands (field-validated: real MAX 56/926/964) → all-unknown with no per-command work, plus per-call manifest memoization. Bounds the council's compound-DoS.
3. **realpath containment** — closes the symlink existence-oracle in the interpreter path check.
4. **Retire `_find_line`** — thread the real 1-based line from `_extract_commands` (additive 3-tuple). Kills the quadratic scan, the cd-taint puncture, and the line-field corruption. **opcov golden stays byte-identical.**
5. **Dequote + `--if-present`** — quoted script token dequoted; `--if-present` (missing script is not a hard error) → unknown.
6. **`fail-on-dangling`** — verified already opt-in (`default: false`, shipped in #118). No-op, documented only. **No `action.yml` change.**

## Scope decisions (out of scope, fast-follows)

- Prose/table directory-context demotion (SuperClaude "inside pm/" class) — fragile heuristic, deferred to its own field sweep.
- Allowlist invert — corpus-validated separate change (council: not a release blocker).

## Verification

- **1392 → 1403 tests green** (11 new, each red-first). `golden` + `agents_md_profile` **28 byte-identical** (hard gate). `ruff` clean. CLI dogfood gate 0 dangling.
- **Field diff, OLD (`2387838`) vs NEW over 140 real repos / 170 instruction files / 0 crashes:** 17 danglings → 4. **All 13 demotions workspace-justified** (1× Chainlit, 12× kmarkussen); zero accidental demotions via cd/budget/threading → no real dangling masked outside genuine workspace repos. The 4 remaining are unchanged (3 TRUE + 1 deferred prose-FALSE).

No release / version bump in this PR — merge and any release are left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)