### PR TITLE
chore(release): bump to 8.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.6.2] - 2026-07-21
+
 ### Added
 - **GitHub Action surfaces dangling commands.** The `AGENTS.md Lint` action now
   runs `check-commands` for `AGENTS.md`/`CLAUDE.md` and renders any dangling
   commands as a section in its existing PR comment. New opt-in `fail-on-dangling`
   input (default `false`) and `dangling_count` output. Requires schliff ≥ 8.6.1
   for false-positive-safe behavior; older engines degrade silently.
+
+### Fixed
+- **`check-commands` workspace false positives + resolver hardening.** A large
+  adversarial review + council + a field sweep of 135 real repos found the 8.6.1
+  check still reporting working commands as `dangling` on monorepos. Every change
+  only demotes `dangling`→`unknown` (never a new false claim); `operational_coverage`
+  is untouched, so scoring is byte-identical. A field diff over 140 real repos: 17 →
+  4 dangling claims, every removal workspace-justified.
+  - **Workspace-aware demotion** (the real false-positive class): a `<pm> run <script>`
+    missing from the ROOT manifest is `unknown`, not `dangling`, when the repo declares
+    workspaces (`pnpm-workspace.yaml` or a truthy `workspaces` key) — the script may
+    live in a child package.
+  - **Denial-of-service input-budget guard** on attacker-authored docs (5000 lines /
+    2048 bytes-per-line / 256 distinct commands → all-`unknown`, no per-command work),
+    plus per-call memoization of manifest parses.
+  - **realpath containment** for the interpreter path check, closing a symlink
+    existence-oracle.
+  - **Accurate report lines** — the real extraction line is threaded from the
+    extractor, retiring a quadratic substring scan that could mislocate the line and
+    bypass the `cd` demotion.
+  - **Dequoted script tokens** and `--if-present` handling (a missing script is not a
+    hard error) → `unknown`.
 
 ## [8.6.1] - 2026-07-21
 
@@ -613,7 +637,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.1...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.2...HEAD
+[8.6.2]: https://github.com/Zandereins/schliff/compare/v8.6.1...v8.6.2
 [8.6.1]: https://github.com/Zandereins/schliff/compare/v8.6.0...v8.6.1
 [8.6.0]: https://github.com/Zandereins/schliff/compare/v8.5.0...v8.6.0
 [8.5.0]: https://github.com/Zandereins/schliff/compare/v8.4.0...v8.5.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.1)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.2)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.6.1
+schliff v8.6.2
 
   structure             █████████░   90/100  great
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.6.1
 
 No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
 
-*Every number in this README comes from released `schliff==8.6.1` (`pip install schliff==8.6.1` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*Every number in this README comes from released `schliff==8.6.2` (`pip install schliff==8.6.2` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -186,7 +186,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.6.1'` in the
+lead an older pinned install; pin it with `schliff-version: '8.6.2'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -222,7 +222,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.6.1
+    rev: v8.6.2
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.6.1.**
+**Current version: 8.6.2.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/playground/pyproject.toml
+++ b/playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "app"
 version = "0.1.0"
-dependencies = [ "schliff==8.6.1" ]
+dependencies = [ "schliff==8.6.2" ]
 requires-python = "~=3.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.6.1"
+__version__ = "8.6.2"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.6.1",
+    "version": "8.6.2",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {


### PR DESCRIPTION
## Summary

Release bump for **8.6.2**, packaging two already-merged changes that were still Unreleased:
- **#121** — command-resolution hotfix (workspace false-positives + DoS hardening). *The engine change since 8.6.1.*
- **#118** — the GitHub Action dangling-command surface (action-only, versioned via the `v1` tag).

Since the only **PyPI-package** change since 8.6.1 is #121 (bugfixes), this is a **patch**.

## What changed

- **3 canonical version sources in lockstep** (gated by `test_version_consistency`): `pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`.
- **Secondary refs:** README PyPI badge `&v=`, hero example, reproduce-pin (`schliff==`), `schliff-version:` example, pre-commit `rev:`; `docs/README.md` "Current version"; `playground/pyproject.toml` pin; leaderboard seed `submissions.json`.
- **CHANGELOG:** `[Unreleased]` → `[8.6.2] - 2026-07-21` (with the hotfix entry) + fresh `[Unreleased]` + compare footer.
- **Deliberately NOT bumped:** feature-floor strings (`action.yml` "requires schliff >= 8.6.1", "older than 8.6.1") — these are availability floors, not the current release.

## Verification

- `test_version_consistency` green; full suite **1403 green**; `ruff` clean.
- README hero score **re-verified against the real engine: 91.6/A, byte-identical** (opcov untouched by #121).
- grep-clean: every remaining `8.6.1` is a legit feature-floor or CHANGELOG history entry.

## Post-merge (human-gated, not in this PR)

- Publish the GitHub Release `v8.6.2` → triggers OIDC test-gated `publish.yml` → PyPI.
- Vercel prod redeploys for playground (pin) + leaderboard (seed) — inert until redeployed.
- README PyPI badge camo cache-bust happens automatically via the `&v=8.6.2` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)