### PR TITLE
chore(release): bump to 8.6.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.6.3] - 2026-07-22
+
+### Security
+- **Hardened the engine against untrusted input in third-party CI.** A pre-launch
+  adversarial audit reproduced these before fixing; no golden score changes
+  (`operational_coverage`/profile byte-identical).
+  - **ReDoS** in the security exfil/env-leak patterns: the greedy `[^\n]*` after a
+    verb prefix was O(n²) on a newline-free line (~1h CPU at the 1MB read cap,
+    reachable ungated via a `.txt` that auto-detects as a system prompt). Bounded to
+    `[^\n]{0,200}`.
+  - **Quadratic DoS** in the clarity scorer (runs on every default instruction-file
+    score): the action-pair extractor scanned the full tail of a newline-free line
+    per match (~3min at the cap). Bounded the tail slice.
+  - **Filesystem-boundary oracles** in `check-commands`: a symlinked `Makefile`/
+    `package.json` or an escaping `bun run <path>` was read/probed outside the repo
+    root, turning resolved/dangling verdicts into an out-of-repo content/existence
+    oracle. Added a `realpath`+`commonpath` containment guard at each manifest read.
+
+### Fixed
+- **`--format <alias>` token budget.** The short aliases (`cursor`, `agents`,
+  `claude`, `skill`, `system-prompt`) fell back to the unknown=1500 budget instead
+  of their real one, flipping the within-budget verdict. They now resolve via
+  `FORMAT_ALIASES` before the lookup.
+- **Dead playground link.** The Action's PR comment linked `play.schliff.dev`
+  (never registered, NXDOMAIN); repointed to the live playground.
+
 ## [8.6.2] - 2026-07-21
 
 ### Added
@@ -637,7 +663,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.2...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.3...HEAD
+[8.6.3]: https://github.com/Zandereins/schliff/compare/v8.6.2...v8.6.3
 [8.6.2]: https://github.com/Zandereins/schliff/compare/v8.6.1...v8.6.2
 [8.6.1]: https://github.com/Zandereins/schliff/compare/v8.6.0...v8.6.1
 [8.6.0]: https://github.com/Zandereins/schliff/compare/v8.5.0...v8.6.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.2)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.3)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.6.2
+schliff v8.6.3
 
   structure             █████████░   90/100  great
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.6.2
 
 No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
 
-*Every number in this README comes from released `schliff==8.6.2` (`pip install schliff==8.6.2` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*Every number in this README comes from released `schliff==8.6.3` (`pip install schliff==8.6.3` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -186,7 +186,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.6.2'` in the
+lead an older pinned install; pin it with `schliff-version: '8.6.3'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -222,7 +222,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.6.2
+    rev: v8.6.3
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.6.2.**
+**Current version: 8.6.3.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/playground/pyproject.toml
+++ b/playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "app"
 version = "0.1.0"
-dependencies = [ "schliff==8.6.2" ]
+dependencies = [ "schliff==8.6.3" ]
 requires-python = "~=3.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.6.2"
+version = "8.6.3"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.6.2"
+__version__ = "8.6.3"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.6.2",
+    "version": "8.6.3",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {


### PR DESCRIPTION
Release bump for **8.6.3** — the pre-launch security batch 1 (#124, already merged).

- 3 canonical version sources in lockstep (gated by `test_version_consistency`).
- Secondary refs: README badge/hero/reproduce-pin/`schliff-version`/pre-commit, `docs/README.md`, `playground/pyproject.toml`, leaderboard seed.
- CHANGELOG `[Unreleased]` → `[8.6.3] - 2026-07-22` (Security + Fixed) + compare footer.

All engine changes are golden-neutral (hero 91.6/A unchanged). Feature-floor strings (`action.yml` >= 8.6.1) left unbumped.

Post-merge: publish the `v8.6.3` GitHub Release (→ OIDC → PyPI), relock the playground `uv.lock`, redeploy playground, and repoint the `v1` tag for the action.yml fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)