### PR TITLE
security(leaderboard): abuse-harden the public submit endpoint

### DIFF
--- a/skills/schliff/tests/unit/test_leaderboard_kv.py
+++ b/skills/schliff/tests/unit/test_leaderboard_kv.py
@@ -52,6 +52,9 @@ class FakeRedis:
             for f, v in self.hashes.get(key, {}).items():
                 flat.extend([f, v])
             return flat  # REST returns a flat [field, value, ...] array
+        if op == "HGET":
+            _, key, field = args
+            return self.hashes.get(key, {}).get(field)
         if op == "HEXISTS":
             _, key, field = args
             return 1 if field in self.hashes.get(key, {}) else 0
@@ -170,9 +173,11 @@ def test_upsert_rejects_new_identity_when_full_but_allows_updates(kv, monkeypatc
     # store now holds MAX_SUBMISSIONS distinct entries -> a brand-new identity is refused
     with pytest.raises(submit.LeaderboardFullError):
         submit._kv_upsert(cfg, _entry(skill="c", repo="https://github.com/u/c"))
-    # ...but updating an EXISTING identity still works (no lock-out of real users)
+    # ...but updating an EXISTING identity still works (no lock-out of real users).
+    # Use a non-downgrade update (95 >= 90) so the cap check is exercised
+    # independently of the grief-downgrade refusal (tested separately below).
     assert submit._kv_upsert(
-        cfg, {**_entry(skill="a", repo="https://github.com/u/a"), "composite": 1.0}) is True
+        cfg, {**_entry(skill="a", repo="https://github.com/u/a"), "composite": 95.0}) is True
     assert len(kv.hashes[submit.SUBMISSIONS_KEY]) == 2  # cap held
 
 
@@ -284,3 +289,45 @@ def test_real_seed_both_same_repo_rows_survive_union(kv, monkeypatch):
     monkeypatch.setattr(query, "SEED_PATH", str(real_seed))
     loaded = query._kv_load_all(query._kv_config())  # empty KV -> seed only
     assert {"schliff", "shieldclaw"} <= {e["skill_name"] for e in loaded}
+
+
+# --- abuse hardening (audit 2026-07-22): #17 grief-downgrade, #18 spoofable IP ---
+
+class _FakeHandler:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+def test_client_ip_prefers_unspoofable_x_real_ip():
+    # x-real-ip is set by Vercel's proxy; it must win over a spoofed leftmost XFF.
+    h = _FakeHandler({"x-real-ip": "9.9.9.9", "x-forwarded-for": "1.2.3.4, 5.6.7.8"})
+    assert submit._client_ip(h) == "9.9.9.9"
+
+
+def test_client_ip_uses_rightmost_xff_not_attacker_leftmost():
+    # The leftmost XFF hop is client-controlled; key the limit on the rightmost
+    # (trusted-proxy) hop so a spoofer can neither bypass nor target a victim.
+    h = _FakeHandler({"x-forwarded-for": "1.2.3.4, 203.0.113.9"})
+    assert submit._client_ip(h) == "203.0.113.9"
+
+
+def test_client_ip_unknown_when_no_headers():
+    assert submit._client_ip(_FakeHandler({})) == "unknown"
+
+
+def test_kv_upsert_refuses_grief_downgrade(kv):
+    cfg = submit._kv_config()
+    submit._kv_upsert(cfg, {**_entry(skill="a"), "composite": 90.0})
+    with pytest.raises(submit.DowngradeRefusedError):
+        submit._kv_upsert(cfg, {**_entry(skill="a"), "composite": 5.0})
+    # the victim's row is intact
+    import json as _json
+    field = submit._dedup_field(_entry(skill="a")["repo_url"], "a")
+    assert _json.loads(kv.hashes[submit.SUBMISSIONS_KEY][field])["composite"] == 90.0
+
+
+def test_kv_upsert_allows_equal_or_higher(kv):
+    cfg = submit._kv_config()
+    submit._kv_upsert(cfg, {**_entry(skill="a"), "composite": 90.0})
+    assert submit._kv_upsert(cfg, {**_entry(skill="a"), "composite": 90.0}) is True  # equal ok
+    assert submit._kv_upsert(cfg, {**_entry(skill="a"), "composite": 95.0}) is True  # higher ok

--- a/web/leaderboard/api/query.py
+++ b/web/leaderboard/api/query.py
@@ -162,11 +162,19 @@ def _dedup_field(repo_url, skill_name):
 
 
 def _client_ip(handler):
-    """Best-effort client IP from Vercel's forwarding headers."""
+    """Best-effort client IP for rate-limit keying. ``x-real-ip`` is set by Vercel's
+    trusted proxy and is not client-spoofable, so prefer it. For ``x-forwarded-for``
+    the RIGHTMOST hop is the one the trusted proxy appended; the leftmost is
+    attacker-controlled — keying the limit on it lets a spoofer both bypass their own
+    limit (rotate the left value) and target a victim (spoof the victim's IP to burn
+    their bucket)."""
+    real = handler.headers.get("x-real-ip", "").strip()
+    if real:
+        return real
     fwd = handler.headers.get("x-forwarded-for", "")
     if fwd:
-        return fwd.split(",")[0].strip()
-    return handler.headers.get("x-real-ip", "") or "unknown"
+        return fwd.split(",")[-1].strip() or "unknown"
+    return "unknown"
 
 
 def _kv_rate_limited(cfg, key, limit, window):

--- a/web/leaderboard/api/submit.py
+++ b/web/leaderboard/api/submit.py
@@ -267,6 +267,13 @@ class ReservedIdentityError(Exception):
     This is an authorization refusal (-> 403), not a malformed request."""
 
 
+class DowngradeRefusedError(Exception):
+    """The (repo_url, skill_name) already holds a HIGHER composite. The board is
+    unauthenticated, so an overwrite that LOWERS an existing row is grief (anyone
+    can zero out a victim's entry). Refuse it (-> 409); genuine re-scores that raise
+    or hold the score still pass. Full ownership proof is out of scope (see #16)."""
+
+
 # --- reserved-identity guard (IDOR / unauthenticated-overwrite, LB-3) -----------
 # The board is unauthenticated and self-reported, so anyone can HSET-overwrite any
 # (repo_url, skill_name) row. Acceptable for community rows (all verified:false) but
@@ -340,11 +347,19 @@ def _dedup_field(repo_url, skill_name):
 
 
 def _client_ip(handler):
-    """Best-effort client IP from Vercel's forwarding headers."""
+    """Best-effort client IP for rate-limit keying. ``x-real-ip`` is set by Vercel's
+    trusted proxy and is not client-spoofable, so prefer it. For ``x-forwarded-for``
+    the RIGHTMOST hop is the one the trusted proxy appended; the leftmost is
+    attacker-controlled — keying the limit on it lets a spoofer both bypass their own
+    limit (rotate the left value) and target a victim (spoof the victim's IP to burn
+    their bucket)."""
+    real = handler.headers.get("x-real-ip", "").strip()
+    if real:
+        return real
     fwd = handler.headers.get("x-forwarded-for", "")
     if fwd:
-        return fwd.split(",")[0].strip()
-    return handler.headers.get("x-real-ip", "") or "unknown"
+        return fwd.split(",")[-1].strip() or "unknown"
+    return "unknown"
 
 
 def _kv_rate_limited(cfg, key, limit, window):
@@ -372,10 +387,19 @@ def _kv_upsert(cfg, entry):
     if _is_reserved_identity(entry["repo_url"], entry["skill_name"]):
         raise ReservedIdentityError
     field = _dedup_field(entry["repo_url"], entry["skill_name"])
-    # Bound growth: once the store is full, refuse brand-new identities but keep
-    # accepting updates to existing rows. (HEXISTS->HLEN->HSET; the tiny TOCTOU
-    # window is acceptable for a DoS bound, not a precise invariant.)
-    if _kv_command(cfg, "HEXISTS", SUBMISSIONS_KEY, field) == 0:
+    existing_raw = _kv_command(cfg, "HGET", SUBMISSIONS_KEY, field)
+    if existing_raw:
+        # Refuse a grief downgrade (an overwrite that LOWERS the stored composite).
+        refuse = False
+        try:
+            refuse = float(json.loads(existing_raw).get("composite", 0)) > float(entry["composite"])
+        except (ValueError, TypeError, RecursionError):
+            refuse = False  # unparseable existing row -> allow overwrite (self-heal)
+        if refuse:
+            raise DowngradeRefusedError
+    else:
+        # Brand-new identity: bound growth. (The tiny TOCTOU window before HSET is
+        # acceptable for a DoS bound, not a precise invariant.)
         if (_kv_command(cfg, "HLEN", SUBMISSIONS_KEY) or 0) >= MAX_SUBMISSIONS:
             raise LeaderboardFullError
     result = _kv_command(cfg, "HSET", SUBMISSIONS_KEY, field,
@@ -463,7 +487,11 @@ class handler(BaseHTTPRequestHandler):
             ip = _client_ip(self)
             # Per-IP cap (defense in depth behind the firewall's 10/60s) AND a
             # global cap that an IP-rotating attacker cannot bypass (dos-02).
-            if (_kv_rate_limited(cfg, f"rl:submit:{ip}", 20, 60)
+            # Namespace the per-IP key under `:ip:` so a client sending
+            # `X-Forwarded-For: global` cannot collide with the reserved
+            # `rl:submit:global` counter (which would let it exhaust the global
+            # bucket for everyone, or ride the global limit as its own).
+            if (_kv_rate_limited(cfg, f"rl:submit:ip:{ip}", 20, 60)
                     or _kv_rate_limited(cfg, "rl:submit:global",
                                         GLOBAL_SUBMIT_LIMIT, GLOBAL_SUBMIT_WINDOW)):
                 self._send_json(429, {"error": "rate limit exceeded"})
@@ -485,10 +513,19 @@ class handler(BaseHTTPRequestHandler):
                     updated = False
                     for i, existing in enumerate(entries):
                         if existing.get("repo_url") == key_repo and existing.get("skill_name") == key_skill:
+                            try:
+                                refuse = float(existing.get("composite", 0)) > float(entry["composite"])
+                            except (ValueError, TypeError):
+                                refuse = False
+                            if refuse:
+                                raise DowngradeRefusedError  # grief downgrade
                             entries[i] = entry
                             updated = True
                             break
                     if not updated:
+                        # Bound growth on the KV-less fallback too (no MAX cap before).
+                        if len(entries) >= MAX_SUBMISSIONS:
+                            raise LeaderboardFullError
                         entries.append(entry)
 
                     _save_submissions(entries)
@@ -497,6 +534,9 @@ class handler(BaseHTTPRequestHandler):
             return
         except LeaderboardFullError:
             self._send_json(429, {"error": "leaderboard is full"})
+            return
+        except DowngradeRefusedError:
+            self._send_json(409, {"error": "a higher score for this entry already exists"})
             return
         except Exception as exc:
             print(f"Storage error: {type(exc).__name__}: {exc}", file=sys.stderr)

--- a/web/leaderboard/index.html
+++ b/web/leaderboard/index.html
@@ -1402,13 +1402,18 @@
         tdRank.appendChild(txt(rank));
         tr.appendChild(tdRank);
 
-        // Name
+        // Name. Only VERIFIED rows get an active hyperlink to their repo: the board
+        // is unauthenticated, so a self-reported row can attribute any score to any
+        // repo. An active <a href> to an attacker-chosen repo_url is an
+        // impersonation/defamation vector (a board that actively links "torvalds/linux
+        // → D") — so unverified rows render as plain, non-clickable text. (Future-proof:
+        // if a server-verified tier is added, those rows link again.)
         var tdName = makeTd('td-name');
-        if (safeUrl) {
+        if (safeUrl && !isUnverified) {
           var a = document.createElement('a');
           a.href = safeUrl;
           a.target = '_blank';
-          a.rel = 'noopener noreferrer';
+          a.rel = 'nofollow ugc noopener noreferrer';
           a.appendChild(txt(name));
           tdName.appendChild(a);
         } else {
@@ -1463,11 +1468,13 @@
         var cardNameEl = document.createElement('div');
         cardNameEl.className = 'card-name';
         cardNameEl.setAttribute('title', name);
-        if (safeUrl) {
+        // See the table-row note: unverified rows render as plain text, not an
+        // active link to a (possibly attacker-chosen) repo_url.
+        if (safeUrl && !isUnverified) {
           var ca = document.createElement('a');
           ca.href = safeUrl;
           ca.target = '_blank';
-          ca.rel = 'noopener noreferrer';
+          ca.rel = 'nofollow ugc noopener noreferrer';
           ca.appendChild(txt(name));
           cardNameEl.appendChild(ca);
         } else {


### PR DESCRIPTION
## Summary

Pre-launch audit batch 2 — **web-only, no engine/golden changes**. The leaderboard is an unauthenticated, self-reported, **all-unverified** community board (there is no `verified:true` tier). Full impersonation defense (#16 — anyone can attribute any score to any repo) needs auth or server-side re-scoring and stays a documented open item; these are the concrete abuse fixes that ship without it. Franz-approved direction: "Abuse-Härtung jetzt, #16 später".

## Fixes

- **#17 grief downgrade** — an overwrite of an existing `(repo_url, skill_name)` that *lowers* its composite is refused (`409`). Anyone could zero out a victim's row; genuine equal/higher re-scores still pass. Applied in both the KV upsert and the `/tmp` fallback.
- **#18 spoofable rate-limit IP** — `_client_ip` took the client-controlled **leftmost** `X-Forwarded-For` (bypass own limit + target a victim by spoofing their IP). Now prefers the unspoofable `x-real-ip`, else the **rightmost** XFF hop. Fixed in `submit.py` **and** `query.py` (kept byte-identical per the cross-file guard). Also namespaced the per-IP key `rl:submit:ip:{ip}` so `X-Forwarded-For: global` can't collide with the reserved `rl:submit:global` counter.
- **#19 /tmp fallback** — added the `MAX_SUBMISSIONS` cap (was unbounded on any KV-less deploy, with an O(n) full-file rewrite per request).
- **Impersonation vector** — unverified rows no longer render an active `<a href>` to an attacker-chosen `repo_url` (a board actively linking "torvalds/linux → D"). They render as plain text; a future server-verified tier would link again.

## Verification

- **1411 → 1416 tests** (6 new): grief-downgrade refused + victim row intact; `_client_ip` prefers unspoofable/rightmost; equal/higher still updates. Full suite green, `ruff` clean.
- Test harness: `FakeRedis` gained `HGET` (the upsert now HGETs to compare composites); the PG-1 `RecursionError` guard is kept on the new json parse.

## Post-merge (human-gated)

- Redeploy the leaderboard to prod (Vercel) so the hardened endpoints + delinked unverified rows go live.

## Still open (documented)

- **#16** structural impersonation — needs server-side re-score or ownership auth (own batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)