### PR TITLE
fix: pre-launch audit batch A — CLI display correctness (golden-neutral)

### DIFF
--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -655,8 +655,16 @@ def cmd_compare(args: argparse.Namespace) -> None:
     score_a = composite_a["score"]
     score_b = composite_b["score"]
 
-    # Collect dimension names present in both scores
-    dims = [k for k in scores_a if isinstance(scores_a[k], dict) and "score" in scores_a[k]]
+    # Collect dimension names measured in BOTH files. Unmeasured dims carry the
+    # -1 sentinel (e.g. triggers/quality/edges without an eval suite); including
+    # them would render literal -1.0 rows and produce phantom deltas against the
+    # 0.0 default. Mirrors the terminal score display, which skips score < 0.
+    dims = [
+        k for k in scores_a
+        if isinstance(scores_a[k], dict)
+        and scores_a[k].get("score", -1) >= 0
+        and scores_b.get(k, {}).get("score", -1) >= 0
+    ]
 
     # Per-dimension deltas: B - A
     deltas = {}

--- a/skills/schliff/scripts/terminal_art.py
+++ b/skills/schliff/scripts/terminal_art.py
@@ -343,7 +343,11 @@ def format_score_display(
         if "eval suite" in wl:
             info_prefix = f"\x1b[36m\u2139{RESET}" if is_color_tty() else "\u2139"
             lines.append(f"  {info_prefix} {w}")
-        elif "unreliable" in wl:
+        else:
+            # Every other warning (low-confidence "unreliable" notes, the
+            # non-canonical calibrated-weights "not comparable" notice, "no
+            # weighted dimensions", ...) renders with the warning glyph rather
+            # than being silently dropped \u2014 the JSON output already surfaces them.
             warn_prefix = f"\x1b[33m\u26a0{RESET}" if is_color_tty() else "\u26a0"
             lines.append(f"  {warn_prefix} {w}")
 

--- a/skills/schliff/tests/unit/test_compare.py
+++ b/skills/schliff/tests/unit/test_compare.py
@@ -175,6 +175,50 @@ class TestCompareTerminalOutput:
 
 
 # ---------------------------------------------------------------------------
+# Unmeasured dimensions (no eval suite) must not leak as -1 sentinels
+# ---------------------------------------------------------------------------
+
+class TestCompareExcludesUnmeasured:
+    """Without an eval suite, triggers/quality/edges score -1 (unmeasured).
+    They must be excluded from the comparison — not rendered as literal -1.0
+    rows, and not counted in deltas/biggest_gap where they produce phantom gaps.
+    Mirrors the terminal score display, which already skips score < 0."""
+
+    def test_terminal_has_no_sentinel_rows(self, tmp_path):
+        path_a = tmp_path / "bad_skill.md"
+        path_b = tmp_path / "good_skill.md"
+        path_a.write_text(BAD_SKILL, encoding="utf-8")
+        path_b.write_text(GOOD_SKILL, encoding="utf-8")
+
+        result = _run_cli("compare", str(path_a), str(path_b))
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "-1.0" not in result.stdout, (
+            f"Unmeasured -1 sentinel leaked into compare table:\n{result.stdout}"
+        )
+
+    def test_json_excludes_unmeasured_dims(self, tmp_path):
+        path_a = tmp_path / "bad_skill.md"
+        path_b = tmp_path / "good_skill.md"
+        path_a.write_text(BAD_SKILL, encoding="utf-8")
+        path_b.write_text(GOOD_SKILL, encoding="utf-8")
+
+        result = _run_cli("compare", str(path_a), str(path_b), "--json")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+
+        for unmeasured in ("triggers", "quality", "edges"):
+            assert unmeasured not in data["deltas"], (
+                f"Unmeasured dim {unmeasured!r} must not appear in deltas"
+            )
+            assert unmeasured not in data["file_a"]["dimensions"], (
+                f"Unmeasured dim {unmeasured!r} must not appear in dimensions"
+            )
+        # every reported delta comes from a measured dimension
+        for dim, delta in data["deltas"].items():
+            assert delta != 1.0 or dim in data["file_b"]["dimensions"]
+
+
+# ---------------------------------------------------------------------------
 # Error handling
 # ---------------------------------------------------------------------------
 

--- a/skills/schliff/tests/unit/test_terminal_art.py
+++ b/skills/schliff/tests/unit/test_terminal_art.py
@@ -275,6 +275,30 @@ class TestFormatScoreDisplay:
         assert "/schliff:init" in output
         assert "ℹ" in output and "⚠" not in output
 
+    def test_shows_calibrated_weights_warning(self, monkeypatch):
+        """A warning that is neither an eval-suite invitation nor an 'unreliable'
+        note — e.g. the calibrated-weights 'not comparable' notice that the JSON
+        output already includes — must still render, not be silently dropped."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        warning = (
+            "Non-canonical weights in effect (weight_source=calibrated via "
+            "SCHLIFF_CALIBRATED_WEIGHTS); this score is not comparable to "
+            "default-weight scores from verify/badge/leaderboard."
+        )
+        output = format_score_display(
+            _make_scores(), _make_composite(warnings=[warning]),
+        )
+        assert "not comparable" in output
+
+    def test_shows_no_weighted_dimensions_warning(self, monkeypatch):
+        """The 'No weighted dimensions to score.' warning must also render —
+        it matches neither keyword branch and was being dropped too."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        output = format_score_display(
+            _make_scores(), _make_composite(warnings=["No weighted dimensions to score."]),
+        )
+        assert "No weighted dimensions to score." in output
+
     def test_single_contradiction_grammar(self, monkeypatch):
         monkeypatch.setenv("NO_COLOR", "1")
         output = format_score_display(


### PR DESCRIPTION
Batch A of the pre-launch audit follow-ups: two golden-neutral CLI display
correctness fixes. **No `.github/workflows` or `action.yml` changes** —
CLI-mergeable, no `v1` tag repoint needed.

## Fixes

**#22 — terminal drops score warnings** (`terminal_art.py`)
The terminal warning loop rendered only warnings containing `eval suite` or
`unreliable`; two composite warnings fell through and were silently dropped —
the calibrated-weights *"not comparable"* notice and *"No weighted dimensions
to score."* — even though the JSON output surfaces them. Every non-eval-suite
warning now renders with the warning glyph.

**#21 — `compare` leaks the -1 sentinel** (`cli.py`)
Without an eval suite, `triggers/quality/edges` score `-1` (unmeasured).
`compare` listed them as literal `-1.0` rows and computed phantom deltas
against the `0.0` default (which could win the "biggest gap" marker). The
dimension set is now filtered to those measured in **both** files, mirroring
the terminal score display (`score < 0` is skipped).

## Deferred (verified against real code)
- **#23** (detect_format unbounded `.txt` read) — the `open()`-with-cap fix is
  correct and unreachable from untrusted input (the playground passes `content`
  and validates the filename to `*.md`, so the `.txt` read is CLI-local only),
  but it trips a CodeQL `py/path-injection` FP that the prior `read_text()`
  spelling didn't. Pulled from this batch to keep it green without either
  weakening the fix or gaming the scanner; will return with a reviewed dismissal
  or caller-side path validation.
- **#14** (playground `json.loads` before size cap) — refuted as open: `raw_body`
  is already capped at `MAX_CONTENT_SIZE` before `json.loads`, `RecursionError`
  is caught → mitigated on pinned 3.12. No code change.
- **#15** (playground temp-dir leak) — confirmed, but it's the **playground web
  API** (needs `vercel --prod`), not engine/CLI. Deferred to a playground batch.

## Verification
- Full suite: **1420 passed** (1416 baseline + 4 new red→green tests)
- **Golden byte-identical**: engine score snapshot over 14 in-repo fixtures is
  identical before/after (both fixes are display-only)
- `ruff==0.15.8 check skills/schliff/scripts/` (the CI gate) → clean, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)