### PR TITLE
fix(scoring): structure score reproducibility — content-only model (#10)

### DIFF
--- a/docs/specs/2026-07-22-structure-reproducibility-content-only.md
+++ b/docs/specs/2026-07-22-structure-reproducibility-content-only.md
@@ -1,0 +1,256 @@
+# Structure score reproducibility (#10) — content-only model (A′)
+
+- Status: direction A′ approved; written design pending Franz review
+- Audit finding: #10 (pre-launch audit 2026-07-22)
+- Branch: `fix/prelaunch-10-structure-reproducibility`
+
+## Goal
+
+Make the `structure` dimension score a **pure function of the file's bytes**, so
+the same SKILL.md / AGENTS.md scores identically whether it is linted locally (in
+its real directory) or scored in isolation (playground / badge / a pasted file).
+Eliminate the reproduced local-vs-badge gap.
+
+## Context
+
+`structure` currently depends on the file's **on-disk neighborhood**, not just
+its content. Reproduced (`scratchpad/repro_10.py`): the same 250-line SKILL.md
+scores **95 in its real directory vs 80 in a bare mkdtemp** — Δ15 for identical
+bytes. The badge/playground score files in isolation; the author lints locally,
+so the public badge disagrees with the author's own linter. For a tool whose
+pitch is "deterministic scoring," that is a credibility gap, worst on AGENTS.md
+where `structure` carries weight **0.4** (→ 6-point composite swing).
+
+Two on-disk-dependent components inside the 0–100 `structure` sum
+(`skills/schliff/scripts/scoring/structure.py`):
+
+1. **Progressive disclosure (`:141`)** — `(skill_dir/"references").is_dir() or len(lines) <= 200` → +15 else +5. On-disk dir check.
+2. **Referenced-files-resolve (`:154-167`)** — declared `references|scripts|templates/` paths credited +10 only if they resolve on disk via `_ref_resolves`, else +5. On-disk existence check.
+
+Δ15 = 10 (progressive disclosure) + 5 (ref resolution).
+
+### Why not the alternatives
+
+- **Option C (keep on-disk, relabel the badge as "content-only")** — rejected: the
+  badge still would not match the local score for the same file. It *is* the bug.
+- **Option B (drop both components, redistribute weight)** — loses the
+  progressive-disclosure signal entirely and shifts the score scale the most.
+- **Naive content-only (Option A)** — rejected after a Fable-5 adversarial review
+  (verified against code): making "declared refs → +10 always" and "any ref
+  mention → +15 disclosure" shipped a **one-token, +6-composite exploit to the
+  live badge/leaderboard** (a single `references/x.md` string in a >200-line file),
+  scored dangling refs *higher* than today (+10 vs +5), and turned the unanchored
+  `_RE_REFS` (which misfires on URLs, build commands, and `references/..`) into
+  unconditional credit. It also left `missing_refs` firing on 100% of refs in
+  isolation, feeding `text_gradient.py`/`doctor.py` garbage "create the missing
+  file" gradients.
+
+**Option A′** (this spec) delivers the same byte-purity while closing those holes.
+
+## Requirements
+
+- **R1** — `structure` score is a pure function of content bytes. Same bytes →
+  identical score in every context. Hard gate: a reproducibility test (the inverse
+  of `repro_10.py`) asserting score-with-siblings == score-without-siblings.
+- **R2** — progressive disclosure credited from *content* (the skill links external
+  detail), not from an on-disk `references/` dir.
+- **R3** — the referenced-files component credited from *content* (declared refs),
+  never from on-disk existence.
+- **R4** — dangling-ref / missing-file detection is **preserved as a non-scoring
+  lint issue**, but emitted only when absence is **provable** from a real on-disk
+  location (a `references/` dir or a `.claude-plugin`/`.git` ancestor). In an
+  isolated context (mkdtemp / normalized temp copy) no `missing_refs` is claimed,
+  so the *report* is honest too and `text_gradient`/`doctor` do not emit "create
+  the missing file" gradients against files a paste-context cannot see.
+- **R5** — anti-gaming: no single-token full credit; cap ref-stuffing; reject
+  traversal tokens. (The systematic composite anti-gaming gate is B4, separate.)
+- **R6** — golden rebaseline documented; ordering (good > medium > bad) and the
+  self-score bands hold; field blast radius quantified.
+
+## Technical decisions
+
+### Component 1 — Progressive disclosure (`structure.py:141`)
+
+Replace the on-disk `references/` dir check with a content **disclosure signal**
+and a 3-tier score:
+
+```python
+disclosure = _disclosure_refs(content)     # see below
+if len(lines) <= 200 or len(disclosure) >= 2:
+    score += 15
+elif len(disclosure) == 1:
+    score += 10
+    issues.append("thin_progressive_disclosure")
+else:
+    score += 5
+    issues.append("no_progressive_disclosure")
+```
+
+`_disclosure_refs(content)` = union of two byte-verifiable "the skill points the
+reader to external detail" forms:
+
+- `_RE_MD_LINK = re.compile(r"\]\(\s*(?!https?:|#)([\w./-]+\.md)\s*\)", re.I)` —
+  a markdown link to a **local** `.md` file (`](./x.md)`, `](references/x.md)`;
+  not `http(s)`, not an anchor). This is the **dominant real-world disclosure
+  pattern** (field-validated below).
+- `_RE_REF_PATH = re.compile(r"(?:\]\(|`|\bsee\s+|\bread\s+|\bload\s+)(references/[\w./-]+)", re.I)` —
+  a `references/` path in a markdown link, backtick, or see/read/load verb (covers
+  non-`.md` reference resources). The anchor keeps bare build-command mentions of
+  `scripts/…` from counting as disclosure.
+
+Rationale: a long skill that links external detail is practicing progressive
+disclosure *in its content*, verifiable from the bytes alone. `scripts/`/`templates/`
+paths no longer count for disclosure (they are code/build mentions, not detail
+splitting).
+
+### Component 2 — Referenced files (`structure.py:154-167`)
+
+Remove on-disk existence from the **score**; keep an anti-stuffing / traversal
+guard so declaration alone cannot be farmed:
+
+```python
+refs = set(_RE_REFS.findall(content))
+if not refs:
+    score += 5                                   # none declared — neutral
+elif any(".." in Path(r).parts for r in refs) or len(refs) > 32:
+    score += 5
+    issues.append("malformed_or_excessive_refs") # traversal tokens / ref-stuffing
+else:
+    score += 10                                  # declared, well-formed — content credit
+```
+
+The 32-ref cap follows the alias-budget precedent from #124. `_ref_resolves`
+stays in the module — used only for the lint issue (Component 3), never the score.
+
+### Component 3 — Honest dangling lint, self-determined (no param threading)
+
+The dangling-ref lint (`missing_refs`) must stay for the local linter but must
+never fire falsely in an isolated context. Rather than thread a `refs_verifiable`
+flag through `build_scores` / `_call_scorer` (fragile — see the `build_scores`
+note below), `structure.py` **determines verifiability itself** from the on-disk
+context, following the established `command_resolution.py` doctrine: *claim
+absence only when it is provable; otherwise stay silent.*
+
+```python
+def _refs_verifiable(skill_dir: Path) -> bool:
+    """A reference can only be PROVEN dangling from a real on-disk location.
+    Positive evidence of a real skill location: a references/ dir, or a
+    .claude-plugin / .git ancestor. A bare mkdtemp (playground/badge) or a
+    normalized temp copy (non-skill.md) has none → verification is impossible,
+    so we never claim a dangling ref (a false dangling burns the artifact)."""
+    if (skill_dir / "references").is_dir():
+        return True
+    for anc in [skill_dir, *skill_dir.parents]:
+        if (anc / ".claude-plugin").is_dir() or (anc / ".git").exists():
+            return True
+    return False
+```
+
+In Component 2's `else` branch (refs present, well-formed → +10):
+
+```python
+    score += 10
+    if _refs_verifiable(skill_dir):
+        missing = sorted(r for r in refs if not _ref_resolves(r, skill_dir))
+        if missing:
+            issues.append(f"missing_refs: {missing}")
+```
+
+The **score is byte-pure regardless** — `_refs_verifiable` gates only whether the
+*issue* is emitted, never a point value. No signature change, no caller updates.
+This also *fixes* a pre-existing false-positive: local AGENTS.md scoring already
+runs through a temp copy (below), so today it emits `missing_refs` for **every**
+declared ref; the gate suppresses those.
+
+#### `build_scores` temp-normalization (why the self-determining gate is needed)
+
+`build_scores` (shared.py:221-230) normalizes non-`skill.md` formats
+(AGENTS.md/CLAUDE.md/.cursorrules) into a `NamedTemporaryFile` and scores *that*.
+So for AGENTS.md — the flagship, structure weight 0.4 — the on-disk checks
+**always** fail, even locally. Two consequences:
+- The reproducibility gap this spec reproduces is a **skill.md** phenomenon
+  (real path vs mkdtemp); AGENTS.md is already temp-scored in every context.
+- A′ is a **bigger win for AGENTS.md than framed**: the normalized temp preserves
+  the *content* (disclosure links + ref declarations), so a long AGENTS.md that
+  links references now earns +15/+10 from content — credit it currently cannot
+  get because the temp has no siblings. This corrects a systematic under-crediting,
+  not just a reproducibility gap.
+
+### Consumer alignment
+
+- `text_gradient.py:131` (missing-refs gradient) fires only on the now-verified
+  `missing_refs` issue (never emitted in isolated/temp contexts → no garbage
+  create-gradients).
+- `text_gradient.py:92` instruction updated: "…extract detail into `references/`
+  files **and link them from SKILL.md**" (linking is what now earns the credit).
+- `doctor.py:87` unchanged (consumes `no_progressive_disclosure`;
+  `thin_progressive_disclosure` is a new, neutral issue).
+
+## Field validation (115 real installed skills)
+
+`scratchpad/validate_aprime.py` compares the current vs A′-v2 structure score
+across every installed SKILL.md under `~/.claude/plugins/cache` + `~/.claude/skills`
+(the two changed components isolated; the rest of `structure` is unchanged, so
+component-delta == score-delta):
+
+- **11/115 changed, mean |Δ| = 0.6.** Tiny footprint.
+- **2 drops (−10)** — both are the *same* skill (`vercel/workflow`, two cached
+  copies): it ships a `references/` dir it **never links in prose** (0 links, 0
+  ref paths). Under byte-purity an unlinked reference dir is invisible to the
+  reader, so −10 is a correct tightening, not a false positive.
+- **1 gain (+10)** — `subagent-driven-development` links 3 flat-sibling `.md`
+  files but has no `references/` dir; the old on-disk check missed its disclosure,
+  A′-v2 credits it correctly.
+- **Fable's `references/`-anchored regex was refuted here**: it false-penalized
+  `nextjs` (435 lines, textbook disclosure via `See [x.md](./x.md)` links whose
+  targets omit the `references/` prefix) by −10. The broadened `_RE_MD_LINK`
+  (any local `.md` link) fixes it. This is the "green fixtures ≠ field-ready"
+  lesson — Fable validated on one file (schliff's own, which happens to use
+  `references/…` paths).
+
+## Golden rebaseline
+
+Golden fixtures (`test_golden.py`) are scored in `tmp_path` (no siblings):
+
+- `GOOD_SKILL` declares `scripts/score-skill.py` → ref component +5 (5→10);
+  progressive disclosure unchanged (≤200 lines). Structure +5; bands `>=80` and
+  composite `30-42` expected to hold.
+- `MEDIUM_SKILL` / `BAD_SKILL` declare no matching paths → unchanged.
+- Self-score tests run at the **real** path → schliff's own SKILL.md stays 100
+  (240 lines, links ≥2 references) and, crucially, now also scores 100 in
+  isolation — the reproducibility win.
+
+Recompute the exact fixture scores during implementation and rebaseline any band
+that moves with a documented value. Ordering (good > medium > bad) and the
+reproducibility test are hard gates.
+
+## Open questions (resolved)
+
+- **`vercel/workflow` −10** (dead `references/` dir; discloses via a
+  `node_modules/**/*.mdx` glob) → **accept**. Byte-purity cannot credit an
+  unlinked on-disk dir; the node_modules-glob pattern is rare/exotic and out of
+  scope for the reproducible structural signal.
+- **≥2 threshold docks legit single-reference long skills to +10 (thin)** (e.g.
+  `skill-creator`, one reference) → **accept**. The anti-gaming benefit (halving
+  the single-link exploit) outweighs a rare −5, and the `thin` tier softens it.
+
+## Testing
+
+- **Reproducibility (R1):** same bytes scored with vs without a `references/`
+  sibling → identical structure score (inverse of `repro_10.py`).
+- **Disclosure signal:** `](./detail.md)` link → counts; `scripts/build` build
+  command → does not; a URL containing `scripts/…` → does not; `references/..`
+  → `malformed_or_excessive_refs`.
+- **Issue context (R4):** a dangling ref in a bare mkdtemp (no `references/` dir,
+  no `.git`/`.claude-plugin` ancestor) → **no** `missing_refs`; the same dangling
+  ref in a real skill dir (with a `.git` ancestor) → `missing_refs` emitted.
+- **Golden:** rebaselined bands + ordering + self-score, all green.
+- **Field regressions (optional):** pin `nextjs` (no penalty), `subagent-driven-
+  development` (+10), and the `vercel/workflow` dead-dir −10 as named cases.
+
+## Out of scope
+
+- B4 (composite anti-gaming coherence gate) — separate batch.
+- Badge manifest via the GitHub tree API at the scored SHA (Fable's follow-up):
+  would let the badge run *verifiable* ref resolution deterministically per SHA,
+  but adds a network dependency to the badge path. Deferred; separate decision.

--- a/docs/specs/2026-07-22-structure-reproducibility-content-only.md
+++ b/docs/specs/2026-07-22-structure-reproducibility-content-only.md
@@ -1,6 +1,6 @@
 # Structure score reproducibility (#10) — content-only model (A′)
 
-- Status: direction A′ approved; written design pending Franz review
+- Status: implemented (TDD, 1422 tests green, golden rebaselined + documented)
 - Audit finding: #10 (pre-launch audit 2026-07-22)
 - Branch: `fix/prelaunch-10-structure-reproducibility`
 

--- a/skills/schliff/scripts/scoring/structure.py
+++ b/skills/schliff/scripts/scoring/structure.py
@@ -3,6 +3,7 @@
 Checks frontmatter, length, examples, headers, progressive disclosure,
 imperative voice, referenced files, and dead content.
 """
+import re
 from bisect import bisect_right
 from pathlib import Path
 
@@ -18,6 +19,33 @@ from scoring.patterns import (
     _RE_TODO,
 )
 from shared import read_skill_safe, strip_frontmatter
+
+# Progressive-disclosure signal (#10, content-only): the SKILL.md POINTS the reader
+# to external detail. Two byte-verifiable forms, unioned by _disclosure_refs:
+#  (1) a markdown link to a LOCAL .md file  ](./x.md) / ](references/x.md)  — not http/anchor
+#  (2) a references/ path in a link/backtick/see-read-load verb (non-.md resources)
+# A bare `scripts/build` build-command mention does NOT count (it is code, not disclosure).
+_RE_MD_LINK = re.compile(r"\]\(\s*(?!https?:|#)([\w./-]+\.md)\s*\)", re.I)
+_RE_REF_PATH = re.compile(r"(?:\]\(|`|\bsee\s+|\bread\s+|\bload\s+)(references/[\w./-]+)", re.I)
+
+
+def _disclosure_refs(content: str) -> set:
+    """Distinct local-detail pointers declared in the content (see regexes above)."""
+    return set(_RE_MD_LINK.findall(content)) | set(_RE_REF_PATH.findall(content))
+
+
+def _refs_verifiable(skill_dir: Path) -> bool:
+    """A reference can only be PROVEN dangling from a real on-disk location. Positive
+    evidence of one: a references/ dir, or a .claude-plugin / .git ancestor. A bare
+    mkdtemp (playground/badge) or a normalized temp copy (non-skill.md) has none, so
+    dangling is unprovable and never claimed — a false dangling burns the artifact
+    (the command_resolution doctrine)."""
+    if (skill_dir / "references").is_dir():
+        return True
+    for anc in [skill_dir, *skill_dir.parents]:
+        if (anc / ".claude-plugin").is_dir() or (anc / ".git").exists():
+            return True
+    return False
 
 
 def _ref_resolves(ref: str, skill_dir: Path) -> bool:
@@ -136,10 +164,18 @@ def _score_structure_inline(skill_path: str) -> dict:
     elif header_count >= 1:
         score += 5
 
-    # Progressive disclosure
+    # Progressive disclosure — credited from CONTENT (the skill links external
+    # detail), not from an on-disk references/ dir, so the score is reproducible
+    # across contexts (#10). A long skill that points readers to detail files is
+    # practicing disclosure in its bytes; a references/ dir it never links is
+    # invisible to the reader and earns nothing.
     skill_dir = Path(skill_path).parent
-    if (skill_dir / "references").is_dir() or len(lines) <= 200:
+    disclosure = _disclosure_refs(content)
+    if len(lines) <= 200 or len(disclosure) >= 2:
         score += 15
+    elif len(disclosure) == 1:
+        score += 10
+        issues.append("thin_progressive_disclosure")
     else:
         score += 5
         issues.append("no_progressive_disclosure")
@@ -151,20 +187,27 @@ def _score_structure_inline(skill_path: str) -> dict:
     elif hedge_count <= 2:
         score += 3
 
-    # Referenced files exist (resolved skill-local OR against a plugin/repo root)
+    # Referenced files — credited from CONTENT (declared refs), never from on-disk
+    # existence, so the score is reproducible (#10). Declaration alone cannot be
+    # farmed: traversal tokens and ref-stuffing get only the neutral credit.
     refs = set(_RE_REFS.findall(content))
     if not refs:
         # No references declared — neutral score (not rewarded, not penalized)
         score += 5
+    elif any(".." in Path(r).parts for r in refs) or len(refs) > 32:
+        # Traversal ('..') or excessive ref-stuffing — neutral credit, no on-disk
+        # resolution attempted (the linter can never become a filesystem oracle).
+        score += 5
+        issues.append("malformed_or_excessive_refs")
     else:
-        missing = sorted(r for r in refs if not _ref_resolves(r, skill_dir))
-        if not missing:
-            # All declared references resolve — reward completeness
-            score += 10
-        else:
-            # Some references resolve in no valid location — partial credit
-            score += 5
-            issues.append(f"missing_refs: {missing}")
+        # References declared and well-formed — content credit.
+        score += 10
+        # Dangling detection is a NON-scoring lint issue, emitted only from a
+        # provable on-disk location (never in an isolated/temp context).
+        if _refs_verifiable(skill_dir):
+            missing = sorted(r for r in refs if not _ref_resolves(r, skill_dir))
+            if missing:
+                issues.append(f"missing_refs: {missing}")
 
     # No dead content (TODO/FIXME/placeholder, empty sections)
     todo_count = len(_RE_TODO.findall(content))

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -89,7 +89,7 @@ def _compute_structure_gradients(skill_path: str) -> list[dict]:
                 "issue": "no_progressive_disclosure",
                 "target": "directory",
                 "op": "create",
-                "instruction": "Create a references/ directory and extract detailed content from SKILL.md into reference files",
+                "instruction": "Extract detailed content from SKILL.md into references/ files AND link them from SKILL.md (e.g. `See [details](references/details.md)`) — progressive disclosure is credited from the links in the content, not from a references/ directory the skill never points to",
                 "delta": 1.5,
                 "confidence": "high",
                 "effort": EFFORT_COMPLEX,

--- a/skills/schliff/tests/unit/test_agents_md_profile.py
+++ b/skills/schliff/tests/unit/test_agents_md_profile.py
@@ -198,9 +198,16 @@ def test_agents_md_corpus_golden_distribution():
     bands = Counter(r[2] for r in rows)
 
     assert len(rows) == 30
-    assert statistics.mean(scores) == pytest.approx(61.46, abs=0.05)
-    assert statistics.median(scores) == pytest.approx(61.40, abs=0.05)
-    assert min(scores) == pytest.approx(29.0, abs=0.05)
+    # Re-baselined for the content-only structure model (#10, A', 2026-07-22).
+    # AGENTS.md is always scored through a normalized temp copy (build_scores), so
+    # its on-disk structure checks always failed; A' now credits progressive
+    # disclosure + declared refs from CONTENT, lifting files that link detail. All
+    # movement is upward (mean/median/min up, max unchanged) — the systematic
+    # under-crediting fix, not noise. Was 61.46/61.40/29.0; one former-F file
+    # (29.0) clears 35 → E (F 1→0, E 4→5).
+    assert statistics.mean(scores) == pytest.approx(61.79, abs=0.05)
+    assert statistics.median(scores) == pytest.approx(61.70, abs=0.05)
+    assert min(scores) == pytest.approx(35.0, abs=0.05)
     assert max(scores) == pytest.approx(91.0, abs=0.05)
 
     # Exact band counts (golden lock) on the hardened scorer. No file reaches S
@@ -210,8 +217,8 @@ def test_agents_md_corpus_golden_distribution():
     assert bands["B"] == 4
     assert bands["C"] == 8
     assert bands["D"] == 12
-    assert bands["E"] == 4
-    assert bands["F"] == 1
+    assert bands["E"] == 5
+    assert bands["F"] == 0
 
     # No file emits the SKILL-only eval-suite warning.
     assert not any("eval suite" in w for _, _, _, ws in rows for w in ws)

--- a/skills/schliff/tests/unit/test_doctor.py
+++ b/skills/schliff/tests/unit/test_doctor.py
@@ -35,6 +35,16 @@ def _write_skill(tmp_path, lines=100, has_refs=False):
         "Output: error message",
         "",
     ]
+    # Progressive disclosure is credited from CONTENT (the skill links external
+    # detail), not from a bare on-disk references/ dir a reader never sees. A
+    # properly-disclosed skill LINKS its reference files.
+    if has_refs:
+        content_lines += [
+            "",
+            "See [example](references/example.md) for detailed patterns.",
+            "See [more](references/more.md) for additional detail.",
+        ]
+
     # Pad with realistic content to reach target line count
     while len(content_lines) < lines:
         content_lines.append(f"- Step {len(content_lines)}: process item")
@@ -47,9 +57,8 @@ def _write_skill(tmp_path, lines=100, has_refs=False):
     if has_refs:
         refs_dir = skill_dir / "references"
         refs_dir.mkdir()
-        (refs_dir / "example.md").write_text(
-            "# Reference\nSome content.", encoding="utf-8"
-        )
+        (refs_dir / "example.md").write_text("# Reference\nSome content.", encoding="utf-8")
+        (refs_dir / "more.md").write_text("# More\nMore content.", encoding="utf-8")
 
     return str(skill_file)
 

--- a/skills/schliff/tests/unit/test_scoring.py
+++ b/skills/schliff/tests/unit/test_scoring.py
@@ -221,9 +221,13 @@ class TestScoreStructure:
 
     def test_genuinely_missing_ref_flagged_with_full_path(self, tmp_path):
         """A ref that exists in no valid location is still flagged — and the issue
-        names the full file path, not the bare 'references' prefix (regex fix)."""
+        names the full file path, not the bare 'references' prefix (regex fix).
+        Content-only model: the dangling lint fires only from a PROVABLE on-disk
+        location, so the skill dir carries a references/ dir (positive evidence)
+        while the referenced patterns.md is genuinely absent."""
         skill_dir = tmp_path / "skills" / "bar"
         skill_dir.mkdir(parents=True)
+        (skill_dir / "references").mkdir()  # real location, but patterns.md absent
         f = skill_dir / "SKILL.md"
         f.write_text(self._REF_BODY)
         result = score_structure(str(f))
@@ -231,10 +235,23 @@ class TestScoreStructure:
         assert missing, "genuinely missing ref must still be flagged"
         assert "references/patterns.md" in missing[0], missing[0]
 
+    def test_missing_ref_not_flagged_in_isolated_context(self, tmp_path):
+        """Content-only model: in a bare context with no provable on-disk location
+        (no references/ dir, no .git/.claude-plugin ancestor — e.g. a playground
+        mkdtemp or a normalized temp copy), a declared ref is NEVER claimed missing.
+        A false dangling burns the artifact (command_resolution doctrine)."""
+        f = tmp_path / "SKILL.md"
+        f.write_text(self._REF_BODY)  # declares references/patterns.md, no siblings
+        result = score_structure(str(f))
+        assert not any("missing_refs" in i for i in result["issues"]), result["issues"]
+
     def test_ref_with_parent_traversal_is_confined(self, tmp_path):
-        """Security: a ref containing '..' is rejected, so the linter cannot be used
-        as a filesystem existence oracle — even when the traversed-to file really
-        exists outside the skill/plugin tree (would resolve True under the old code)."""
+        """Security: a ref containing '..' is rejected at the SCORE component before
+        any filesystem touch, so the linter can never be used as a filesystem
+        existence oracle — even when the traversed-to file really exists outside the
+        tree. Content-only model: '..' → malformed_or_excessive_refs (no on-disk
+        resolution attempted at all), a strictly stronger confinement than the old
+        resolve-then-flag path."""
         skill_dir = tmp_path / "skills" / "foo"
         skill_dir.mkdir(parents=True)
         # A real file OUTSIDE the tree that a traversal ref would reach unconfined.
@@ -251,8 +268,12 @@ class TestScoreStructure:
             f = skill_dir / "SKILL.md"
             f.write_text(body)
             result = score_structure(str(f))
-            missing = [i for i in result["issues"] if "missing_refs" in i]
-            assert missing, "traversal ref must be treated as unresolved (confinement), not silently resolved"
+            assert any("malformed_or_excessive_refs" in i for i in result["issues"]), (
+                f"traversal ref must be rejected as malformed, not resolved: {result['issues']}"
+            )
+            assert not any("missing_refs" in i for i in result["issues"]), (
+                "a '..' ref must never reach on-disk resolution"
+            )
         finally:
             secret.unlink(missing_ok=True)
 
@@ -296,6 +317,85 @@ class TestScoreStructure:
         result = score_structure(good_skill)
         # Threshold lowered from 70 to 65 to account for refs change (5pt less)
         assert result["score"] >= 65
+
+
+# --- content-only structure model (#10 reproducibility, A') ---
+
+def _long_skill(num_md_links: int = 0, extra_body: str = "") -> str:
+    """A >200-line SKILL.md with `num_md_links` distinct markdown links to local
+    .md files (the disclosure signal). Long enough that progressive disclosure is
+    not credited by the length branch alone."""
+    links = "\n".join(
+        f"See [detail {i}](./references/detail{i}.md) for more." for i in range(num_md_links)
+    )
+    sections = "\n".join(
+        f"## Section {i}\n\nDo step {i} carefully and verify the output before continuing.\n"
+        f"Run the check and confirm the result matches what is expected here.\n"
+        for i in range(40)
+    )
+    return (
+        "---\nname: long-skill\n"
+        "description: A long skill for exercising the content-only structure model.\n---\n\n"
+        "# Long Skill\n\nUse this when you need the long thing.\n\n"
+        f"{links}\n\n{extra_body}\n\n{sections}\n"
+    )
+
+
+class TestStructureContentOnly:
+    """#10: structure score is a pure function of content bytes (byte-purity).
+    Same content scores identically with or without on-disk siblings."""
+
+    def test_reproducible_with_and_without_siblings(self, tmp_path):
+        content = _long_skill(num_md_links=2)
+        assert content.count("\n") + 1 > 200  # exercises the on-disk-dependent branch
+
+        # (a) real skill dir WITH the referenced files present
+        real = tmp_path / "real"
+        (real / "references").mkdir(parents=True)
+        (real / "references" / "detail0.md").write_text("# d0\n")
+        (real / "references" / "detail1.md").write_text("# d1\n")
+        (real / "SKILL.md").write_text(content)
+
+        # (b) bare mkdtemp WITHOUT any siblings (playground/badge context)
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        (bare / "SKILL.md").write_text(content)
+
+        s_real = score_structure(str(real / "SKILL.md"))["score"]
+        s_bare = score_structure(str(bare / "SKILL.md"))["score"]
+        assert s_real == s_bare, f"structure not reproducible: real={s_real} bare={s_bare}"
+
+    def test_two_md_links_earn_full_disclosure(self, tmp_path):
+        f = tmp_path / "SKILL.md"
+        f.write_text(_long_skill(num_md_links=2))
+        result = score_structure(str(f))
+        assert "no_progressive_disclosure" not in result["issues"]
+        assert "thin_progressive_disclosure" not in result["issues"]
+
+    def test_one_md_link_is_thin_disclosure(self, tmp_path):
+        f = tmp_path / "SKILL.md"
+        f.write_text(_long_skill(num_md_links=1))
+        result = score_structure(str(f))
+        assert "thin_progressive_disclosure" in result["issues"]
+
+    def test_scripts_build_mention_is_not_disclosure(self, tmp_path):
+        # A long skill that only mentions scripts/ in a build command (no .md links,
+        # no references/ path) must NOT be credited with progressive disclosure.
+        f = tmp_path / "SKILL.md"
+        f.write_text(_long_skill(num_md_links=0, extra_body="Run `npm run scripts/build` to build."))
+        result = score_structure(str(f))
+        assert "no_progressive_disclosure" in result["issues"]
+
+    def test_ref_stuffing_is_capped(self, tmp_path):
+        stuffed = " ".join(f"references/f{i}.md" for i in range(40))
+        content = (
+            "---\nname: stuffed\ndescription: A skill stuffing many references.\n---\n\n"
+            f"# Stuffed\n\nUse this. {stuffed}\n"
+        )
+        f = tmp_path / "SKILL.md"
+        f.write_text(content)
+        result = score_structure(str(f))
+        assert any("malformed_or_excessive_refs" in i for i in result["issues"]), result["issues"]
 
 
 # --- score_efficiency tests ---

--- a/skills/schliff/tests/unit/test_stress.py
+++ b/skills/schliff/tests/unit/test_stress.py
@@ -483,8 +483,13 @@ class TestRegressionGoodSkillPinned:
     def test_structure_exact(self, tmp_path):
         path = _write(tmp_path, _GOOD_SKILL_CONTENT)
         result = score_structure(path)
-        assert result["score"] == 95, (
-            f"good_skill structure regression: expected 95, got {result['score']}"
+        # Re-baselined 95→100 for the content-only structure model (#10, A').
+        # good_skill declares `scripts/score-skill.py`; the referenced-files
+        # component now credits a well-formed declared ref (+10) from content
+        # instead of requiring on-disk resolution (+5 when it did not resolve in
+        # the temp scoring dir). Progressive disclosure unchanged (37 lines ≤200).
+        assert result["score"] == 100, (
+            f"good_skill structure regression: expected 100, got {result['score']}"
         )
 
     def test_efficiency_exact(self, tmp_path):
@@ -511,13 +516,14 @@ class TestRegressionGoodSkillPinned:
     def test_composite_exact(self, tmp_path):
         path = _write(tmp_path, _GOOD_SKILL_CONTENT)
         result = _score_all(path)
-        # Re-baselined for the unified full-denominator composite (2026-05-26).
-        # _score_all measures only structure/efficiency/composability/clarity — with
-        # no eval suite, triggers/quality/edges are uncredited → coverage 0.42, so the
-        # ceiling is ~42. Verified: 95*(.15/.95)+100*(.10/.95)+30*(.10/.95)+87*(.05/.95)
-        # = 33.3. Was 79.0 under the old renormalized (coverage-divided) scale.
-        assert result["score"] == 33.3, (
-            f"good_skill composite regression: expected 33.3, got {result['score']}"
+        # Re-baselined for the unified full-denominator composite (2026-05-26),
+        # then 33.3→34.1 for the content-only structure model (#10, A', 2026-07-22):
+        # structure 95→100 (the declared `scripts/score-skill.py` ref is credited
+        # from content, not on-disk resolution). _score_all measures only
+        # structure/efficiency/composability/clarity (no eval suite → coverage 0.42).
+        # Verified: 100*(.15/.95)+100*(.10/.95)+30*(.10/.95)+87*(.05/.95) = 34.1.
+        assert result["score"] == 34.1, (
+            f"good_skill composite regression: expected 34.1, got {result['score']}"
         )
 
 


### PR DESCRIPTION
Pre-launch audit **#10** (Batch C, scoring-validity). The `structure` dimension
score depended on the file's on-disk neighborhood, so the **same file scored 95
in its real dir vs 80 in isolation** (badge/playground) — Δ15, worst on AGENTS.md
(structure weight 0.4). The public badge disagreed with the author's own linter,
undermining the core "deterministic scoring" claim.

**This is a scoring-model change** — golden scores are intentionally rebaselined
with documented values (not golden-neutral, unlike Batch A #128).

## What changed
`structure` is now a **pure function of the file's bytes**:
- **Progressive disclosure** credited from content disclosure-links (markdown
  links to local `.md` files ∪ anchored `references/` paths), 3-tier (≥2→+15,
  1→+10 *thin*, 0→+5) — not from an on-disk `references/` dir a reader never
  links. `scripts/` build mentions no longer count.
- **Referenced-files** credits well-formed declared refs (+10) from content, with
  a traversal (`..`) / ref-stuffing (>32) guard that also stops the linter ever
  becoming a filesystem oracle.
- **Dangling detection preserved** as a non-scoring lint issue, self-gated to
  provable on-disk locations (a `references/` dir or `.claude-plugin`/`.git`
  ancestor) — the `command_resolution` "dangling only when provable" doctrine —
  so it never fires falsely in an isolated/temp context.

## Design provenance
Direction chosen after a **Fable-5 adversarial review** (which killed a naive
content-only variant that shipped a 1-token +6-composite exploit to the live
badge/leaderboard), then **field-validated over 115 real installed skills**
(11 changed, mean|Δ|=0.6). The field test refuted Fable's own `references/`-only
regex — it false-penalized the dominant real pattern (`nextjs`: `See [x.md](./x.md)`
links without a `references/` prefix) — and the broadened `_RE_MD_LINK` fixes it.

## Also fixes a pre-existing under-crediting
AGENTS.md is always scored through a normalized temp copy (`build_scores`), so its
on-disk structure checks *always* failed even locally; content disclosure links
are now credited (corpus mean 61.46→61.79, **all movement upward**).

## Verification
- **1422 tests green** (6 new red→green: reproducibility gate, disclosure signal,
  thin-tier, ref-stuffing cap, isolated-context dangling suppression).
- Original repro now `Δ=0` (90 == 90; was 95 vs 80).
- Real-code field spot-check: `nextjs` no penalty, `subagent-driven-development`
  +credit, `vercel/workflow` dead-dir correctly not credited.
- Golden rebaselined with documented values (good_skill structure 95→100 /
  composite 33.3→34.1; agents.md distribution 61.46→61.79). Ordering
  (good>medium>bad) + reproducibility are hard gates.
- `ruff==0.15.8 check skills/schliff/scripts/` clean.

Spec: `docs/specs/2026-07-22-structure-reproducibility-content-only.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)