### PR TITLE
chore(release): bump to 8.7.0 (batch A + C, honest reproducibility)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.6.3",
+  "version": "8.7.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.7.0] - 2026-07-22
+
+### Changed
+- **The `structure` score is now reproducible — a pure function of the file's
+  bytes (#10).** It previously depended on the file's on-disk neighbourhood (a
+  sibling `references/` directory and whether declared references resolved on
+  disk), so the *same* file scored ~15 points higher in its real directory than
+  in isolation — the public badge disagreed with the author's own CLI, worst on
+  AGENTS.md (structure weight 0.4). Now:
+  - Progressive disclosure is credited from **content** — markdown links to local
+    `.md` detail files (and anchored `references/` paths) — not from a
+    `references/` directory a reader is never pointed to. `scripts/` build-command
+    mentions no longer count. Tiered: ≥2 links → full credit, 1 → partial, 0 → none.
+  - The referenced-files component credits well-formed declared references from
+    content, with a traversal (`..`) / ref-stuffing guard that also prevents the
+    linter from ever being used as a filesystem existence oracle.
+  - Dangling-reference detection is preserved as a **non-scoring lint issue**,
+    emitted only from a provable on-disk location, so it never fires falsely in an
+    isolated or temp-scored context.
+  - This also corrects a long-standing under-crediting of AGENTS.md/CLAUDE.md/
+    `.cursorrules`, which are always scored through a normalized temp copy: their
+    content disclosure links are now credited. **Scores for files that link detail
+    move upward** — including this repo's own AGENTS.md (91.6 [A] → 93.6 [A]), which
+    now scores identically in-repo and in isolation. Golden scores were rebaselined
+    with documented values; field-validated over 115 real installed skills. A new
+    isolation-equivalence test pins that a file scores the same with and without
+    its on-disk siblings.
+
+### Fixed
+- **The terminal no longer silently drops score warnings (#22).** The calibrated-
+  weights "not comparable" notice and the "no weighted dimensions" warning — both
+  already present in the JSON output — were dropped from the terminal rendering.
+- **`compare` no longer leaks the `-1` sentinel (#21).** Unmeasured dimensions
+  (triggers/quality/edges with no eval suite) were rendered as literal `-1.0`
+  rows and produced phantom deltas; they are now excluded, mirroring the terminal
+  score display.
+
 ## [8.6.3] - 2026-07-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.6.3)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.7.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![AGENTS.md quality](https://img.shields.io/endpoint?url=https%3A%2F%2Fschliff-playground.vercel.app%2Fapi%2Fbadge%3Frepo%3DZandereins%2Fschliff)](https://schliff-playground.vercel.app)
 
-*That last badge is Schliff scoring this repo's own `AGENTS.md` — live, right now: **91.6 · A**.*
+*That last badge is Schliff scoring this repo's own `AGENTS.md` — live, right now: **93.6 · A**.*
 
 **Your AI instruction files silently degrade — and nothing catches it.** `AGENTS.md` is read by Cursor, Codex, Copilot, and Claude Code — one rotting file now quietly degrades four tools. A trigger phrase rots, an edge case slips, the file balloons past its token budget. No error, no red test — just agents that quietly get worse.
 
@@ -29,37 +29,37 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.6.3
+schliff v8.7.0
 
-  structure             █████████░   90/100  great
+  structure             ██████████   95/100  excellent
   operational_coverage  ██████████  100/100  perfect
   efficiency            ████████░░   78/100  good
   composability         ████░░░░░░   45/100  poor
   clarity               ██████████  100/100  perfect
 
-  Structural Score  ██████████████████░░  91.6/100  [A]
+  Structural Score  ███████████████████░  93.6/100  [A]
 
   Tokens: 837 / 3,000 (ok)
   Format: agents.md (normalized)
 ```
 
-No model produced that number. Run it on another laptop and you get 91.6 again. **A score you can't reproduce isn't a measurement — it's a vibe.**
+No model produced that number. Run it on another laptop and you get 93.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*Every number in this README comes from released `schliff==8.6.3` (`pip install schliff==8.6.3` to reproduce byte-for-byte). No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.7.0` (`pip install schliff==8.7.0`); the hydra field run below is dated to the version it was measured on. No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
 ## A real catch
 
-The SKILL.md for ShieldClaw — a real prompt-injection-defense skill, now archived — is Schliff's reproducible before/after. The fixtures ship in [`docs/case-studies/shieldclaw/`](docs/case-studies/shieldclaw/); every number below is the current engine's output, reproducible with `schliff score`. (For the 27.9 row, score a copy of `SKILL-before.md` outside that directory — in place, the engine auto-discovers the sibling eval suite.)
+The SKILL.md for ShieldClaw — a real prompt-injection-defense skill, now archived — is Schliff's reproducible before/after. The fixtures ship in [`docs/case-studies/shieldclaw/`](docs/case-studies/shieldclaw/); every number below is the current engine's output, reproducible with `schliff score`. (For the 28.7 row, score a copy of `SKILL-before.md` outside that directory — in place, the engine auto-discovers the sibling eval suite.)
 
 | | Score | Grade | Dimensions measured |
 | --- | --- | --- | --- |
-| Before, scored in isolation | 27.9 | F | 4/7 — no eval suite; explicit ceiling warning |
-| Before, with its eval suite | 83.7 | B | 7/7 |
-| After fixes | 93.8 | A | 7/7 |
+| Before, scored in isolation | 28.7 | F | 4/7 — no eval suite; explicit ceiling warning |
+| Before, with its eval suite | 84.5 | B | 7/7 |
+| After fixes | 94.6 | A | 7/7 |
 
-Two separate effects, and Schliff refuses to conflate them. Adding the eval suite lifted the **measurement ceiling** (27.9 → 83.7) — that is coverage, not quality. The **quality** delta is 83.7 → 93.8, driven by composability **20 → 86** and efficiency **60 → 83** after adding scope boundaries, an I/O contract, and handoffs — structural gaps a linter can't see, caught as a number that was too low.
+Two separate effects, and Schliff refuses to conflate them. Adding the eval suite lifted the **measurement ceiling** (28.7 → 84.5) — that is coverage, not quality. The **quality** delta is 84.5 → 94.6, driven by composability **20 → 86** and efficiency **60 → 83** after adding scope boundaries, an I/O contract, and handoffs — structural gaps a linter can't see, caught as a number that was too low.
 
 A second field run, against an external repo ([hydra](docs/case-studies/hydra/), measured on released `schliff==8.4.0`, 2026-07-03): **71.0 [C] → 76.5 [B]** — edges 82→100, composability 56→81, fix merged upstream ([Zandereins/hydra#34](https://github.com/Zandereins/hydra/pull/34)). Efficiency deliberately stayed at 47: a ~14k-token file against a 1,000-token budget was an **informed decline**, not a blind chase of the number. (External repo — not re-runnable from these fixtures.)
 
@@ -186,7 +186,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.6.3'` in the
+lead an older pinned install; pin it with `schliff-version: '8.7.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -222,7 +222,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.6.3
+    rev: v8.7.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.6.3.**
+**Current version: 8.7.0.**
 
 ## Understand the tool
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.6.3"
+version = "8.7.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.6.3"
+__version__ = "8.7.0"

--- a/skills/schliff/tests/unit/test_scoring.py
+++ b/skills/schliff/tests/unit/test_scoring.py
@@ -397,6 +397,29 @@ class TestStructureContentOnly:
         result = score_structure(str(f))
         assert any("malformed_or_excessive_refs" in i for i in result["issues"]), result["issues"]
 
+    def test_own_skill_md_scores_identically_in_isolation(self):
+        """#10 held to ourselves: the repo's own SKILL.md must score the same
+        in-repo (with its references/ siblings on disk) as in a bare temp dir
+        (no siblings) — the flagship reproducibility claim, as an executable gate.
+        This is the exact non-reproducibility #10 fixed: a skill.md is scored at
+        its real path, so before the content-only model the on-disk neighbourhood
+        shifted the composite."""
+        from shared import build_scores
+
+        skill = Path(__file__).resolve().parents[2] / "SKILL.md"  # skills/schliff/SKILL.md
+        assert skill.exists(), skill
+        assert (skill.parent / "references").is_dir(), "expected a real references/ sibling"
+
+        in_repo = compute_composite(build_scores(str(skill)))["score"]
+        with tempfile.TemporaryDirectory() as d:
+            copy = Path(d) / "SKILL.md"
+            copy.write_text(skill.read_text(encoding="utf-8"), encoding="utf-8")
+            isolated = compute_composite(build_scores(str(copy)))["score"]
+        assert in_repo == isolated, (
+            f"own SKILL.md not reproducible across contexts: "
+            f"in-repo={in_repo} isolated={isolated}"
+        )
+
 
 # --- score_efficiency tests ---
 

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,17 +15,17 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.6.3",
+    "version": "8.7.0",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {
     "skill_name": "shieldclaw",
     "repo_url": "https://github.com/zandereins/schliff",
     "format": "SKILL.md",
-    "composite": 93.8,
+    "composite": 94.6,
     "grade": "A",
     "dimensions": {
-      "structure": 95,
+      "structure": 100,
       "triggers": 100,
       "quality": 90,
       "edges": 100,


### PR DESCRIPTION
Release **8.7.0** — ships the pre-launch audit **batch A** (#128, CLI display
fixes) + **batch C** (#129, structure score reproducibility, content-only model).

Reworked after a Fable-5 + council review: the self-edit to this repo's AGENTS.md
was **decoupled** (it lands later as a plain docs change, not a release grade
event), so this release leads with the **honest engine-only number**, not a
self-tuned grade.

## Flagship: honest 93.6 [A] that reproduces in /tmp
The #129 fix moves this repo's own AGENTS.md **91.6 → 93.6** (still A) — and now
it scores **identically in-repo and in isolation**. The README leads with that
dogfood story ("we caught our own non-reproducibility, fixed the engine not the
file"), with a note that the agents.md headline weights structure/opcov/efficiency
0.4/0.4/0.2 (composability/clarity shown, not counted).

## What's in
- Version bumped in the 3 lockstep sources (gated by `test_version_consistency`).
- CHANGELOG 8.7.0 entry (no composability→grade misattribution).
- README regenerated from the 8.7.0 engine; reproducibility claim scoped (hydra is
  dated to its 8.4.0 measurement, not claimed reproducible from 8.7.0).
- **New isolation-equivalence test**: the repo's own SKILL.md must score the same
  in-repo (references/ siblings) as in a bare temp dir — executable proof of the
  flagship claim.
- **Leaderboard seed refreshed**: schliff row → 8.7.0 (score 98.9/S unchanged);
  shieldclaw showcase row → 94.6/A, structure 100 (was 93.8/95), matching the
  README + `submit.py` RESERVED_IDENTITY.

## Verification
- **1427 tests green**; version consistency green; own-SKILL.md isolation test green.
- README stale-number sweep clean; wheel builds at 8.7.0.

Post-merge chain (council-hardened): Release `v8.7.0` → publish.yml (OIDC→PyPI) →
bump `playground/pyproject.toml` + relock `playground/uv.lock` with
`--refresh-package schliff` **after** PyPI resolves → `vercel --prod` playground +
leaderboard → live-verify via `/api/score` engine_version (no-store), badge is
eventually-consistent. No action.yml change → no v1 repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)