### PR TITLE
fix: scope the truth-claim schliff makes about itself + close the no-op release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,13 @@ jobs:
           python -m venv /tmp/smoke
           /tmp/smoke/bin/pip install dist/*.whl
           # Verify the published import surface and the console-script entry point resolve.
-          /tmp/smoke/bin/python -c "import skills.schliff; from skills.schliff.scripts.cli import main; print('import ok')"
+          # -P (PYTHONSAFEPATH, 3.11+; this job pins 3.12) is load-bearing, not hygiene:
+          # without it Python prepends the cwd — the repo checkout — to sys.path, so the
+          # import resolves against the SOURCE TREE and the gate passes even when the wheel
+          # ships nothing. Verified: in a venv WITHOUT schliff installed, the un-flagged
+          # command exits 0; with -P it exits 1 (ModuleNotFoundError), and still exits 0
+          # once the wheel is really installed. Same doctrine as action.yml's `python3 -P`.
+          /tmp/smoke/bin/python -P -c "import skills.schliff; from skills.schliff.scripts.cli import main; print('import ok')"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Pure-Python wheel; nothing to compile.
 ## Test
 
 ```bash
-make test-unit          # pytest suite (1,347 tests) — run this before every commit
+make test-unit          # pytest unit suite — run this before every commit
 make lint               # ruff check skills/schliff/scripts/
 make test-all           # unit + integration + self + proof suites
 ```

--- a/README.md
+++ b/README.md
@@ -134,13 +134,62 @@ Schliff does **not** quietly renormalize across whatever you happened to measure
 
 ## What the score does not measure
 
-- **Structure, not truth.** Schliff cannot verify that a documented command exists or runs. A syntactically plausible fabrication — invented-but-real-looking commands in well-formed sections — scores in the S range. This is a documented, test-pinned limit ([`test_known_limit_plausible_fabrication_scores_high`](skills/schliff/tests/unit/test_operational_coverage.py), spec §11).
+- **Structure, not truth.** The *score* cannot verify that a documented command exists or runs. A syntactically plausible fabrication — invented-but-real-looking commands in well-formed sections — scores in the S range. This is a documented, test-pinned limit ([`test_known_limit_plausible_fabrication_scores_high`](skills/schliff/tests/unit/test_operational_coverage.py), spec §11). The `check-commands` subcommand closes part of this gap outside the score — see [Catching command drift](#catching-command-drift) below.
 - **Not agent behavior.** A high score doesn't prove your agent gets better — validity evidence today is case-study-level (the two dated before/afters above), not benchmark-level.
 - **Token counts are estimates.** stdlib `len//4`, not a tokenizer.
 - **Coverage is on you.** `triggers`/`quality`/`edges` need an eval suite (`/schliff:init`) or the ceiling warning caps the score. AGENTS.md has no such gap.
 - **Informed declines are valid.** A low dimension can be a deliberate tradeoff (hydra left efficiency at 47 rather than gut a 14k-token file).
 
 A high Schliff score is necessary, not sufficient.
+
+---
+
+## Catching command drift
+
+The score reads structure. `check-commands` reads your repo: for every setup/build/test
+command in an `AGENTS.md` or `CLAUDE.md`, it asks whether the thing actually exists.
+
+Given this `AGENTS.md`:
+
+````markdown
+# Example
+
+## Test
+
+```bash
+make test
+```
+````
+
+and a `Makefile` that only defines `lint:`:
+
+```console
+$ schliff check-commands AGENTS.md --repo .
+DANGLING  AGENTS.md:6  `make test` — make target 'test' is not defined in Makefile
+
+1 dangling, 0 resolved, 0 unknown (of 1 command).
+$ echo $?
+1
+```
+
+Non-zero exit makes it a CI gate. Schliff runs it against its own `AGENTS.md` on every
+pull request and every push to `main` ([`test.yml`](.github/workflows/test.yml)), which is
+the only adoption claim made here.
+
+**What it resolves, precisely** — the honest scope matters more than the headline:
+
+- **Make targets** and **npm/pnpm/yarn scripts**, plus referenced script paths on disk.
+- **Conservative by design:** a command is reported `dangling` only when absence is
+  *provable* (the manifest exists and the target is definitively missing). Anything
+  unprovable is `unknown`, never `dangling` — one false accusation would burn the tool.
+- **Known gap:** make targets are matched against a fixed vocabulary while npm scripts
+  use prefix matching, so a hyphenated target like `make test-unit` is currently not
+  examined at all ([#133](https://github.com/Zandereins/schliff/issues/133)). It stays
+  silent rather than guessing — but silence here is a coverage limit, not a clean bill.
+
+It is a drift guard, not a bug finder: across a sweep of real repositories most findings
+were in small or unmaintained projects, because well-maintained repos generally keep
+their documented commands working.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ LLM-judge and evolve features are optional extras (`[judge]`, `[evolve]`); the c
 
 ## See it on real files
 - **[case-studies/shieldclaw/](case-studies/shieldclaw/)** — before/after of a real skill optimization, with baseline and optimized score artifacts and the eval suite.
-- **[launch/state-of-ai-instructions.md](launch/state-of-ai-instructions.md)** — the public report: 120 instruction files scored across 60 repos. The corpus itself is not bundled (third-party files, varying licenses); regenerate it locally with the pipeline in [`../skills/schliff/scripts/launch/`](../skills/schliff/scripts/launch/) (`collect_corpus.py` → `score_corpus.py` → `aggregate_stats.py`).
+- **[launch/state-of-ai-instructions.md](launch/state-of-ai-instructions.md)** — the public report: 120 instruction files scored across 60 repos. **Historical:** measured 2026-04-17 on schliff v7.1.0; the figures do not reproduce on the current engine (see the header note in the file). The corpus itself is not bundled (third-party files, varying licenses); regenerate it locally with the pipeline in [`../skills/schliff/scripts/launch/`](../skills/schliff/scripts/launch/) (`collect_corpus.py` → `score_corpus.py` → `aggregate_stats.py`).
 
 ## Internal / working docs (not part of the public guide)
 `specs/`, `research/`, `ops/`, and `superpowers/` hold in-progress design specs,

--- a/docs/launch/state-of-ai-instructions.md
+++ b/docs/launch/state-of-ai-instructions.md
@@ -1,3 +1,11 @@
+> **Historical record — these figures do not reproduce on the current release.**
+> Measured 2026-04-17 with schliff **v7.1.0** (7 dimensions). The engine has since gained
+> an eighth dimension, changed its headline weights per format, and re-derived its corpus
+> goldens. Re-running the pipeline against a current release will produce different
+> numbers. Kept as a dated snapshot of what was measured then, not as a present-tense
+> claim — the same convention used for the [hydra case study](../case-studies/hydra/),
+> which is pinned to `schliff==8.4.0`.
+
 # State of AI Instructions 2026
 
 > We scored 120 public AI instruction files with schliff. **Mean grade: D. 59% below C.** Adding an eval suite — which zero of 60 sampled source repos ship — would lift the mean **+22 points**. Here's the data.

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -395,9 +395,10 @@ def cmd_check_commands(args: argparse.Namespace) -> None:
             print(f"DANGLING  {args.skill_path}{loc}  `{r['command']}` — {r['evidence']}")
         resolved = sum(1 for r in results if r["status"] == "resolved")
         unknown = sum(1 for r in results if r["status"] == "unknown")
+        noun = "command" if len(results) == 1 else "commands"
         print(
             f"\n{len(dangling)} dangling, {resolved} resolved, {unknown} unknown "
-            f"(of {len(results)} commands)."
+            f"(of {len(results)} {noun})."
         )
 
     sys.exit(1 if dangling else 0)

--- a/skills/schliff/tests/unit/test_cli.py
+++ b/skills/schliff/tests/unit/test_cli.py
@@ -237,3 +237,29 @@ class TestCanonicalUnderCalibrationFlag:
         off = self._run(args, home_with_calib, False)
         on = self._run(args, home_with_calib, True)
         assert off.returncode == on.returncode, "verify pass/fail flipped under the env flag"
+
+
+# ---------------------------------------------------------------------------
+# check-commands — summary line grammar
+# ---------------------------------------------------------------------------
+
+class TestCheckCommandsSummary:
+    """The summary line is a documented, user-facing surface (README example),
+    so its grammar is pinned: one command must not read "of 1 commands"."""
+
+    def _repo(self, tmp_path, agents_body):
+        (tmp_path / "Makefile").write_text("lint:\n\truff check .\n", encoding="utf-8")
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(agents_body, encoding="utf-8")
+        return str(agents), str(tmp_path)
+
+    def test_singular_for_one_command(self, tmp_path):
+        agents, repo = self._repo(tmp_path, "# Example\n\n## Test\n\n```bash\nmake test\n```\n")
+        result = _run_cli("check-commands", agents, "--repo", repo)
+        assert "(of 1 command)." in result.stdout, f"got: {result.stdout!r}"
+        assert "1 commands" not in result.stdout
+
+    def test_plural_for_several_commands(self, tmp_path):
+        agents, repo = self._repo(tmp_path, "# Example\n\n## Test\n\n```bash\nmake test\nmake lint\n```\n")
+        result = _run_cli("check-commands", agents, "--repo", repo)
+        assert "(of 2 commands)." in result.stdout, f"got: {result.stdout!r}"


### PR DESCRIPTION
Three claims this repo makes about itself were wrong, overstated, or hidden — plus the
release gate that was supposed to catch a class of them turned out not to check anything.
No engine change, no version bump, goldens byte-identical, badge stays 95.8 [S].

## 1 — the release smoke-test was a no-op

`publish.yml` installed the built wheel into a fresh venv, then ran
`python -c "import skills.schliff"` **from the repo root**. Python prepends the cwd to
`sys.path`, so the import resolved against the source tree. The gate passed regardless of
what the wheel contained — a wheel shipping zero files would have published green.

Reproduced and fixed in both directions on 3.12 (the version the job pins):

| | without wheel installed | with wheel installed |
|---|---|---|
| current command | `exit 0` — gate blind | `exit 0` |
| `python -P` | `exit 1` ModuleNotFoundError | `exit 0` |

`-P` (`PYTHONSAFEPATH`) is the doctrine `action.yml` already applies, with the reasoning
written out there.

**The published 8.7.0 wheel was checked and is intact** — installed from PyPI into a clean
3.12 venv outside the repo, import resolves to `site-packages`, entry point and
`check-commands` both work. This closes the gate for future releases; it is not an
incident.

## 2 — `check-commands` was invisible

The README's limitations section said *"Schliff cannot verify that a documented command
exists or runs."* That is true of the **score**, but it reads as a blanket admission —
while `check-commands` (shipped in 8.6.0) does exactly that. It appeared once in the repo,
in a CLI table 108 lines below that sentence.

The sentence is now scoped to the score and points at a new section with a worked example
the reader can reproduce in 30 seconds, the exit-code contract, and the resolver's honest
limits. Framed as a **drift guard, not a bug finder** — consistent with what the field
sweeps actually found.

The example output is copied from a real run, which is how the `(of 1 commands)` grammar
bug in commit 2 was found.

## 3 — the resolver has a real gap, documented rather than papered over

`make <target>` is matched against a fixed vocabulary while `npm run <script>` uses prefix
matching, so `make test-unit` is not examined at all — including this repo's own
`make test-unit` / `make test-all`. The dogfood gate reports `0 dangling` and would keep
doing so if both targets were deleted.

Filed as #133 rather than fixed here: it moves `operational_coverage` (weight 0.4 on the
`agents.md` profile), which re-baselines the corpus goldens and can move this repo's own
published badge. That needs a spec and a documented re-derivation, not a docs PR. The
README states the gap instead of implying full coverage.

## 4 — stale numbers

`AGENTS.md` claimed "pytest suite (1,347 tests)"; the suite had 1,427. The count is
**removed rather than corrected** — refreshing it only resets the clock until the next test
lands, and a stale number inside a well-formed section is exactly the failure mode the
README documents as a known limit. Verified score-neutral.

`docs/launch/state-of-ai-instructions.md`, linked from `docs/README.md` as "the public
report", headlines figures measured on v7.1.0 with 7 dimensions. The engine has since
gained a dimension, changed headline weights and re-derived its corpus goldens, so those
numbers no longer reproduce. Marked historical and dated — the convention the hydra case
study already follows.

## Verification

- `1429 passed` (1427 + 2 new, red → green for the plural fix)
- `ruff==0.15.8 check skills/schliff/scripts/` → clean
- goldens byte-identical (`test_agents_md_profile.py` 7 passed)
- badge unchanged: in-repo `95.8` == isolated copy `95.8`, every dimension identical
- dogfood gate still `exit 0`
- no version bump

**Merge note:** touches `.github/workflows/publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
