### PR TITLE
docs: correct the mechanism behind the check-commands known gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ the only adoption claim made here.
 - **Conservative by design:** a command is reported `dangling` only when absence is
   *provable* (the manifest exists and the target is definitively missing). Anything
   unprovable is `unknown`, never `dangling` — one false accusation would burn the tool.
-- **Known gap:** make targets are matched against a fixed vocabulary while npm scripts
-  use prefix matching, so a hyphenated target like `make test-unit` is currently not
-  examined at all ([#133](https://github.com/Zandereins/schliff/issues/133)). It stays
-  silent rather than guessing — but silence here is a coverage limit, not a clean bill.
+- **Known gap:** `make` targets are recognised only from a fixed vocabulary — `make test`
+  is examined, `make test-unit` is not looked at at all. That is a deliberate tradeoff, not
+  an oversight: the same narrow matching is what stops English prose like *"make sure the
+  tests pass"* from being read as a command. Measured over 259 real instruction files,
+  loosening it would catch 2 genuine commands and 14 non-commands
+  ([#133](https://github.com/Zandereins/schliff/issues/133)). It stays silent rather than
+  guessing — but silence here is a coverage limit, not a clean bill.
 
 It is a drift guard, not a bug finder: across a sweep of real repositories most findings
 were in small or unmaintained projects, because well-maintained repos generally keep


### PR DESCRIPTION
#134 shipped a wrong causal claim into the one section whose whole point is not making
claims the tool cannot support. Docs only — no engine change, 1429 tests unchanged, own
score still 95.8.

## What was wrong

> make targets are matched against a fixed vocabulary while npm scripts use prefix matching

Both halves are false:

- **`make` is not in `_RUNNER`** and never reaches `_runner_family`. It goes through the
  `_GUARDED` branch, which exists to stop English homonyms — `make sure`, `just`, `go`,
  `task` — from being read as commands.
- **npm scripts do not prefix-match.** An unrecognised `npm run <x>` is credited `build`
  by a fallback that never looks at the target name. `npm run wibble` counts as build.

The *conclusion* was right — `make test-unit` is not examined — so the bullet stays. Only
the reason changes, and it is replaced with the measured tradeoff rather than a mechanism,
which is the more useful thing for a reader anyway.

## What it says now

> `make` targets are recognised only from a fixed vocabulary — `make test` is examined,
> `make test-unit` is not looked at at all. That is a deliberate tradeoff, not an oversight:
> the same narrow matching is what stops English prose like *"make sure the tests pass"*
> from being read as a command. Measured over 259 real instruction files, loosening it
> would catch 2 genuine commands and 14 non-commands (#133).

The 259 files are the 30-file AGENTS.md corpus, 228 installed SKILL.md, and this repo's
own. The 2 genuine commands are both in this repo's `AGENTS.md`; the 14 non-commands
include a literal `Make sure` **inside** a bash fence, which is also what killed the
assumption that fence context makes relaxation safe.

## Why separate from the fix

The corrected analysis lives in #133 and the proposed change in #136, which is
golden-touching and needs a documented re-derivation plus a decision from the maintainer.
This correction is golden-neutral and should not wait behind that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
