### PR TITLE
fix(scoring): an unrecognised runner target is unclassified, not a build (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- **An unrecognised `<runner> run <target>` no longer counts as a build command
+  (#133).** `operational_coverage` credited the `build` category whenever a
+  `run`/`r`/`exec`/`dlx` keyword had been consumed — without ever inspecting the
+  target. `npm run wibble` scored a build; `npm run test-unit` scored a build
+  rather than a test; and the identical script written as `yarn test-unit`, with
+  no keyword to consume, was dropped entirely. The engine reported "real build
+  command resolved" about a target it had not looked at.
+
+  Such commands now carry the family `unclassified`: real and runnable, family
+  undetermined. This mirrors the doctrine `check-commands` already follows —
+  claim `dangling` only when provable, otherwise `unknown`.
+
+  `pylint` joined the intrinsic test tools, where the 16 other linters already
+  sat, so `uv run pylint` is now classified `test` instead of losing its family
+  along with the fallback.
+
+  **Impact:** `unclassified` credits no category, so files that documented no
+  build step stop being scored as if they did. Over the 30-file AGENTS.md corpus
+  exactly one file moves (80.6 → 72.6, one B→C reclassification); mean 61.79 →
+  61.53, median/min/max unchanged. Golden re-derived from the engine.
+
+  **Not affected:** `check-commands` resolves the identical command set — proven
+  set-identical over 259 real instruction files (409 command/status tuples, zero
+  difference, zero new `dangling` claims). `make test-unit` and friends remain
+  outside the vocabulary by design; loosening that guard was measured to buy 2
+  genuine commands at the cost of 14 non-commands, and is documented in the
+  README rather than changed.
+
+- **Output contract:** `schliff check-commands --json` may now emit
+  `"family": "unclassified"`. Existing values are unchanged and `status` is
+  untouched, but consumers that switch on `family` should treat it as an open set.
+
 ## [8.7.0] - 2026-07-22
 
 ### Changed

--- a/skills/schliff/scripts/scoring/operational_coverage.py
+++ b/skills/schliff/scripts/scoring/operational_coverage.py
@@ -90,6 +90,9 @@ _SHELL_LANGS = {
 # --------------------------------------------------------------------------- #
 # Command classification token sets (§4.2 hardening)
 # --------------------------------------------------------------------------- #
+# A real, runnable command whose operational family could not be determined.
+UNCLASSIFIED = "unclassified"
+
 _JUNK = {
     "echo", "ls", "pwd", "cd", "true", "false", ":", "exit", "cat", "whoami",
     "date", "clear", "sleep", "head", "tail", "sort", "which",
@@ -101,6 +104,11 @@ _WRAPPERS = {"sudo", "command", "exec", "time", "env", "xargs", "nohup", "then",
 _TEST_INTRINSIC = {
     "pytest", "vitest", "jest", "mocha", "tox", "nox", "ruff", "eslint", "mypy",
     "prettier", "black", "flake8", "isort", "pyright", "nextest", "pre-commit",
+    # `lint` is already a _TEST_TOKEN, so the tools that perform it belong here.
+    # pylint was the only linter a 259-file sweep found missing (#133); without
+    # this entry the UNCLASSIFIED change below would move `uv run pylint` from
+    # one wrong family to no family at all.
+    "pylint",
 }
 # tsc sits in the build family per spec §4.2 ("build / compile / ... / tsc / vite").
 _BUILD_INTRINSIC = {"vite", "webpack", "tsc"}
@@ -292,8 +300,8 @@ def _runner_family(verb: str, nonflag):
     # Runner-in-runner delegation: `uv pip install ...` -> pip's family.
     if a0 in _RUNNER:
         return _runner_family(a0, nonflag[nonflag.index(a0) + 1:])
-    # `npm run <unknown-script>` -> generic build/run
-    return "build" if consumed_run else None
+    # `npm run <unknown-script>` -> real command, unclassifiable family.
+    return UNCLASSIFIED if consumed_run else None
 
 
 def _classify(seg: str, inline: bool):

--- a/skills/schliff/tests/unit/test_agents_md_profile.py
+++ b/skills/schliff/tests/unit/test_agents_md_profile.py
@@ -198,14 +198,26 @@ def test_agents_md_corpus_golden_distribution():
     bands = Counter(r[2] for r in rows)
 
     assert len(rows) == 30
-    # Re-baselined for the content-only structure model (#10, A', 2026-07-22).
-    # AGENTS.md is always scored through a normalized temp copy (build_scores), so
-    # its on-disk structure checks always failed; A' now credits progressive
-    # disclosure + declared refs from CONTENT, lifting files that link detail. All
-    # movement is upward (mean/median/min up, max unchanged) — the systematic
-    # under-crediting fix, not noise. Was 61.46/61.40/29.0; one former-F file
-    # (29.0) clears 35 → E (F 1→0, E 4→5).
-    assert statistics.mean(scores) == pytest.approx(61.79, abs=0.05)
+    # Re-baselined for UNCLASSIFIED runner targets (#133, 2026-07-27). Was
+    # 61.79 mean / B 4 / C 8. An unrecognised `<runner> run <target>` no longer
+    # credits `build` on the strength of the consumed `run` keyword alone, so a
+    # file that documented no build step stops being reported as if it did.
+    # EXACTLY ONE of the 30 files moves: markov-kernel__databricks-mcp
+    # 80.6 → 72.6, which is opcov −20 × the agents.md weight 0.4 = −8.0 — the
+    # arithmetic is an internal check that nothing else shifted. That file
+    # documents `uv run pytest`, `uv run black .`, `uv run pylint …` and a
+    # `-- --help` invocation, i.e. no build command at all; the credit it lost
+    # was manufactured. Movement is downward and confined to that correction:
+    # median/min/max unchanged, one B→C reclassification.
+    #
+    # Derived by running the engine over the corpus, never hand-tuned. The
+    # per-target behaviour this rests on is pinned in
+    # TestRunnerClassificationCharacterization (test_operational_coverage.py).
+    #
+    # Prior baseline for the content-only structure model (#10, A', 2026-07-22):
+    # was 61.46/61.40/29.0 before that change; one former-F file (29.0) cleared
+    # 35 → E (F 1→0, E 4→5).
+    assert statistics.mean(scores) == pytest.approx(61.53, abs=0.05)
     assert statistics.median(scores) == pytest.approx(61.70, abs=0.05)
     assert min(scores) == pytest.approx(35.0, abs=0.05)
     assert max(scores) == pytest.approx(91.0, abs=0.05)
@@ -214,8 +226,8 @@ def test_agents_md_corpus_golden_distribution():
     # (>=95); the two CJK docs floor opcov directives to 0 (English-scoped, §8.1).
     assert bands["S"] == 0
     assert bands["A"] == 1
-    assert bands["B"] == 4
-    assert bands["C"] == 8
+    assert bands["B"] == 3
+    assert bands["C"] == 9
     assert bands["D"] == 12
     assert bands["E"] == 5
     assert bands["F"] == 0

--- a/skills/schliff/tests/unit/test_operational_coverage.py
+++ b/skills/schliff/tests/unit/test_operational_coverage.py
@@ -16,7 +16,11 @@ from pathlib import Path
 import pytest
 
 from scoring.composite import compute_composite
-from scoring.operational_coverage import _extract_commands, score_operational_coverage
+from scoring.operational_coverage import (
+    UNCLASSIFIED,
+    _extract_commands,
+    score_operational_coverage,
+)
 from scoring.registry import (
     _INSTRUCTION_FILE_SCORERS,
     WEIGHT_PROFILES,
@@ -882,21 +886,26 @@ class TestRunnerClassificationCharacterization:
         ("yarn test-unit", None),
     ]
 
-    # DEFECT B (#133, to be fixed): once a `run`-like token is consumed, an
-    # unrecognised target is credited `build` without the target ever being
-    # inspected. Note `yarn test-unit` above vs `yarn run test-unit` here —
-    # same tool, same script, opposite outcome.
-    FALSE_BUILD_CREDIT = [
-        ("yarn run test-unit", "build"),
-        ("npm run test-unit", "build"),      # a test script credited as build
-        ("npm run lint-fix", "build"),       # a lint script credited as build
-        ("npm run wibble", "build"),         # nothing at all credited as build
-        ("npm run db:push", "build"),
-        ("pnpm run test-unit", "build"),
-        ("uv run pylint pkg tests", "build"),  # pylint is a linter -> test
-        ("uv run tool -- --help", "build"),    # --help is inspection junk -> nothing
-        ("bun run scripts/x.ts", "build"),
-        ("cargo run examples/a/Cargo.toml", "build"),
+    # DEFECT B — FIXED (#133). A consumed `run` token no longer manufactures a
+    # `build` credit for a target that was never inspected. These are real,
+    # runnable commands whose family the engine cannot determine, so it now says
+    # exactly that: UNCLASSIFIED credits no category, while the row itself stays
+    # extracted so `check-commands` still resolves it against the repo.
+    #
+    # `lint-fix` and `db:push` stay UNCLASSIFIED on purpose. Reading them as
+    # test/setup would need boundary matching (`test-*`, `lint-*`), which is
+    # deliberately out of scope here — a second mechanism in the same change
+    # would confound the golden re-derivation.
+    UNCLASSIFIED_TARGETS = [
+        ("yarn run test-unit", UNCLASSIFIED),
+        ("npm run test-unit", UNCLASSIFIED),
+        ("npm run lint-fix", UNCLASSIFIED),
+        ("npm run wibble", UNCLASSIFIED),
+        ("npm run db:push", UNCLASSIFIED),
+        ("pnpm run test-unit", UNCLASSIFIED),
+        ("uv run tool -- --help", UNCLASSIFIED),
+        ("bun run scripts/x.ts", UNCLASSIFIED),
+        ("cargo run examples/a/Cargo.toml", UNCLASSIFIED),
     ]
 
     @pytest.mark.parametrize("command,family", CORRECT_TODAY)
@@ -907,9 +916,27 @@ class TestRunnerClassificationCharacterization:
     def test_guarded_verbs_drop_unknown_targets(self, command, family):
         assert self._family(command) == family
 
-    @pytest.mark.parametrize("command,family", FALSE_BUILD_CREDIT)
-    def test_consumed_run_credits_build_without_inspecting_target(self, command, family):
+    @pytest.mark.parametrize("command,family", UNCLASSIFIED_TARGETS)
+    def test_unknown_delegated_target_is_unclassified(self, command, family):
         assert self._family(command) == family
+
+    @pytest.mark.parametrize("command", [c for c, _ in UNCLASSIFIED_TARGETS])
+    def test_unclassified_credits_no_category(self, command, tmp_path):
+        """UNCLASSIFIED must never reach a scored category. It is not in
+        ("setup", "build", "test"), so `cat in credited_fams` cannot match — this
+        pins that invariant against a future rename or a stray membership test."""
+        result = _op(tmp_path, f"# P\n\n## Test\n\n```bash\n{command}\n```\n")
+        assert not any(
+            c["credited"] for k, c in result["details"]["categories"].items()
+            if k in ("setup", "build", "test")
+        )
+
+    def test_pylint_is_a_test_tool(self):
+        """`pylint` joined `_TEST_INTRINSIC` alongside the 16 linters already
+        there. Without it the UNCLASSIFIED change would move `uv run pylint` from
+        a wrong family to no family — one error traded for another."""
+        assert self._family("uv run pylint pkg tests") == "test"
+        assert self._family("pylint pkg tests") == "test"
 
     def test_prose_never_credits(self):
         """The reason DEFECT A is accepted. `Make sure` occurs inside a bash


### PR DESCRIPTION
Closes #133. Spec: `docs/specs/2026-07-27-runner-target-classification.md`.

`_runner_family` credited the `build` category whenever a `run`/`r`/`exec`/`dlx` keyword had
been consumed — **without ever inspecting the target**:

| | today | now |
| --- | --- | --- |
| `npm run wibble` | `build` | `unclassified` |
| `npm run test-unit` | `build` | `unclassified` |
| `yarn test-unit` (no keyword) | dropped | dropped |
| `uv run pylint …` | `build` | **`test`** |
| `npm run test`, `uv run pytest` | `test` | `test` |

The engine was reporting *"real build command resolved"* about a target it had not looked
at — the same class of unsupported claim #134 set out to remove from this repo.

Such targets now carry the family `unclassified`: real and runnable, family undetermined.
That is the doctrine `check-commands` already follows — claim `dangling` only when provable,
otherwise `unknown` — applied to the one place in the scorer that lacked it.

`pylint` joins `_TEST_INTRINSIC`, where the 16 other linters already sat. Without it this
change would move `uv run pylint` from a wrong family to *no* family: one error traded for
another.

## Why a sentinel and not `None`

A first attempt returned `None` and **was reverted**. The suite caught it: `_extract_commands`
is a shared seam and collects only `if fam:`, so a falsy family removes the row from
`command_resolution` as well. The shipped dangling fixture went from 3 findings to 1 —
`npm run evals` and the markdown-injection vector went invisible. A linter that silently
stops reporting is worse than the scoring defect it was meant to fix.

`unclassified` is truthy, so the resolver's input is untouched. That is not an argument, it
is measured below.

## Measured

**`check-commands` is set-identical** over 259 real instruction files (30-file AGENTS.md
corpus + 228 installed SKILL.md + this repo): 409 `(file|command|status)` tuples, **zero**
difference, **zero** new `dangling` claims. All 48 `command_resolution` tests pass; the
fixture still reports 3 dangling.

**Golden re-derived from the engine**, never hand-tuned:

| | before | after |
| --- | --- | --- |
| mean | 61.79 | 61.53 |
| median / min / max | 61.70 / 35.0 / 91.0 | unchanged |
| bands | B 4, C 8 | B 3, C 9 |

Exactly **one of 30 files** moves: `markov-kernel__databricks-mcp` 80.6 → 72.6, which is
opcov −20 × the agents.md weight 0.4 — the arithmetic is an internal check that nothing else
shifted. That file documents `uv run pytest`, `uv run black .`, `uv run pylint …` and a
`-- --help` call: **no build command at all**. The credit it lost was manufactured.

**This repo's own score is untouched:** 95.8, opcov 100, in-repo == isolated. Dogfood gate
still exits 0.

## Deliberately not done

The spec's **step 1** (apply the read-only guard to the delegated target) was dropped after
measurement: `_is_readonly` does not fire there — the `--` separator defeats its positional
check — and the sweep found **83** delegated known tools, none followed by `--help`/`--version`.
Speculative code with no measured case.

**Defect A** (`make test-unit` outside the vocabulary) stays won't-fix per the spec: loosening
that prose guard was measured to buy 2 genuine commands at the cost of 14 non-commands,
including a literal `Make sure` inside a bash fence.

## Review surface

The characterization matrix added in #138 is where this change is visible. The rows that flip
are exactly the ones labelled DEFECT B; the correct-today and prose-guard groups are untouched.
Two new invariants come with it: `unclassified` can never credit a scored category, and
`pylint` classifies as `test` both delegated and bare.

## Contract note

`schliff check-commands --json` may now emit `"family": "unclassified"`. `status` is unchanged
and no existing value was removed, but consumers switching on `family` should treat it as an
open set. CHANGELOG records it.

`1457 → 1466` tests, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
