### PR TITLE
chore(docs): explicit markdown conventions, fix what renders wrong, prune merged branches

### DIFF
--- a/.github/ISSUE_TEMPLATE/share_results.md
+++ b/.github/ISSUE_TEMPLATE/share_results.md
@@ -8,6 +8,7 @@ labels: community
 <!-- What skill did you improve? -->
 
 ## Before / After
+
 | Metric | Before | After |
 |--------|--------|-------|
 | Score  |        |       |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 <!-- What problem does this solve? -->
 
 ## Checklist
+
 - [ ] `make test-all` passes (all test suites green)
 - [ ] `bash test-self.sh` passes (all self-tests green)
 - [ ] `python3 score-skill.py SKILL.md --json` composite >= 90

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -75,7 +75,7 @@
   // third-party snapshots, and regenerable corpora. The proof suite asserts
   // that a bad skill scores badly, so linting these would be a category error.
   "ignores": [
-    "benchmarks/corpus/**",
+    "benchmarks/**",
     "demo/**",
     "skills/schliff/tests/**",
     "docs/launch/corpus/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,86 @@
+// Markdown conventions for this repo, made explicit.
+//
+// Without this file every editor lints against markdownlint's defaults, which
+// this repo has never followed: ~5,000 findings across 98 files, 54% of them
+// line-length alone. Noise at that volume hides the findings that are real.
+//
+// The dividing line below is CORRECTNESS vs COSMETICS. Rules that change what a
+// reader sees stay on. Rules that merely pick one valid style over another are
+// off, because this repo never chose one and retrofitting a choice means a
+// ~2,000-line diff across 60 mostly-historical documents — measured, and it
+// broke a scoring guard that had held across ten edits to the same file.
+{
+  "config": {
+    // --- off: no convention exists, and enforcing one is churn ---------------
+
+    // Prose and tables, not code. 1,413 lines exceed 120 chars (longest 1,363)
+    // and markdown reflows on render, so a column limit buys churn, not
+    // readability. Python keeps its 120-char ruff limit; different medium,
+    // different reason.
+    "MD013": false,
+
+    // The README hero needs <picture>/<source> for a theme-aware image, which
+    // markdown cannot express.
+    "MD033": false,
+
+    // GitHub alert syntax (`> [!NOTE]`) puts blank lines between adjacent
+    // blockquotes. That is how the feature is written.
+    "MD028": false,
+
+    // Files legitimately open with an HTML block (README hero) or YAML
+    // frontmatter rather than an H1.
+    "MD041": false,
+
+    // Table pipe style. Measured before deciding: enforcing `tight` strips all
+    // padding (`|Dimension|Metric|`), which is harder to read at source and
+    // rewrote this repo's own SKILL.md enough to move its pinned score;
+    // enforcing `compact` or `aligned` rewrites ~100 tables the other way.
+    // Cosmetic either way — GitHub renders all three identically. MD056 below
+    // still catches tables that are genuinely broken.
+    "MD060": false,
+
+    // Bullet marker, emphasis marker, ordered-list numbering, emphasis used as
+    // a heading: all valid markdown, all rendering the same. No convention was
+    // ever recorded, so there is nothing to enforce.
+    "MD004": false,
+    "MD049": false,
+    "MD029": false,
+    "MD036": false,
+
+    // A fence without a language loses syntax highlighting but renders
+    // correctly, and many here are deliberately plain (command output, score
+    // readouts). Note for scorer work: operational_coverage treats an
+    // unlabelled fence as shell, so adding labels would change extraction.
+    "MD040": false,
+
+    // GitHub autolinks bare URLs; this repo renders on GitHub.
+    "MD034": false,
+
+    // --- configured ---------------------------------------------------------
+
+    // A CHANGELOG repeats "### Changed" under every version heading, which is
+    // the format's whole shape. Duplicates only matter between siblings.
+    "MD024": { "siblings_only": true }
+
+    // --- everything else stays ON, because it changes what a reader sees -----
+    // MD056 table-column-count : a short row silently drops data on GitHub
+    // MD032/MD022/MD031/MD058  : missing blank lines merge lists, headings and
+    //                            fences into the preceding paragraph
+    // MD009/MD010/MD012/MD047  : trailing spaces become hard breaks; tabs and
+    //                            stray blanks render inconsistently
+    // MD038 no-space-in-code   : `` ` x ` `` renders the padding
+  },
+
+  // Scorer INPUT, not documentation. Deliberately malformed fixtures, pinned
+  // third-party snapshots, and regenerable corpora. The proof suite asserts
+  // that a bad skill scores badly, so linting these would be a category error.
+  "ignores": [
+    "benchmarks/corpus/**",
+    "demo/**",
+    "skills/schliff/tests/**",
+    "docs/launch/corpus/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/.vercel/**"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Changed
+
 - **An unrecognised `<runner> run <target>` no longer counts as a build command
   (#133).** `operational_coverage` credited the `build` category whenever a
   `run`/`r`/`exec`/`dlx` keyword had been consumed — without ever inspecting the
@@ -41,6 +42,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.7.0] - 2026-07-22
 
 ### Changed
+
 - **The `structure` score is now reproducible — a pure function of the file's
   bytes (#10).** It previously depended on the file's on-disk neighbourhood (a
   sibling `references/` directory and whether declared references resolved on
@@ -67,6 +69,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
     its on-disk siblings.
 
 ### Fixed
+
 - **The terminal no longer silently drops score warnings (#22).** The calibrated-
   weights "not comparable" notice and the "no weighted dimensions" warning — both
   already present in the JSON output — were dropped from the terminal rendering.
@@ -78,6 +81,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.6.3] - 2026-07-22
 
 ### Security
+
 - **Hardened the engine against untrusted input in third-party CI.** A pre-launch
   adversarial audit reproduced these before fixing; no golden score changes
   (`operational_coverage`/profile byte-identical).
@@ -94,6 +98,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
     oracle. Added a `realpath`+`commonpath` containment guard at each manifest read.
 
 ### Fixed
+
 - **`--format <alias>` token budget.** The short aliases (`cursor`, `agents`,
   `claude`, `skill`, `system-prompt`) fell back to the unknown=1500 budget instead
   of their real one, flipping the within-budget verdict. They now resolve via
@@ -104,6 +109,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.6.2] - 2026-07-21
 
 ### Added
+
 - **GitHub Action surfaces dangling commands.** The `AGENTS.md Lint` action now
   runs `check-commands` for `AGENTS.md`/`CLAUDE.md` and renders any dangling
   commands as a section in its existing PR comment. New opt-in `fail-on-dangling`
@@ -111,6 +117,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   for false-positive-safe behavior; older engines degrade silently.
 
 ### Fixed
+
 - **`check-commands` workspace false positives + resolver hardening.** A large
   adversarial review + council + a field sweep of 135 real repos found the 8.6.1
   check still reporting working commands as `dangling` on monorepos. Every change
@@ -135,6 +142,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.6.1] - 2026-07-21
 
 ### Fixed
+
 - **`check-commands` false positives on real repos.** An adversarial review plus a
   field sweep of real monorepos (palantir/blueprint, remotion, remix, swc) found
   the 8.6.0 check reporting working commands as `dangling` — the exact
@@ -166,6 +174,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.6.0] - 2026-07-20
 
 ### Added
+
 - **`check-commands`** — a deterministic CI gate that flags setup/build/test
   commands in an `AGENTS.md`/`CLAUDE.md` that don't resolve to a real make
   target, npm script, or path in the repo (exit 1 if dangling). Reuses the
@@ -174,12 +183,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   ~70 real repos. schliff dogfoods it against its own `AGENTS.md` in CI. (#112)
 
 ### Fixed
+
 - **`operational_coverage` object-first prohibitions**, badge temp-dir leak, and
   badge error caching (#110).
 
 ## [8.5.0] - 2026-07-07
 
 ### Fixed
+
 - **`verify` scores under the detected format profile** (#102, closes #101).
   It previously hand-rolled the SKILL scorer set, so `schliff verify AGENTS.md`
   scored the file under the wrong profile and failed spuriously (27.7/F on a
@@ -194,17 +205,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   prose no longer false-positive. Corpus goldens re-derived.
 
 ### Security
+
 - **Runtime scorer prompt hardened** (#99): skill content is nonce-wrapped
   (`<skill_context_NONCE>`) so crafted files cannot forge the prompt
   structure. Defense-in-depth — the dimension remains opt-in and gated off.
 
 ### Added
+
 - Instant star-count notify workflow for the profile-repo badge (#98).
 - Theme-aware README hero (light/dark SVG) + social-preview asset (#106).
 - Dependabot now groups github-actions bumps into one PR — split bumps of
   lockstep actions (codeql init/analyze) could never pass CI (#107).
 
 ### Docs
+
 - **README redesigned** (#100): AGENTS.md-first, every number ground-truthed
   against the released engine, ShieldClaw case-study table disambiguated
   (ceiling vs quality), hydra field study added, new "What the score does not
@@ -213,6 +227,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.4.0] - 2026-07-03
 
 ### Added
+
 - **`operational_coverage` dimension for AGENTS.md** (PR #83). Measures whether
   an AGENTS.md actually equips a coding agent to operate the repo: real
   setup/build/test commands (command-family classification, doc-wide, headings
@@ -221,6 +236,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and accepted by the leaderboard submit API.
 
 ### Changed
+
 - **BREAKING (scores): AGENTS.md headline profile is now
   `structure 0.40 / operational_coverage 0.40 / efficiency 0.20`** (was
   0.5/0.5). `efficiency` was a validated gameable proxy — a junk-fence-stuffed
@@ -229,6 +245,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   SKILL.md / CLAUDE.md / .cursorrules / system-prompt scoring is byte-identical.
 
 ### Security
+
 - Fixed a ReDoS in the operational_coverage heading regex (quadratic on
   whitespace-only heading lines; playground/Action/leaderboard take untrusted
   input). Found and fixed pre-release by a 75-agent adversarial review, along
@@ -239,6 +256,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.3.0] - 2026-06-25
 
 ### Added
+
 - **AGENTS.md scoring profile.** `AGENTS.md` is project context for coding agents,
   not a reusable skill, so it is now scored on a dedicated headline
   (`0.5·structure + 0.5·efficiency`) instead of the SKILL.md rubric. The
@@ -256,12 +274,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `uses: Zandereins/schliff@v1`. (#66, #68, #69)
 
 ### Fixed
+
 - The Action's PR comment no longer renders unmeasured (`null`) dimensions as a
   misleading `0/100`; they are omitted, matching the engine's terminal output. (#68)
 
 ## [8.2.0] - 2026-06-11
 
 ### Added
+
 - Public **Vercel deployments**: an interactive playground (`POST /api/score`, real scoring
   engine) and a community leaderboard (`/api/submit`, `/api/query`). (#50, #54)
 - Leaderboard **durable storage on Upstash Redis (Vercel KV, $0)** — atomic dedup upsert that
@@ -271,6 +291,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Machine-readable version output / agentic-integration groundwork. (#57)
 
 ### Changed
+
 - **BREAKING: drop Python 3.9 support** — minimum supported version is now Python 3.10
   (`requires-python = ">=3.10"`). Python 3.9 reached end-of-life on 2025-10-31. The CI test
   matrix and ruff `target-version` were updated accordingly. (#55)
@@ -280,6 +301,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   dimensions) instead of a coverage-capped composite; removed a phantom `sync` dimension. (#54)
 
 ### Fixed
+
 - Leaderboard submit read-modify-write **race + non-atomic write** (now flock-serialized +
   atomic `os.replace`). (#58)
 - Vercel deployability (score.py `sys.path` bootstrap, `framework:null`, build-artifact
@@ -287,6 +309,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   a11y/contrast/keyboard + Google-Fonts CSP. (#50, #53, #55, #56)
 
 ### Security
+
 - **Fix ReDoS / remote CPU-DoS in the scoring engine.** `_RE_REAL_EXAMPLES` / `_RE_DIFF_EXAMPLE`
   used an unbounded `input.*output` (O(n²) under `findall`); a ~256KB single-line payload via the
   public playground pegged a serverless function's CPU for ~90s. Bounded to `input.{0,200}?output`
@@ -304,6 +327,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [8.1.0] - 2026-06-03
 
 ### Added
+
 - Multi-agent correctness/security/determinism hardening (PR #46): calibrated weights gated
   behind `SCHLIFF_CALIBRATED_WEIGHTS` (off by default) so `verify`/`badge`/leaderboard stay
   reproducible; `weight_source`/`weights_hash` provenance; BOM-invariant scoring at the read
@@ -313,6 +337,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   issue-template `config.yml`. Top-level `--version`/`-V` flag.
 
 ### Changed
+
 - README + `docs/` redesign: accurate full-denominator composite model (replaces the previously
   inverted description in `SCORING.md`), correct dimension/weight tables, single-sourced version,
   current architecture with diagrams. Web playground/leaderboard corrected to the canonical model
@@ -321,12 +346,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Performance: `doctor` single tree-walk, O(n) header lookup in `structure`, cached regexes/MinHash.
 
 ### Removed
+
 - Internal launch corpus and marketing drafts from the public tree (regenerable via
   `skills/schliff/scripts/launch/`); untracked local tooling artifacts.
 
 ## [8.0.0] - 2026-05-29
 
 ### Added
+
 - Failure-mode-first AI-Eval foundation: sprint spec + 7 ADRs, Phase-0 open-coded failure-mode
   taxonomy (10 snapshotted skills), Phase-1 calibration scaffold.
 - Deterministic judge guards (`scoring/guards.py`): destructive-command, gating-invariant
@@ -342,6 +369,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `?score_model=N` selects a scale (default = the latest epoch present).
 
 ### Changed
+
 - **BREAKING (scoring):** Composite is now computed over a single canonical 7-dimension basis
   with a full denominator — unmeasured dimensions are uncredited (not silently renormalized away).
   Scores for skills without an eval suite are lower and now reflect coverage. This unifies the
@@ -360,6 +388,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - README leads with native install (`/plugin marketplace add`, `npx skills add`); pip demoted to CLI/CI.
 
 ### Fixed
+
 - `missing_refs` (structure): referenced files resolve skill-local OR against an enclosing
   plugin/.git root (fixes false-positives on plugin-monorepo layouts), with full paths in the
   message; plus path-traversal confinement (reject `..`, resolve-confine) so an untrusted SKILL.md
@@ -372,12 +401,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `commands/schliff/mesh.md` registered as `/mesh` instead of `/schliff:mesh`.
 
 ### Security
+
 - Pre-launch audit (3 parallel lenses + Hydra closing council): removed tracked internal docs that
   contradicted the pitch; SECURITY.md version table + network/exec claims scoped to the zero-dep core.
 
 ## [7.2.0] - 2026-04-24
 
 ### Security
+
 - **Prompt-injection hardening in `schliff evolve`**: user-authored skill
   content is wrapped in explicit XML tags with a per-call random nonce
   before being passed to LLM prompts. Earlier versions fed raw content
@@ -392,6 +423,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   line on stderr and exits 1.
 
 ### Fixed
+
 - **Scoring robustness across all dimensions**: all five scorers that
   consume user-authored eval-suite JSON (`edges`, `triggers`, `quality`,
   `runtime`, `coherence`) now guard their list-valued fields with
@@ -414,6 +446,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `terminal_art.score_to_grade`; previously each surface drifted.
 
 ### Changed
+
 - **E-band grade now emitted in badge/CI output.** Consumers that parse
   a grade field with a closed set of `{S, A, B, C, D, F}` must now accept
   `E` as well. **Breaking for JSON consumers** that did exhaustive grade
@@ -429,6 +462,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   duplicate, keeping grade mapping in one place.
 
 ### Added
+
 - **`RELEASING.md` pre-release checklist** documents the full release
   procedure (version bump, CHANGELOG draft, tag, publish, badge cache-bust).
 - **Cross-platform CI expansion**: GitHub Actions matrix covers Python
@@ -442,6 +476,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   breakage from future major releases; test files excluded from the wheel.
 
 ### Test coverage
+
 - Total: 1017 → 1117 (+100) / 0 skipped / 0 failed
 - New files: `test_scoring_type_guards.py`, `test_cli_error_handling.py`,
   `test_install_version.py`; expanded `test_scoring_edges_malformed.py`
@@ -450,12 +485,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [7.1.1] - 2026-04-18
 
 ### Fixed
+
 - **List-marker support in actionable-line patterns**: `_RE_ACTIONABLE_LINES` and three sibling patterns (`_RE_RUN_PATTERN`, `_RE_DIFF_SIGNAL`, `_RE_IMPERATIVE_INSTRUCTION`) previously only matched numbered list prefixes (`1. Run X`) or bare imperatives, silently dropping markdown bullets (`- Run X`, `* Use Y`, `+ Install Z`). A shared `_LIST_MARKER` alternation is now applied to all four. Impact on a real public CLAUDE.md (root file merged into `modelcontextprotocol/servers`): efficiency 57 → 64, composite 59.2 → 61.0.
 - **10 new regression and false-positive tests** in `TestListMarkerSupport` covering supported markers, bare-imperative regression, nested indentation, word-boundary guards, and marker-without-verb cases. Full suite: 1017 passed (up from 1007).
 
 ## [7.1.0] - 2026-03-27
 
 ### Added
+
 - **`schliff report`**: Generate Markdown quality reports with dimension breakdown, shareable via `--gist` (GitHub Gist API)
 - **`schliff drift`**: Stale reference scanner — detects paths, scripts, and make targets referenced in instruction files that no longer exist on disk
 - **`schliff sync`**: Cross-file instruction consistency analysis — finds contradictions, gaps, and redundancies across all instruction files in a repository
@@ -467,6 +504,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 140 new tests (592 → 732 total), 4 audit iterations on core branch, 1 audit iteration each on intelligence and web branches
 
 ### Security
+
 - Path traversal prevention in drift detector (normpath + containment check, absolute/parent path rejection)
 - Control character and bidirectional override rejection in leaderboard skill_name validation
 - Content-Security-Policy headers on playground and leaderboard
@@ -475,6 +513,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Version field length bound (max 50 chars) on leaderboard submissions
 
 ### Fixed
+
 - Token budget severity/within_budget contradiction at exactly 100% utilization
 - Doctor relpath used process cwd instead of scan_root (wrong paths when invoked from different directory)
 - `find_redundancies` O(n²) performance — capped at 150 directives
@@ -484,6 +523,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [7.0.0] - 2026-03-26
 
 ### Added
+
 - **Multi-format support**: Score CLAUDE.md, .cursorrules, AGENTS.md alongside SKILL.md
   - Auto-detection from filename, `--format` override flag
   - Content normalization (synthetic frontmatter for non-SKILL.md formats)
@@ -500,6 +540,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 52 new tests (540 → 592 total), 4 rounds × 6 agents security review per feature branch
 
 ### Security
+
 - SSRF redirect protection (`_SafeRedirectHandler`)
 - YAML injection prevention in content normalization
 - Path traversal guard in playground API
@@ -510,6 +551,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [6.3.0] - 2026-03-26
 
 ### Added
+
 - `schliff diff <path>` command — show score delta vs. previous commit (or any `--ref`)
   - Ref validation (prevents git flag injection), path containment check, size limit guard
   - Human-readable and `--json` output formats
@@ -521,6 +563,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - README: "Where Schliff fits" ecosystem diagram moved to Quick Start section
 
 ### Fixed
+
 - Scoring: trigger precision/recall reported 100.0 when no predictions existed (now 0.0)
 - Scoring: clarity scorer skipped ambiguous pronoun detection on first line (i==0 case)
 - Scoring: efficiency scorer returned float instead of int (inconsistent with other dimensions)
@@ -534,6 +577,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [6.2.0] - 2026-03-25
 
 ### Added
+
 - `schliff demo` command — score a built-in bad skill to see schliff in action instantly
 - `schliff badge <path>` command — generate copy-paste markdown badge for READMEs
 - Pre-commit hook support (`.pre-commit-hooks.yaml`) for automatic skill quality gates
@@ -543,6 +587,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Show HN launch draft (`docs/specs/show-hn-draft.md`)
 
 ### Fixed
+
 - Security: ReDoS in `_RE_ERROR_BEHAVIOR` — bounded `[\w\s]+` to `\w[\w ]{0,80}`
 - Security: OOM-safe eval-suite loading — `stat().st_size` check before `read_text()`
 - Security: symlink rejection on `references/` directory and files in `estimate_token_cost`
@@ -557,6 +602,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Fixed stale BUG DOCUMENTED comments in test_edge_cases.py
 
 ### Changed
+
 - Quick Start: reordered to demo → doctor → score for better onboarding
 - README: GIF uses absolute GitHub raw URL (fixes broken image on PyPI)
 - README: Mermaid diagram section includes "view on GitHub" hint for PyPI
@@ -566,6 +612,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [6.1.0] - 2026-03-24
 
 ### Added
+
 - Description-aware trigger generation in init-skill (Issue #13)
 - Precision/recall reporting in trigger scorer
 - `schliff verify` command for CI integration (exit 0/1/2, --min-score, --regression)
@@ -576,10 +623,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 10 new eval-suite test cases (tc-8..tc-17) with 66 coherence-covering assertions
 
 ### Changed
+
 - SKILL.md compressed by 13% (1676→1455 words) without information loss
 - Self-score: 95.7 → 99.0/100 [S] (quality 91→99 via coherence, efficiency 88→92 via compression)
 
 ### Fixed
+
 - Init script no longer generates Schliff-specific triggers for non-Schliff skills
 - Structural markers (code fences, headers, horizontal rules) excluded from repetition count
 - Code block content excluded from repetition counting (prevents false positives on examples)
@@ -592,11 +641,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [6.0.0] - 2026-03-24
 
 ### Changed
+
 - **Rebrand: SkillForge → Schliff** — "the finishing cut" (German: den letzten Schliff geben)
 - All `/skillforge:*` commands renamed to `/schliff:*`
 - All internal references, paths, demo files updated
 
 ### Added
+
 - **Clarity as default dimension** — 7th dimension always active (5% weight, opt-out via `--no-clarity`)
 - **Token cost estimation** — Doctor shows per-skill token cost + fleet total
 - **GitHub Action** — `Zandereins/schliff@v6` scores skills in CI, comments on PRs
@@ -613,16 +664,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 3 new unit tests (token estimation, context contradictions)
 
 ### Fixed
+
 - Trigger threshold floor prevents false positives on small eval suites
 - Missing dimension warnings always shown (except opt-in runtime)
 - Clarity false positives on same verb with different context
 
 ### Breaking
+
 - `--clarity` flag removed (clarity is now default; use `--no-clarity` to opt out)
 
 ## [5.1.1] - 2026-03-22
 
 ### Fixed
+
 - Atomic file writes in text-gradient.py (prevents skill corruption on crash)
 - `re.error` guard on all user-controlled regex patterns
 - Path traversal validation before skill file writes
@@ -639,6 +693,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [5.1.0] - 2026-03-22
 
 ### Added
+
 - **Honest Scoring** — "Structural Score" label everywhere, replacing misleading "Quality Score"
 - **Stemming Tokenizer** — suffix-stripping replaces fixed synonym tables for better keyword matching
 - **Beam Search** — top-3 exploration instead of greedy top-1 from iteration 4 onward
@@ -653,6 +708,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **Underscore Alias Modules** — `score_skill.py`, `text_gradient.py`, `skill_mesh.py`, `parallel_runner.py` for Python import compatibility
 
 ### Fixed
+
 - State truncation bug in auto-improve loop
 - EMA indexing off-by-one in plateau detection
 - Deterministic hash for MinHash reproducibility
@@ -660,6 +716,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [5.0.0] - 2026-03-21
 
 ### Added — The Self-Driving Engine
+
 - **Auto-Apply** (`text-gradient.py --apply`) — deterministic patches apply themselves without LLM
 - **Auto-Improve** (`auto-improve.py`) — autonomous loop driver: score → gradient → apply → keep/revert → repeat
 - **Strategy Predictor** (`meta-report.py predict_best_strategy()`) — predicts P(keep) before trying
@@ -675,6 +732,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - New subcommands: `/schliff:auto`, `/schliff:mesh-evolve`, `/schliff:predict`, `/schliff:recall`
 
 ### Changed
+
 - Dimension weights redistributed: triggers 25%→20%, quality 25%→20%, composability 10%→5%, new runtime 15%
 - `compute_composite()` auto-loads `calibrated-weights.json` when available
 - Scorer test updated: 7 dimensions (6 core + runtime opt-in)
@@ -682,16 +740,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [4.1.0] - 2026-03-21
 
 ### Fixed
+
 - 3 critical + 4 high security issues from 4-agent code review
 - CI stability with `--no-runtime-auto` in self-tests
 
 ## [3.1.0] - 2026-03-20
 
 ### Fixed
+
 - `--since` flag now correctly scopes all 11 methods in `progress.py`
 - Consistent score capping across all scoring functions
 
 ### Added
+
 - Cost tracking: real `duration_ms`, `tokens_estimated`, `delta`, computed `status`
 - 25 new integration tests (51 total)
 - `explain_score_change()` wired into `--diff` output
@@ -699,12 +760,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - CHANGELOG.md, SECURITY.md, GitHub CI workflow
 
 ### Removed
+
 - Dead code: `history/results.tsv`
 - Shell expansion risk: replaced `xargs` with `sed` in `run-eval.sh`
 
 ## [3.0.0] - 2026-03-20
 
 ### Added
+
 - Runtime evaluator — invoke Claude with test prompts
 - Diff-aware scoring (`--diff` flag)
 - Strategy meta-learning in `progress.py`
@@ -713,6 +776,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - 26-test integration suite + 12-test self-test suite
 
 ### Fixed
+
 - 7 critical bugs found by sparring agents
 - 3 assertion type mismatches
 - 2 crash bugs, clarity false positives
@@ -720,17 +784,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [2.3.0] - 2026-03-19
 
 ### Added
+
 - Bidirectional synonym expansion, plateau guard, interaction effect detection
 
 ## [2.0.0] - 2026-03-18
 
 ### Added
+
 - TF-IDF trigger scoring, composability analysis, 9-phase protocol
 - Discovery mode, parallel experimentation, noisy metric handling
 
 ## [1.0.0] - 2026-03-17
 
 ### Added
+
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
 [Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.3...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ All tests must pass before submitting a PR.
 ## Adding a New Scoring Dimension
 
 1. Create `scripts/scoring/your_dimension.py`:
+
    ```python
    """scoring/your_dimension.py — Your Dimension scoring."""
    from shared import read_skill_safe
@@ -74,6 +75,7 @@ All tests must pass before submitting a PR.
    ```
 
 2. Register in `scripts/scoring/__init__.py`:
+
    ```python
    from scoring.your_dimension import score_your_dimension
    ```

--- a/benchmarks/anti-gaming/skills/clean-reference.md
+++ b/benchmarks/anti-gaming/skills/clean-reference.md
@@ -6,29 +6,23 @@ description: Use when adding a release entry to CHANGELOG.md, before tagging a v
 # Changelog Updater
 
 ## When to use
-
 Use this when a release is about to be tagged and CHANGELOG.md needs a new version section.
 Do NOT use for editing release notes on the GitHub releases page — that is a separate surface.
 
 ## Steps
-
 1. Read the current `## [Unreleased]` section.
 2. Create a new `## [X.Y.Z] - YYYY-MM-DD` heading below Unreleased.
 3. Move entries from Unreleased into the new section, grouped under Added / Changed / Fixed / Removed.
 4. Leave an empty Unreleased section for future entries.
 
 ## Example
-
 Before:
-
 ```
 ## [Unreleased]
 ### Fixed
 - Crash on empty input
 ```
-
 After:
-
 ```
 ## [Unreleased]
 
@@ -38,10 +32,8 @@ After:
 ```
 
 ## Edge cases
-
 - No Unreleased entries: stop and report; do not create an empty version section.
 - Date unknown: ask for the release date rather than guessing.
 
 ## Handoff
-
 After updating, hand off to the tagging step; this skill does not run git commands.

--- a/benchmarks/anti-gaming/skills/clean-reference.md
+++ b/benchmarks/anti-gaming/skills/clean-reference.md
@@ -6,23 +6,29 @@ description: Use when adding a release entry to CHANGELOG.md, before tagging a v
 # Changelog Updater
 
 ## When to use
+
 Use this when a release is about to be tagged and CHANGELOG.md needs a new version section.
 Do NOT use for editing release notes on the GitHub releases page — that is a separate surface.
 
 ## Steps
+
 1. Read the current `## [Unreleased]` section.
 2. Create a new `## [X.Y.Z] - YYYY-MM-DD` heading below Unreleased.
 3. Move entries from Unreleased into the new section, grouped under Added / Changed / Fixed / Removed.
 4. Leave an empty Unreleased section for future entries.
 
 ## Example
+
 Before:
+
 ```
 ## [Unreleased]
 ### Fixed
 - Crash on empty input
 ```
+
 After:
+
 ```
 ## [Unreleased]
 
@@ -32,8 +38,10 @@ After:
 ```
 
 ## Edge cases
+
 - No Unreleased entries: stop and report; do not create an empty version section.
 - Date unknown: ask for the release date rather than guessing.
 
 ## Handoff
+
 After updating, hand off to the tagging step; this skill does not run git commands.

--- a/benchmarks/anti-gaming/skills/sophisticated-gamer.md
+++ b/benchmarks/anti-gaming/skills/sophisticated-gamer.md
@@ -6,26 +6,33 @@ description: Use when deployment is needed — deployment pipelines, deployment 
 # Deployment Orchestrator
 
 ## When to use
+
 Use this skill when a deployment must be orchestrated across deployment stages: deployment build, deployment test, deployment staging, deployment canary, deployment production. Reach for deployment orchestration whenever deployment promotion, deployment gating, deployment verification, or deployment rollback is required for a deployment release.
 
 Do NOT use for editing application source code, for writing deployment scripts from scratch, or for infrastructure provisioning — those are separate surfaces handled elsewhere.
 
 ## Inputs and outputs
+
 **Input:** a deployment manifest path and a target deployment environment name.
 **Output:** a deployment status report (success or failure) and a deployment audit log written to the deployment artifacts directory.
 
 ## Steps
+
 1. Read the deployment manifest and validate the deployment target environment.
 2. Run the deployment preflight: deployment health checks, deployment dependency resolution, deployment credential checks.
 3. Execute the deployment in deployment-canary mode first, then promote the deployment to deployment-production.
 4. Verify the deployment via deployment smoke tests and record the deployment result.
 
 ## Example
+
 Before a deployment to staging:
+
 ```
 deploy --manifest deploy.yaml --env staging --strategy canary
 ```
+
 After a successful deployment:
+
 ```
 deployment: staging
 status: promoted
@@ -33,24 +40,31 @@ canary: passed
 ```
 
 ## Edge cases
+
 - Deployment manifest missing: stop and report; do not start a partial deployment.
 - Deployment target unknown: ask for the deployment environment rather than guessing a deployment target.
 - Deployment canary fails: trigger an automatic deployment rollback and report the failed deployment.
 
 ## Error behavior
+
 On any deployment failure the skill aborts the deployment, performs a deployment rollback to the last known-good deployment, and reports the deployment error. It never leaves a deployment in a half-promoted deployment state.
 
 ## Idempotency and safety
+
 Re-running the same deployment is idempotent: a deployment already promoted is detected and skipped safely. The deployment never mutates global deployment state outside the named deployment environment.
 
 ## Dependencies
+
 Requires a deployment CLI to be available; if the deployment CLI is absent, falls back to an alternative deployment API client. No other hard tool requirement.
 
 ## Namespace
+
 All deployment artifacts are namespaced under the `deploy/` prefix to isolate deployment state from other skills.
 
 ## Version compatibility
+
 Compatible with deployment-engine v2 and above. For deployment-engine v1, use the legacy deployment adapter.
 
 ## Handoff
+
 After the deployment completes, hand off to the monitoring skill; this skill does not run post-deployment monitoring itself.

--- a/benchmarks/anti-gaming/skills/sophisticated-gamer.md
+++ b/benchmarks/anti-gaming/skills/sophisticated-gamer.md
@@ -6,33 +6,26 @@ description: Use when deployment is needed — deployment pipelines, deployment 
 # Deployment Orchestrator
 
 ## When to use
-
 Use this skill when a deployment must be orchestrated across deployment stages: deployment build, deployment test, deployment staging, deployment canary, deployment production. Reach for deployment orchestration whenever deployment promotion, deployment gating, deployment verification, or deployment rollback is required for a deployment release.
 
 Do NOT use for editing application source code, for writing deployment scripts from scratch, or for infrastructure provisioning — those are separate surfaces handled elsewhere.
 
 ## Inputs and outputs
-
 **Input:** a deployment manifest path and a target deployment environment name.
 **Output:** a deployment status report (success or failure) and a deployment audit log written to the deployment artifacts directory.
 
 ## Steps
-
 1. Read the deployment manifest and validate the deployment target environment.
 2. Run the deployment preflight: deployment health checks, deployment dependency resolution, deployment credential checks.
 3. Execute the deployment in deployment-canary mode first, then promote the deployment to deployment-production.
 4. Verify the deployment via deployment smoke tests and record the deployment result.
 
 ## Example
-
 Before a deployment to staging:
-
 ```
 deploy --manifest deploy.yaml --env staging --strategy canary
 ```
-
 After a successful deployment:
-
 ```
 deployment: staging
 status: promoted
@@ -40,31 +33,24 @@ canary: passed
 ```
 
 ## Edge cases
-
 - Deployment manifest missing: stop and report; do not start a partial deployment.
 - Deployment target unknown: ask for the deployment environment rather than guessing a deployment target.
 - Deployment canary fails: trigger an automatic deployment rollback and report the failed deployment.
 
 ## Error behavior
-
 On any deployment failure the skill aborts the deployment, performs a deployment rollback to the last known-good deployment, and reports the deployment error. It never leaves a deployment in a half-promoted deployment state.
 
 ## Idempotency and safety
-
 Re-running the same deployment is idempotent: a deployment already promoted is detected and skipped safely. The deployment never mutates global deployment state outside the named deployment environment.
 
 ## Dependencies
-
 Requires a deployment CLI to be available; if the deployment CLI is absent, falls back to an alternative deployment API client. No other hard tool requirement.
 
 ## Namespace
-
 All deployment artifacts are namespaced under the `deploy/` prefix to isolate deployment state from other skills.
 
 ## Version compatibility
-
 Compatible with deployment-engine v2 and above. For deployment-engine v1, use the legacy deployment adapter.
 
 ## Handoff
-
 After the deployment completes, hand off to the monitoring skill; this skill does not run post-deployment monitoring itself.

--- a/commands/schliff/analyze.md
+++ b/commands/schliff/analyze.md
@@ -17,6 +17,7 @@ Perform a comprehensive analysis of a skill and identify top improvements.
    "Which skill should I analyze? Give me the path to its SKILL.md."
 
 2. Check if an eval suite exists. If not, suggest initialization:
+
    ```
    No eval suite found at eval-suite.json.
    Run /schliff:init first to auto-generate one, then I can give you detailed metrics.
@@ -32,11 +33,13 @@ Perform a comprehensive analysis of a skill and identify top improvements.
 4. If a references/ directory exists, list and read each file for additional context.
 
 5. Run structural analysis:
+
    ```bash
    bash scripts/analyze-skill.sh /path/to/SKILL.md
    ```
 
 6. If eval suite exists, run comprehensive scoring:
+
    ```bash
    python3 scripts/score-skill.py \
      /path/to/SKILL.md \
@@ -45,6 +48,7 @@ Perform a comprehensive analysis of a skill and identify top improvements.
    ```
 
 7. If eval suite exists, run assertion checks:
+
    ```bash
    bash scripts/run-eval.sh \
      /path/to/SKILL.md \
@@ -54,7 +58,7 @@ Perform a comprehensive analysis of a skill and identify top improvements.
 
 8. Score each dimension manually for nuance:
 
-   - **Structure (15% weight)**: 
+   - **Structure (15% weight)**:
      * Frontmatter completeness, header organization, length proportionality
      * Examples and progressive disclosure (simple → complex)
      * Readability and logical flow

--- a/commands/schliff/auto.md
+++ b/commands/schliff/auto.md
@@ -23,11 +23,13 @@ Run the autonomous, script-driven improvement loop on a skill.
    If eval suite is missing: "Run `/schliff:init <path>` first to generate an eval suite."
 
 3. Run the autonomous improvement loop:
+
    ```bash
    python3 scripts/auto-improve.py /path/to/SKILL.md --json
    ```
 
 4. Monitor output and present progress as it runs:
+
    ```
    === Schliff Auto-Improve ===
    Skill: [name]
@@ -52,6 +54,7 @@ Run the autonomous, script-driven improvement loop on a skill.
 ## Stopping Conditions
 
 The loop stops automatically when:
+
 - Composite score reaches 98+
 - All dimensions reach 90+
 - EMA-based ROI drops below 0.1 for 5 consecutive iterations

--- a/commands/schliff/bench.md
+++ b/commands/schliff/bench.md
@@ -16,16 +16,19 @@ Establish or update a quality baseline benchmark for the target skill.
 1. Identify the target skill path from the user's message.
 
 2. If no eval suite exists and the user hasn't run `/schliff:init` yet, suggest it:
+
    ```
    No eval suite found. Run /schliff:init first to auto-generate one.
    ```
 
 3. Run structural analysis:
+
    ```bash
    bash scripts/analyze-skill.sh /path/to/SKILL.md
    ```
 
 4. Run the Python scorer to get all 7 dimensions:
+
    ```bash
    python3 scripts/score-skill.py \
      /path/to/SKILL.md \
@@ -34,6 +37,7 @@ Establish or update a quality baseline benchmark for the target skill.
    ```
 
 5. Run binary eval assertions (if eval suite exists):
+
    ```bash
    bash scripts/run-eval.sh \
      /path/to/SKILL.md \
@@ -48,6 +52,7 @@ Establish or update a quality baseline benchmark for the target skill.
    - Pass rate: (assertions_passed / assertions_total)
 
 7. Record the benchmark in schliff-results.jsonl:
+
    ```bash
    echo '{"exp": N, "timestamp": "ISO-8601", "trigger": "bench", \
      "composite_score": XX, "pass_rate": "X/Y", "scores": {...}}' \
@@ -55,6 +60,7 @@ Establish or update a quality baseline benchmark for the target skill.
    ```
 
 8. Create a history snapshot of the current SKILL.md:
+
    ```bash
    cp /path/to/SKILL.md /path/to/skill/schliff-history/exp-NNN-benchmark.md
    ```

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -13,6 +13,7 @@ Run a comprehensive health check on all installed skills.
 ## Instructions
 
 1. Run the doctor script:
+
    ```bash
    python3 scripts/doctor.py --json
    ```

--- a/commands/schliff/eval.md
+++ b/commands/schliff/eval.md
@@ -26,7 +26,7 @@ The eval system operates in two modes that can be combined:
    - Run against actual skill outputs
    - Produce pass rate: X/Y assertions (percentage)
 
-The `composite_score` is a weighted average of measured dimensions. The `pass_rate` 
+The `composite_score` is a weighted average of measured dimensions. The `pass_rate`
 tracks binary assertion success independently.
 
 ## Usage
@@ -45,21 +45,25 @@ tracks binary assertion success independently.
 ### Examples
 
 #### Standard evaluation (all dimensions + assertions)
+
 ```
 /schliff:eval .claude/skills/my-skill/SKILL.md
 ```
 
 #### Quick pass/fail check
+
 ```
 /schliff:eval .claude/skills/my-skill/SKILL.md --quick
 ```
 
 #### Compare to previous run
+
 ```
 /schliff:eval .claude/skills/my-skill/SKILL.md --compare .schliff-eval/exp-15.json
 ```
 
 #### With custom timeout
+
 ```
 /schliff:eval .claude/skills/my-skill/SKILL.md --timeout 600
 ```
@@ -71,11 +75,13 @@ tracks binary assertion success independently.
 Read the SKILL.md to extract the skill name and location.
 
 Look for `eval-suite.json` in the skill directory:
+
 ```bash
 ls <skill_dir>/eval-suite.json
 ```
 
 If no eval suite exists, offer to generate one from the template:
+
 ```
 Would you like me to generate an eval suite from the template?
 I'll create triggers, test cases, and edge cases for <skill_name>.
@@ -90,12 +96,14 @@ python3 scripts/score-skill.py <SKILL.md> --eval-suite <eval-suite.json> --json
 ```
 
 This produces:
+
 - `composite_score` (weighted average, 0-100)
 - `dimensions` (per-dimension breakdown)
 - `confidence` (how many dimensions were measured)
 
-**Note:** Some dimensions (`quality`, `edges`) require runtime eval. If unmeasured, 
+**Note:** Some dimensions (`quality`, `edges`) require runtime eval. If unmeasured,
 the confidence will be lower. Static dimensions that always work:
+
 - `structure` (code organization)
 - `triggers` (description matching)
 - `efficiency` (token efficiency)
@@ -146,11 +154,13 @@ Edge cases stress-test error handling and boundary conditions.
 ### 4. Produce unified results
 
 Use `/schliff:eval`'s internal runner (`run-eval.sh`), which orchestrates:
+
 - Python scorer
 - Binary assertion runner
 - Results compilation
 
 Output JSON structure:
+
 ```json
 {
   "experiment_id": 42,
@@ -228,10 +238,12 @@ RECOMMENDATIONS
 ### 6. Save results and tracking
 
 Results are saved to:
+
 - **JSON**: `.schliff-eval/exp-<N>.json` (full details)
 - **JSONL log**: `.schliff-eval/results.jsonl` (one line per run, for graphing)
 
 The results log format (JSONL):
+
 ```jsonl
 {"experiment_id": 42, "skill_name": "my-skill", "pass_rate": 80, "composite_score": 85.3, "timestamp": "2026-03-19T15:30:45Z"}
 {"experiment_id": 43, "skill_name": "my-skill", "pass_rate": 85, "composite_score": 86.8, "timestamp": "2026-03-19T15:45:20Z"}
@@ -252,6 +264,7 @@ If `--compare` is provided:
    - `✗` = regressed
 
 Example:
+
 ```
 COMPARISON TO BASELINE [exp #38]
 
@@ -267,10 +280,9 @@ COMPARISON TO BASELINE [exp #38]
 
 - **Quick iterations**: Use `--quick` mode during skill development (assertions only).
 - **Full validation**: Run the full eval before committing improvements.
-- **Baseline tracking**: Save a baseline after each major improvement, then use 
+- **Baseline tracking**: Save a baseline after each major improvement, then use
   `--compare` to verify that refactoring didn't regress quality.
-- **Minimal evals**: A skill with just 3-4 positive triggers + 2-3 test cases is 
+- **Minimal evals**: A skill with just 3-4 positive triggers + 2-3 test cases is
   usually enough to catch regressions.
-- **Timeout strategy**: Set `--timeout 600` for complex skills with many assertions 
+- **Timeout strategy**: Set `--timeout 600` for complex skills with many assertions
   (default 300s is usually sufficient).
-

--- a/commands/schliff/init.md
+++ b/commands/schliff/init.md
@@ -51,6 +51,7 @@ Initialize Schliff improvement tracking for a skill.
         * Assertion: response explains what it could/couldn't do and why
 
 4. Save the generated eval suite as JSON:
+
    ```bash
    python3 scripts/init-skill.py \
      /path/to/SKILL.md \
@@ -59,6 +60,7 @@ Initialize Schliff improvement tracking for a skill.
    ```
 
 5. Run the baseline benchmark using the new eval suite:
+
    ```bash
    python3 scripts/score-skill.py \
      /path/to/SKILL.md \
@@ -67,17 +69,20 @@ Initialize Schliff improvement tracking for a skill.
    ```
 
 6. Create the schliff-results.jsonl file and record experiment #0:
+
    ```bash
    echo '{"exp": 0, "timestamp": "ISO-8601", "trigger": "init", "composite_score": XX, "pass_rate": X/Y, "scores": {...}}' \
      > /path/to/skill/schliff-results.jsonl
    ```
 
 7. Create the version history directory:
+
    ```bash
    mkdir -p /path/to/skill/schliff-history/
    ```
 
 8. Save a copy of the baseline SKILL.md:
+
    ```bash
    cp /path/to/SKILL.md /path/to/skill/schliff-history/exp-000-baseline.md
    ```

--- a/commands/schliff/log-failure.md
+++ b/commands/schliff/log-failure.md
@@ -18,12 +18,15 @@ Manually log a skill failure for later triage and analysis.
    - **Context** (optional): Any additional details (input that caused it, expected vs actual behavior)
 
 2. Validate the failure type is one of the known types:
+
    ```
    trigger | quality | edge | crash
    ```
+
    If unknown, suggest the closest match.
 
 3. Construct the failure entry:
+
    ```json
    {
      "skill": "skill-name",
@@ -36,18 +39,21 @@ Manually log a skill failure for later triage and analysis.
    ```
 
 4. Append to the failure log:
+
    ```bash
    mkdir -p .schliff
    echo '<JSON_ENTRY>' >> .schliff/failures.jsonl
    ```
 
 5. If the file exceeds 1 MB, warn the user:
+
    ```
    Warning: failures.jsonl is getting large. Consider running /schliff:triage
    to process and archive resolved failures.
    ```
 
 6. Confirm the log entry:
+
    ```
    Failure logged:
    - Skill: [name]

--- a/commands/schliff/report.md
+++ b/commands/schliff/report.md
@@ -106,6 +106,7 @@ Based on analysis of kept experiments:
 ### Parsing JSONL Format
 
 Each line in `schliff-results.jsonl` is a JSON object:
+
 ```json
 {
   "exp": 0,
@@ -131,6 +132,7 @@ Each line in `schliff-results.jsonl` is a JSON object:
 ### Computing Trends
 
 For each dimension across kept iterations:
+
 - Split experiments into early half and late half
 - Calculate average score for each half
 - Classify as: improving (+2% or more), stable (within 2%), declining (-2% or more)
@@ -138,6 +140,7 @@ For each dimension across kept iterations:
 ### Top Impactful Improvements
 
 Sort kept iterations by `delta` field (composite score change from previous kept baseline):
+
 1. Select top 5 by magnitude
 2. Display in order of experiment number (chronological)
 3. Include commit hash for traceability
@@ -145,6 +148,7 @@ Sort kept iterations by `delta` field (composite score change from previous kept
 ### Experiment Velocity
 
 Calculate as:
+
 ```
 velocity = (total_experiments) / (total_duration_seconds / 3600)
 ```
@@ -159,4 +163,3 @@ Shows how many experiments per hour the improvement loop is achieving.
 4. **If stable across dimensions:** Consider novel approaches
 5. **If high crash rate (>10%):** Review crash logs, simplify hypotheses
 6. **If low keep rate (<25%):** Improve hypothesis generation or scoring
-

--- a/commands/schliff/triage.md
+++ b/commands/schliff/triage.md
@@ -13,12 +13,15 @@ Cluster and prioritize logged failures, then generate targeted fixes.
 ## Instructions
 
 1. Locate the failure log:
+
    ```bash
    cat .schliff/failures.jsonl 2>/dev/null | head -5
    ```
+
    If empty or missing: "No failures logged yet. Use `/schliff:log-failure` to record issues, or failures are auto-logged during eval runs."
 
 2. Load and parse all failure entries. Each entry has:
+
    ```json
    {"skill": "skill-name", "failure_type": "trigger|quality|edge|crash", "description": "what went wrong", "timestamp": "ISO-8601", "context": "optional details"}
    ```
@@ -26,6 +29,7 @@ Cluster and prioritize logged failures, then generate targeted fixes.
 3. Cluster failures by `skill` + `failure_type`. Count occurrences per cluster.
 
 4. Sort clusters by count (descending). Present the top issues:
+
    ```
    === Schliff Failure Triage ===
 
@@ -45,11 +49,13 @@ Cluster and prioritize logged failures, then generate targeted fixes.
    - **Crash failures**: Identify the unhandled input and suggest a guard clause
 
 6. If `text-gradient.py` is available, run it to generate concrete patches:
+
    ```bash
    python3 scripts/text-gradient.py /path/to/SKILL.md --focus "failure_description" --json
    ```
 
 7. Present recommended actions:
+
    ```
    Recommended Actions:
    1. [skill-name] Add 3 negative triggers to eval-suite.json (trigger cluster)

--- a/commands/schliff/update.md
+++ b/commands/schliff/update.md
@@ -18,6 +18,7 @@ Update Schliff to the latest version.
    - Ask the user for the path if not found
 
 2. **Pull latest changes:**
+
    ```bash
    cd <repo_root>
    git fetch origin main
@@ -28,12 +29,15 @@ Update Schliff to the latest version.
 3. **Show version diff** — compare the CHANGELOG.md before and after pull to highlight new features.
 
 4. **Re-install if using copy mode** (not symlinks):
+
    ```bash
    bash install.sh
    ```
+
    If symlink mode is detected (skills dir is a symlink), skip this step — git pull already updated everything.
 
 5. **Verify installation:**
+
    ```bash
    cd skills/schliff/scripts
    python3 score-skill.py ../SKILL.md --json 2>&1 | python3 -c "import sys,json;d=json.load(sys.stdin);print(f'Schliff v5.1 — Score: {d[\"composite_score\"]}/100')"

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,13 @@ and quick start, see the [project README](../README.md).
 **Current version: 8.7.0.**
 
 ## Understand the tool
+
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — how the scoring pipeline fits together: the scorer registry, the composite model, and the script-level file tree.
 - **[SCORING.md](SCORING.md)** — dimensions, weights, grades, and methodology.
 - **[adr/](adr/)** — Architecture Decision Records (0001–0007): the *why* behind the design (failure-mode-first scoping, calibration protocol, same-family LLM default, spec-versioning, …).
 
 ## What it measures
+
 - **Multi-format.** Scores `SKILL.md`, `CLAUDE.md`, `.cursorrules`, `AGENTS.md`, and system prompts. The `SKILL.md` family (also `CLAUDE.md` / `.cursorrules` / `AGENTS.md`) shares one scorer registry; system prompts have their own scorer and weight set. Each format carries its own token budget.
 - **Headline dimensions** (`SKILL.md` family): structure, triggers, quality, edges, efficiency, composability, clarity. These seven form the headline composite, renormalized to sum to 1.0.
 - **Full-denominator composite.** Unmeasured dimensions contribute 0 and *stay in the basis* — the score ceiling equals weight-coverage, so a partially measured skill can't inflate its grade. (Optional weight **calibration** is **off by default** to keep `verify` / `badge` / leaderboard reproducible across machines; opt in via `SCHLIFF_CALIBRATED_WEIGHTS` for the interactive `score` command only.)
@@ -23,10 +25,12 @@ and quick start, see the [project README](../README.md).
 LLM-judge and evolve features are optional extras (`[judge]`, `[evolve]`); the core engine never requires a network call.
 
 ## See it on real files
+
 - **[case-studies/shieldclaw/](case-studies/shieldclaw/)** — before/after of a real skill optimization, with baseline and optimized score artifacts and the eval suite.
 - **[launch/state-of-ai-instructions.md](launch/state-of-ai-instructions.md)** — the public report: 120 instruction files scored across 60 repos. **Historical:** measured 2026-04-17 on schliff v7.1.0; the figures do not reproduce on the current engine (see the header note in the file). The corpus itself is not bundled (third-party files, varying licenses); regenerate it locally with the pipeline in [`../skills/schliff/scripts/launch/`](../skills/schliff/scripts/launch/) (`collect_corpus.py` → `score_corpus.py` → `aggregate_stats.py`).
 
 ## Internal / working docs (not part of the public guide)
+
 `specs/`, `research/`, `ops/`, and `superpowers/` hold in-progress design specs,
 research notes, runbooks, and planning artifacts. They are kept for transparency
 and reproducibility but are working documents, not stable public documentation —

--- a/docs/adr/0001-failure-mode-first-scoping.md
+++ b/docs/adr/0001-failure-mode-first-scoping.md
@@ -35,12 +35,14 @@ The deterministic linter's existing dimensions remain untouched. The LLM-Judge l
 ## Consequences
 
 **Positive:**
+
 - AI-Eval pillar evaluates what cannot be regex-checked; provides genuine value-add over the existing linter.
 - Aligns with Hamel/Shreya practitioner consensus, reducing "premature formalization" risk identified during sparring-round meta-finding.
 - Failure taxonomy is a reusable artifact for v8.1+ AI-Eval expansion (more dims, more domains).
 - Avoids the trap of building eval infrastructure before understanding failure modes.
 
 **Negative:**
+
 - Day 1–3 budget is locked to Franz's solo cognitive work; subagents can prepare (clone, pre-annotate, queue) but cannot replace the reading.
 - If kill-gate triggers (no semantic dims emerge), AI-Eval pillar is dropped from v8.0 — narrative is simpler but less ambitious. Trade-off accepted.
 - Phase 0 cannot start in parallel with Phase 1 worktree builds; serializes the first 3 days.

--- a/docs/adr/0002-calibration-set-protocol.md
+++ b/docs/adr/0002-calibration-set-protocol.md
@@ -25,11 +25,13 @@ The practitioner-mainstream evidence converged decisively against the upfront pl
 ## Consequences
 
 **Positive:**
+
 - Calibration cost stays inside one sprint; no labelling sweatshop phase.
 - Binary scale forces taxonomy clarity (any "it depends" item exposes a missing failure mode rather than hiding inside a 3-of-5).
 - Re-grade pass institutionalises drift handling instead of pretending drift does not happen.
 
 **Negative:**
+
 - Single labeller = single point of bias; mitigated only by ADR-0005's cross-family validation pass and public methodology disclosure.
 - Holdout < 200 limits statistical power for thin-sliced sub-analyses; acceptable at v8.0 scope.
 

--- a/docs/adr/0003-composio-corpus-exclusion.md
+++ b/docs/adr/0003-composio-corpus-exclusion.md
@@ -30,11 +30,13 @@ The license posture across the candidate sources is therefore not uniform: **Com
 ## Consequences
 
 **Positive:**
+
 - Zero legal risk on launch; corpus is provably clean.
 - Forces tighter focus on the 191-skill set — sufficient for ADR-0001's failure-mode coding (n=30 sample) and Phase P3 calibration (n=100–150 holdout per ADR-0002).
 - Establishes a clean precedent: license-first corpus hygiene is a measurement-layer credibility signal.
 
 **Negative:**
+
 - Corpus is ~4.5x smaller than the maximum-feasible alternative; some long-tail failure modes (especially integration-skill-specific ones) likely under-represented.
 - Schliff loses the "evaluated against ~1000 skills" headline number; v8.0 ships with "evaluated against ~190 skills, all clean-licensed".
 

--- a/docs/adr/0004-both-modes-ship-judge-advisory.md
+++ b/docs/adr/0004-both-modes-ship-judge-advisory.md
@@ -32,11 +32,13 @@ On (1), a phased rollout (advisor-only in v8.0, autonomous in v8.1) was the orig
 ## Consequences
 
 **Positive:**
+
 - One gating-mechanism (the deterministic guard) means one place to audit and tune for regressions; reduces cognitive surface area.
 - LLM-Judge stays slow/expensive but advisory — it can be Sonnet-4.5 with N=5 self-consistency (ADR-0006) without blocking the inner loop.
 - Both modes ship → no "advisor never gets used" failure mode.
 
 **Negative:**
+
 - Two modes to document, support, and test in the README/CHANGELOG.
 - Users who *want* LLM-judgment to block patches must wait for v8.1 (an opt-in `--llm-gate` flag is on the v8.1 backlog).
 

--- a/docs/adr/0005-per-dimension-reliability-reporting.md
+++ b/docs/adr/0005-per-dimension-reliability-reporting.md
@@ -27,11 +27,13 @@ The reporting-shape question is separate. Going per-dimension-only optimises for
 ## Consequences
 
 **Positive:**
+
 - Per-dim drilldown earns measurement-layer credibility with eval-literate readers (the Hamel/Shreya/Eugene audience).
 - Composite anchor satisfies first-glance scan on README and HN comment threads; removes the "what is this number" friction.
 - Threshold suppression ("preview" flag) is a built-in honesty mechanism for dimensions still calibrating.
 
 **Negative:**
+
 - Two-layer reporting is more documentation surface to maintain (methodology page must stay in sync with the headline computation).
 - Macro-averaging in the composite hides class imbalance across dimensions; mitigated only by the per-dim drilldown one click away.
 

--- a/docs/adr/0006-same-family-llm-default.md
+++ b/docs/adr/0006-same-family-llm-default.md
@@ -29,11 +29,13 @@ Local-only was rejected on capability: published Cohen's κ vs human for Prometh
 ## Consequences
 
 **Positive:**
+
 - Cost stays inside the v8.0 budget; calibration cycles can be re-run cheaply when the corpus or rubric shifts.
 - N=5 self-consistency directly addresses the documented variance failure mode.
 - Cross-family fallback path exists and is invoked exactly where it adds signal (disagreement, validation pass) — not as a flat tax.
 
 **Negative:**
+
 - Self-preference bias remains a known limitation; methodology page must disclose it explicitly with the validation-pass result.
 - Adding a new family (e.g., Gemini-3 when it ships) requires re-running the validation pass before publishing.
 

--- a/docs/adr/0007-spec-versioning-via-adr.md
+++ b/docs/adr/0007-spec-versioning-via-adr.md
@@ -27,11 +27,13 @@ The cultural reference points (IETF RFCs, Rust RFC process) are governance patte
 ## Consequences
 
 **Positive:**
+
 - ADRs are the smaller, debate-ready unit — cheaper to write, cheaper to revise, cheaper to argue about than a versioned monolith.
 - Avoids the "spec lags reality" failure mode common when both ADRs and a master spec must co-evolve.
 - Clear bump-trigger conditions prevent the question from re-arising at every ADR; future-proofs the decision.
 
 **Negative:**
+
 - New readers must follow the addendum-pointer chain to reconstruct the current view; v0.3 read alone is incomplete.
 - ADR-archaeology becomes the onboarding cost when condition (a) eventually fires; mitigated by the addendum index and ADR cross-references.
 

--- a/docs/case-studies/shieldclaw/SKILL-after.md
+++ b/docs/case-studies/shieldclaw/SKILL-after.md
@@ -23,6 +23,7 @@ Do not use ShieldClaw for trusted first-party API responses or user-authored loc
 ## Active Hooks (v0.3)
 
 When installed as a plugin, 4 hooks scan tool inputs, outputs, and outgoing messages at zero token cost:
+
 - `before_tool_call`: Blocks tool calls with CRITICAL injection patterns in parameters
 - `tool_result_persist`: Prepends warnings to tool outputs containing injection patterns
 - `after_tool_call`: Logs findings from tool outputs for audit trail

--- a/docs/case-studies/shieldclaw/SKILL-before.md
+++ b/docs/case-studies/shieldclaw/SKILL-before.md
@@ -21,6 +21,7 @@ description: "Prompt injection defense for OpenClaw agents. Provides real-time a
 ## Active Hooks (v0.3)
 
 When installed as a plugin, 4 hooks automatically scan tool inputs, outputs, and outgoing messages at zero token cost:
+
 - `before_tool_call`: Blocks tool calls with CRITICAL injection patterns in parameters
 - `tool_result_persist`: Prepends warnings to tool outputs containing injection patterns
 - `after_tool_call`: Logs findings from tool outputs for audit trail

--- a/docs/launch/state-of-ai-instructions.md
+++ b/docs/launch/state-of-ai-instructions.md
@@ -220,6 +220,7 @@ schliff report <file>       # markdown quality report
 ```
 
 The full data-collection pipeline is in `scripts/launch/`:
+
 - `collect_corpus.py` — fetches files via GitHub search
 - `score_corpus.py` — runs `schliff score --json` on each file
 - `aggregate_stats.py` — produces all numbers above

--- a/docs/ops/vercel-deploy-runbook.md
+++ b/docs/ops/vercel-deploy-runbook.md
@@ -2,6 +2,7 @@
 
 > Status as of 2026-06-03: **DEPLOYED**. Both projects are live and public in
 > team `zaneins-projects`:
+>
 > - Playground: https://schliff-playground.vercel.app (`POST /api/score`)
 > - Leaderboard: https://schliff-leaderboard.vercel.app (`GET /api/query`, `POST /api/submit`)
 >

--- a/docs/research/2026-04-28-skill-failure-modes.md
+++ b/docs/research/2026-04-28-skill-failure-modes.md
@@ -362,10 +362,12 @@ Hamel's question is never "is this skill good?" — it is "what does this specim
 ### Final scored judge scope (human-ratified)
 
 **3 core + 1 opt-in + deterministic helpers:**
+
 1. `verifiable_success` (B) — rock-solid; incl. `#reflexivity` sub-tag. Members 01/02/03/05/07.
 2. `assumption_completeness` (C) — solid; scoped to the *unstated-assumption* core, disjoint from `composability`. Members 01/03/04/06. (`#externalized-content` = harness meta-property, not a member.)
 3. `capability_fidelity` (A) — ⚠ probationary; sole clean anchor 03; lead with `#capability-overclaim`. **Gated on counter-samples.**
 4. `harmful_downstream_instruction` (F) — opt-in; 02 + 09.
+
 - **Deterministic (not LLM):** destructive-command detector → human-review flag (09); mixed-script frontmatter check (10); the **gating invariant** (judge runs only above a linter-completeness floor).
 - **Retained annotation, NOT scored:** `#process-overhead` (proportionality/absolutism, 06/07) — Hamel 4-bar fail; revisit only on cross-archetype recurrence with measurable κ.
 
@@ -383,6 +385,7 @@ Hamel's question is never "is this skill good?" — it is "what does this specim
 **Optimal minimal anchor set (keep + feature):** `02` (F+B), `03` (A), `07` (B/false-precision), `04` (C/owner-coupled), `01` (C/clean-high-band), `09` (F/safety). **Controls:** `08` (stub floor), `10` (hypertrophy floor). **Secondary:** `05` (B/reflexivity, license-gated). **Most droppable as a calibration anchor:** `06` (de-scored, redundant) — retain only as a `#process-overhead` annotation example.
 
 **The three corpus gaps that matter more than any single skill (Hamel):**
+
 1. **A is a one-specimen anchor** → `capability_fidelity` cannot be aligned/validated. **Add ≥2 more A specimens (one procedural, one non-procedural)** before A scores anything.
 2. **The set is fail-heavy with zero clean PASS controls** → the judge's **TNR / false-positive rate is unmeasurable**. **Add known-GOOD specimens per scored dim** (reserve candidates: `mcp-builder` 79.1, `claude-api` 68.4 K1-positive, `doc-coauthoring` K4-positive) as negative controls.
 3. **Representativeness of the *scored* dims:** the probes (08/09/10) are mostly *floor/control*, not mid-band messy production skills that fail B/C/A. Schliff's users live at mean composite 61.7 — **add mid-band community probes that exhibit B/C/A failures**, not just stubs and dumps.
@@ -402,6 +405,7 @@ Phase-0 open-coding ran as a Claude 10-council **third-opinion advisory**, then 
 **KILL-GATE 1: PASS (conditional, disciplined scope)** — confirmed by cross-family GPT-5 sub-reviewer (+ corroborating Claude interim). AI-Eval pillar proceeds to Phase 1.
 
 **Locked Phase-1 judge scope — 4 dimensions:**
+
 1. `capability_fidelity` — *narrowed:* only "skill looks formally clean but doesn't deliver its claimed capability"; empty-body/missing-procedure cases are excluded (linter territory).
 2. `verifiable_success` — unrestricted; strongest dim.
 3. `assumption_completeness` — scoped disjoint from `composability` (judge the *unstated* assumption + *missing fallback*, not whether a dependency is declared).

--- a/docs/research/rewrites/02-canvas-design.SKILL.md
+++ b/docs/research/rewrites/02-canvas-design.SKILL.md
@@ -7,6 +7,7 @@ license: Complete terms in LICENSE.txt
 These are instructions for creating design philosophies — aesthetic movements that are then EXPRESSED VISUALLY. Output only .md files, .pdf files, and .png files.
 
 Complete this in two steps:
+
 1. Design Philosophy Creation (.md file)
 2. Express it on a canvas (.pdf file or .png file)
 
@@ -15,16 +16,19 @@ First, undertake this task:
 ## DESIGN PHILOSOPHY CREATION
 
 To begin, create a VISUAL PHILOSOPHY (not layouts or templates) that will be interpreted through:
+
 - Form, space, color, composition
 - Images, graphics, shapes, patterns
 - Minimal text as visual accent
 
 ### THE CRITICAL UNDERSTANDING
+
 - What is received: Some subtle input or instructions by the user that should be taken into account as a foundation; it should not constrain creative freedom.
 - What is created: A design philosophy/aesthetic movement.
 - What happens next: Then, the same version receives the philosophy and EXPRESSES IT VISUALLY — creating artifacts that are 90% visual design, 10% essential text.
 
 Consider this approach:
+
 - Write a manifesto for an art movement
 - The next phase involves making the artwork
 
@@ -37,6 +41,7 @@ The philosophy must emphasize: Visual expression. Spatial communication. Artisti
 **Articulate the philosophy** (4-6 paragraphs — concise but complete):
 
 To capture the VISUAL essence, express how the philosophy manifests through:
+
 - Space and form
 - Color and material
 - Scale and rhythm
@@ -44,6 +49,7 @@ To capture the VISUAL essence, express how the philosophy manifests through:
 - Visual hierarchy
 
 **CRITICAL GUIDELINES:**
+
 - **Avoid redundancy**: Each design aspect should be mentioned once. Do not repeat points about color theory, spatial relationships, or typographic principles unless adding new depth.
 - **State the quality bar once**: The philosophy should frame the work as the product of deep expertise and master-level execution — work that rewards close attention and reads as deliberate, not incidental. State this aspiration clearly and move on; do not pad the prose with repeated craftsmanship superlatives. The quality bar is enforced by the acceptance checklist in CANVAS CREATION, not by repetition.
 - **Leave creative space**: Remain specific about the aesthetic direction, but concise enough that the next Claude has room to make interpretive choices, also at a high level of craftsmanship.
@@ -75,6 +81,7 @@ Visual expression: Grid-based precision, bold photography or stark graphics, dra
 *These are condensed examples. The actual design philosophy should be 4-6 substantial paragraphs.*
 
 ### ESSENTIAL PRINCIPLES
+
 - **VISUAL PHILOSOPHY**: Create an aesthetic worldview to be expressed through design
 - **MINIMAL TEXT**: Text is sparse, essential-only, integrated as a visual element — never lengthy
 - **SPATIAL EXPRESSION**: Ideas communicate through space, form, color, composition — not paragraphs

--- a/docs/research/rewrites/README.md
+++ b/docs/research/rewrites/README.md
@@ -35,4 +35,3 @@ session synthesis.
 - All three verified genuinely better than their originals, with no gutting of legitimate function and no new beyond-linter defects.
 - **Skill 09 safety audit passed:** no destructive command left unguarded; the safe-path additions are technically correct (REISUB `s→u→b` ordering + sync-wait, timestamped `cp -a` GRUB backups, correct GRUB2 `grub2-mkconfig` path vs Legacy hand-edit).
 - **03 nit (patched):** the original luminance rule presented a flat `0.5` cutoff with WCAG-formula authority it didn't have — softened to a contrast-ratio-preferred rule with the `0.5`-is-not-WCAG-accurate caveat, removing a mild false-precision (`#confident-but-unsourced`) artifact.
-

--- a/docs/specs/2026-03-28-v8-design.md
+++ b/docs/specs/2026-03-28-v8-design.md
@@ -329,6 +329,7 @@ def dimension_guard(old_dims, new_dims, threshold=3.0):
 ```
 
 Thresholds by context:
+
 - Deterministic patches: 2.0 (conservative, isolated patches)
 - LLM generations — gradient strategy: 3.0
 - LLM generations — holistic strategy: 5.0 (allows larger rewrites)
@@ -392,12 +393,15 @@ TOP ISSUES (ranked by impact):
 TARGET: {target_score}/100
 
 Address the top {n} issues. Return the complete improved file.
+
 ```
 
 **User prompt (holistic strategy):**
 
 ```
+
 CURRENT FILE ({score}/100 [{grade}]):
+
 ```markdown
 {content}
 ```
@@ -406,6 +410,7 @@ WEAKEST DIMENSIONS: {weakest_3}
 
 Rewrite to maximize composite score while protecting strong dimensions.
 Return the complete improved file.
+
 ```
 
 ### Token Estimates
@@ -426,11 +431,13 @@ Typical 200-line SKILL.md: ~3,500 tokens/generation.
 **Storage:** JSONL per session (append-only, human-readable, trivial to parse).
 
 ```
+
 ~/.schliff/lineage/
   └── {skill_name}/
       ├── {timestamp}_{session_id}.jsonl
       └── snapshots/
           └── {session_id}_gen{N}.md
+
 ```
 
 **JSONL structure:**
@@ -473,6 +480,7 @@ class PlateauDetector:
 ```
 
 **Escape strategies:**
+
 1. Strategy switch (gradient → holistic) — 2 more generations
 2. Temperature bump (0.3 → 0.6) — 2 more generations
 3. Stop — plateau is real
@@ -628,6 +636,7 @@ Separate repo `Zandereins/schliff-action` (GitHub Marketplace expects dedicated 
 ### Configuration
 
 **Claude Code** (`~/.claude/settings.json`):
+
 ```json
 {
   "mcpServers": {
@@ -640,6 +649,7 @@ Separate repo `Zandereins/schliff-action` (GitHub Marketplace expects dedicated 
 ```
 
 **Cursor** (`.cursor/mcp.json`):
+
 ```json
 {
   "mcpServers": {
@@ -688,6 +698,7 @@ schliff-mcp = "skills.schliff.scripts.mcp_server:main"
 `schliff badge --gist` updates a GitHub Gist with shields.io endpoint JSON. GitHub Action auto-updates on push. Zero backend needed.
 
 **Grade-to-color mapping:**
+
 - S (>=95): gold
 - A (>=85): brightgreen
 - B (>=75): green
@@ -732,6 +743,7 @@ Hashtag: #SchliffScore. Leaderboard/competition mechanic.
 ### Content Anchor: "State of AI Instructions" Report
 
 Score 100+ public skills/instructions from GitHub, publish findings:
+
 - "73% of public AI instruction files score below C"
 - "61% score 0/100 on triggers, quality, AND edges (no eval suite)"
 - "Files under 300 tokens consistently outscore 1000+ token files"
@@ -763,6 +775,7 @@ Published as: GitHub repo + dev.to article + Twitter thread.
 ### README Restructure
 
 New section order for maximum conversion:
+
 1. Title + tagline ("The quality score for AI instructions")
 2. Badges (version, downloads, tests, license, score)
 3. One-liner pitch (1 sentence)

--- a/docs/specs/2026-04-25-measurement-layer-vision.md
+++ b/docs/specs/2026-04-25-measurement-layer-vision.md
@@ -99,6 +99,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 **Status today.** Spec exists (`2026-03-29-v8-final-plan.md`), implementation 0%. v7.2.0 ships the CLI; the library API does not exist as a public surface yet.
 
 **Scope.**
+
 - Public `from schliff import score, evaluate, observe` API with stable type-annotated signatures
 - Single-choke-point security: `allowed_root: Path` parameter on every public entry that touches a filesystem path. **Action item from architecture review:** the existing v8-final-plan does not explicitly scope this refactor; cross-reference must be added to v8-final-plan Phase 1a security requirements (path-traversal threat tests, `allowed_root` parameter on `build_scores()` and every public scorer entry, `os.path.realpath()` prefix-match on all file I/O).
 - Pure-function scorers (no hidden home-dir state introduced by Säule 1). **Existing-state caveat (architecture review):** `composite.py:_load_calibrated_weights()` already reads `~/.schliff/meta/calibrated-weights.json` silently. This is a feature (auto-calibrated weights) not a bug, but Säule 1 must document it explicitly: every public entry that may consult calibrated weights documents it in its docstring; `compute_composite(..., use_calibrated_weights=False)` opt-out exists; tests cover both cold-cache and warm-cache paths.
@@ -106,6 +107,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 - Multi-format support extended to system-prompts (zero existing competition per v8-vision)
 
 **Acceptance criteria.**
+
 - A consumer can `pip install schliff` and run `from schliff import score; score(Path("CLAUDE.md"), allowed_root=Path.cwd())` without touching the CLI
 - Path-traversal threat tests pass for every public entry
 - All existing CLI behaviours backed by the new library API (no parallel implementations)
@@ -120,6 +122,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 **Status today.** Net-new. No code, no spec.
 
 **Scope.**
+
 - `schliff.eval.run(suite, output)` accepts a normalized eval suite and returns `EvalResult` with deterministic-rule verdicts
 - Built-in adapters: Promptfoo-yaml-import, DeepEval-pytest-fixture, OpenAI-evals-jsonl
 - Deterministic-first decision tree:
@@ -132,6 +135,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
   - DeepEval-pytest: AST-check imports for arbitrary `exec`/`eval`/`__import__` calls in fixture defaults BEFORE pytest discovery; reject suspicious files
 
 **Acceptance criteria.**
+
 - Promptfoo-yaml suite import: `schliff.eval.run(suite="promptfoo.yaml", output=...)` produces results identical to Promptfoo's own runner for 95%+ of suite types
 - Deterministic-shortcut metric: at least 40% of real-world public Promptfoo suites should hit at least one deterministic check (pre-launch corpus study required — see §13 OQ3)
 - Zero LLM calls when a suite uses only `contains`/`regex`/`json_schema`/`format`/`length`/`equals`
@@ -144,6 +148,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 **Status today.** Net-new. No code, no spec. Hardest of the five.
 
 **Scope.**
+
 - `schliff.observe(trace)` accepts a normalized trace format and returns `TraceReport` with detected patterns
 - Initial pattern library (5–7 detectors, all deterministic):
   - Prompt-injection cascade: agent-A output containing instructions appears unsanitized in agent-B prompt
@@ -156,6 +161,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 - **Output sanitization (security review condition).** Trace-derived output payloads (the JUnit/GitHub/Sentry emissions) must NOT re-leak unsanitized user content. Specifically: every adapter declares which trace fields contain user-controlled content (LangSmith `messages`, OpenAI `function outputs`, Anthropic `thinking` blocks); `observe()` strips or hashes these in the emitted payload by default; opt-in `include_raw=True` for users who explicitly want raw content (and accept the third-party-leakage risk).
 
 **Acceptance criteria.**
+
 - Each detector has at least 3 positive-case tests (real traces from public agents, anonymized) and 5 negative-case tests (clean traces that should NOT trigger)
 - False-positive rate < 5% on a benchmark corpus of 1000+ clean public traces (security review expanded baseline from 100)
 - Embedding-free fallback for off-topic drift (no mandatory `[ml]` extra)
@@ -169,6 +175,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 **Status today.** Partially started. v7-launch attempted (see `project_schliff_state.md` — posts never went out). Awesome-list submissions tried, none accepted yet. Public playground exists.
 
 **Scope.**
+
 - Public benchmark site (`leaderboard.schliff.dev`): top 100 public skills/CLAUDE.mds by Schliff-score, updated nightly. **Anti-vision boundary (architecture review).** This is a *quality-bar leaderboard*, not a registry-of-record: skills are submitted by their owners via `schliff publish`; Schliff hosts the score display but does not curate, gate, or own the canonical list. The badge definition is public + versioned so the community can fork the leaderboard. This wording matters because §8 explicitly disclaims marketplace ambitions.
 - VS Code extension with live Schliff-score in the gutter
 - Pre-commit hook + GitHub Action mature, badge-able, documented in 5+ public repo READMEs
@@ -178,6 +185,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 - **IPC and upload boundary hardening (security review condition).** VS Code extension messages must be valid JSON, size-capped (1MB), and schema-validated; `BadJSON` and oversize messages dropped with clear error. Leaderboard uploads enforce `MAX_SKILL_SIZE`, reject path-traversal in any zip extraction (Zip-Slip guard), timeout extraction at 5s, require GitHub-OAuth or scoped API key (no anonymous submissions to prevent leaderboard-spam).
 
 **Acceptance criteria.**
+
 - 10+ external repos using `schliff verify` in CI by end of 2026
 - Mentioned in at least 2 third-party blog posts / talks
 - Featured in at least 1 awesome-list (without nudging — see `reference_awesome_claude_code.md` policy)
@@ -190,6 +198,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 **Status today.** Net-new. No code, no spec.
 
 **Scope.**
+
 - Specialised dimensions for regulated use-cases:
   - PII-leakage detector (in skills AND in observed outputs) — extends existing security scorer
   - Jailbreak-resistance scoring: skill resists known jailbreak families on a held-out adversarial set
@@ -199,6 +208,7 @@ Each Säule has: scope, acceptance criteria, dependencies. Ship targets are trac
 
 **Key Management (security review condition — added v0.2).**
 Signing keys MUST NOT live in `.schliff/keys/` or any filesystem path that a malicious skill could reach via path-traversal. Required policy:
+
 - Keys live in environment variables (`SCHLIFF_SIGNING_KEY` containing base64-encoded Ed25519 private key) or are injected via hermetic build systems (Bazel, Nix, GitHub-Actions secrets)
 - Keys rotated annually; every signing operation verifies key age < 365 days and refuses to sign with stale keys
 - CI environments must NOT log key material; key-detection in stack traces / error messages is mandatory
@@ -206,6 +216,7 @@ Signing keys MUST NOT live in `.schliff/keys/` or any filesystem path that a mal
 - No "convenience" auto-generated keys — refusing to sign without configured key is the default
 
 **Acceptance criteria.**
+
 - One certified compliance-mode passes a third-party legal review (target: GDPR for v0.1, EU-AI-Act for v1.0)
 - PII detector benchmark: 95%+ recall on a synthetic test corpus, < 1% false-positive rate on 1000 random public skills
 - Audit-trail receipts cryptographically reproducible from the input + rule version
@@ -288,6 +299,7 @@ This workflow is heavy. Honestly heavy. But it is what produced v7.2.0 with zero
 **Critical assumption (added v0.2 from simplify review).** Reviewer-agents in the Cross-Review gate run in **parallel** (minutes), not serial (days). If agent dispatch becomes serial, the workflow exceeds sustainable cycle time for solo+AI capacity and must be re-evaluated. Track this empirically: average Cross-Review wall-clock per non-trivial PR; if it exceeds 2 hours consistently, a Säule's velocity is threatened.
 
 **Two carve-outs:**
+
 - One-line bugfixes do not need a spec (commit message + reverse-TDD test is enough)
 - Doc-only PRs skip the cross-review agents
 
@@ -323,36 +335,42 @@ The register is updated at every reviewer-agent pass. New entries require an own
 Each entry: decision, alternatives considered, why-this-one, what-would-flip-it.
 
 **ADR-001 — Position Schliff as a measurement layer, not a competitor.**
+
 - Alternatives: (a) compete head-on with Promptfoo for output-eval, (b) merge into agnix as a quality module, (c) become a hosted SaaS
 - Chosen: (d) measurement layer used by all of the above
 - Why: avoids 3 unwinnable head-on fights; Datadog precedent shows the category is a viable scaling path; matches existing deterministic-first ideology
 - Flip if: Anthropic ships a free official skill-quality SDK with the same deterministic-first API AND market evidence shows users prefer the official version over Schliff (≥ 80% adoption inside 12 months of Anthropic's launch). Response then aligns with R1 mitigation: re-position as adapter / reference implementation under the official SDK; only consider retirement of the core if Schliff's deterministic-first differentiation no longer holds (e.g., Anthropic's official tool ships the same engine and supersedes Schliff's MIT advantage).
 
 **ADR-002 — Library-first, CLI-second.**
+
 - Alternatives: (a) keep CLI as primary; (b) ship CLI + library at parity; (c) deprecate CLI
 - Chosen: (b) parity, but library is the canonical surface for new features
 - Why: adapters and IDE extensions need the library; CLI users are not abandoned but no longer drive design
 - Flip if: a usability study shows users dramatically prefer CLI for >80% of flows (unlikely)
 
 **ADR-003 — Deterministic-first decision tree, LLM-judge as opt-in fallback.**
+
 - Alternatives: (a) LLM-judge always; (b) deterministic-only, no LLM ever; (c) library decides automatically based on assertion type
 - Chosen: (d) deterministic when applicable, LLM only on explicit `judge="llm"` arg
 - Why: keeps cost predictable for CI users; protects deterministic-first marketing claim; users who want LLM can always opt in
 - Flip if: deterministic checks turn out to apply to <10% of real eval suites (Säule 2 corpus study will tell us)
 
 **ADR-004 — Single `allowed_root` parameter on every path-touching public entry.**
+
 - Alternatives: (a) one global `allowed_root` set per process; (b) per-call argument; (c) no enforcement, document the threat
 - Chosen: (b) per-call argument, mandatory in library, default `None` in CLI for backward compat
 - Why: per-call is composable; library users (Promptfoo etc.) need fine-grained control; backward-compat keeps CLI users
 - Flip if: no library users emerge, suggesting the security argument is theoretical for current adoption
 
 **ADR-005 — No core dependency on a specific LLM SDK.**
+
 - Alternatives: (a) bundle litellm; (b) bundle Anthropic SDK; (c) abstract everything via litellm but as optional dep
 - Chosen: (c) — `schliff[evolve]` extras include litellm; core stays zero-dep
 - Why: matches current shipping pattern; protects core install footprint; avoids supply-chain blast on unrelated installs
 - Flip if: zero users adopt the optional dep (signal: nobody actually wants the LLM features)
 
 **ADR-006 — Reviewer-agent gates use hallucination-exclusion protocol mandatorily.**
+
 - Alternatives: (a) trust agent verdicts; (b) require human re-verification of every finding; (c) require every finding cite file:line + empirical reproduction
 - Chosen: (c) — see protocol in PR #32 review process
 - Why: agents over-claim in extended runs; the protocol caught false-positives in the v7.2.0 review (e.g. SSRF claim was wrong because allowlist was overlooked); validated again on this spec's own review (market-validation softened the "LLM-judge-first" claim that v0.1 overstated)
@@ -381,21 +399,25 @@ OQ7 (test infrastructure) and OQ8 (burn-rate) from v0.1 deferred to per-Säule r
 ## 14. Reviewer-agent verdicts (v0.1 review, integrated in v0.2)
 
 ### Architecture-reviewer — GREEN-WITH-CONDITIONS
+
 - **Verdict:** No blockers. The codebase has evolved to address critical architectural risks. Säulen-split is sound.
 - **Conditions integrated v0.2:** (1) calibrated-weights hidden state documented as feature in §6.1 + Principle 2 reworded; (2) `allowed_root` cross-reference added as Säule-1 action item; (3) Säule-3 stream-vs-stateless tension added as OQ9; (4) Säule-4 leaderboard wording clarified as quality-bar-not-marketplace (§6.4 + §8).
 - **Awareness findings (non-blocking):** runtime.py has implicit `claude` CLI dependency (acceptable); composite.py cache is process-local-not-thread-safe (documented); MCP-tool-scoring spec must be written before Phase 1c (was already in v8-final-plan).
 
 ### Security-reviewer — GREEN-WITH-CONDITIONS
+
 - **Verdict:** No exploitable vulnerabilities introduced. Three Säulen (2, 3, 4) introduce new boundaries that must be hardened in their sub-specs before code.
 - **Conditions integrated v0.2:** (1) Principle 8 added — adapter input validation; (2) R11 / Principle 7 strengthened — trace content leakage to third-party sinks; (3) Principle 9 / R12 added — IPC + upload boundaries; (4) §6.5 Key Management subsection + R13 added; (5) R14 added — adapter supply-chain risks; (6) Principle 7 strengthened to flag PII fields in observe() output.
 - **Hardening (defense-in-depth, tracked):** Säule-2 assertion-type whitelist (already in §6.2 acceptance criteria); Säule-3 false-positive baseline expanded from 100 to 1000+ traces; Säule-4 leaderboard auth via OAuth/API-key.
 
 ### Market-validation-reviewer — GREEN-WITH-CONDITIONS
+
 - **Verdict:** Strategic thesis defensible. Three corrections required.
 - **Corrections integrated v0.2:** (1) star counts updated (Promptfoo 12k → 20.5k, DeepEval 10k → 15k, agnix 207 → 208, awesome-claude-code 38.9k → 40.9k); (2) LangFuse 25k★ added to §5 table; (3) "LLM-judge-first" framing softened in §3 — Promptfoo + DeepEval recommend deterministic-first in docs but their tooling defaults still pull users toward LLM-judges; Schliff's wedge is library-first canonical implementation.
 - **Findings integrated v0.2:** R11 added (no AI-trace standard, OpenTelemetry-AI nascent) — affects Säule 3 long-term; R1 commentary updated (Anthropic Agent Skills standard already shipped Dec 2025, Skill-Creator plugin Mar 2026 — increases probability of full quality-scorer SDK).
 
 ### Simplify-reviewer — GREEN-WITH-CONDITIONS
+
 - **Verdict:** Spec is sound but contains redundancy. Several high-value cuts taken in v0.2; aggressive cuts deferred.
 - **Cuts integrated v0.2:** (1) §15 + §16 merged into single Navigation & Governance; (2) R3 + R5 merged → R3; R6 + R10 merged → R6 in risk register; (3) Säule ship-target lines removed from §6 (single source of truth in §7); (4) §10 parallel-agent-assumption explicitly noted as a workflow load-bearer.
 - **Cuts NOT taken (rationale):** §2+§4 collapse and §3-table-move would conflict with new security/market content additions; preserved for clarity. §9 Principles kept inline (not moved to ARCH-005) because they are read frequently by reviewer-agents and the indirection cost exceeds the duplication cost.
@@ -405,6 +427,7 @@ OQ7 (test infrastructure) and OQ8 (burn-rate) from v0.1 deferred to per-Säule r
 ## 15. Navigation & Governance
 
 **Cross-references (related specs and source docs):**
+
 - v8 implementation detail (Säule 1 superset): `docs/specs/plans/2026-03-29-v8-final-plan.md`
 - v8 architectural design: `docs/specs/2026-03-28-v8-design.md`
 - System prompt scoring spec (Säule 1 sub-component): `docs/specs/system-prompt-scoring-spec.md`

--- a/docs/specs/2026-04-27-v8-product-completion.md
+++ b/docs/specs/2026-04-27-v8-product-completion.md
@@ -71,6 +71,7 @@ The original plan defined 7 LLM-judge dimensions before observing data. **This w
 - **F3** `metrics-contract`: `ScoreDelta`, `JudgeAgreement`, `FixOutcome` typed records — single source for all four pillars
 
 ### P1 — Success Stories
+
 - A1 corpus selection (Anthropic 13 + Rezvani 108 + Schliff dogfood ~20 + Synthetic ~50 ≈ 191 skills)
 - A2 baseline benchmark run
 - A3 improvement campaigns (consumes P4)
@@ -78,6 +79,7 @@ The original plan defined 7 LLM-judge dimensions before observing data. **This w
 - A5 publication: `docs/case-studies/`, links from README
 
 ### P2 — Closed-corpus benchmark
+
 - B1 corpus contract: `benchmarks/corpus/v1/manifest.jsonl` with per-skill SHA, license, included-flag
 - B2 baseline scoring infra (consumes F1, F3)
 - B3 determinism test: `f(x)==f(x)` across runs (Vision-Spec §9 Principle 4)
@@ -85,6 +87,7 @@ The original plan defined 7 LLM-judge dimensions before observing data. **This w
 - B5 public report generator: HTML/MD with score histograms + commit hash
 
 ### P3 — AI-Eval (LLM-as-judge, dims emerge from Phase 0)
+
 - C1 judge harness: `evaluate(..., judge="llm")` with deterministic prompt template + pinned model + temp 0.3
 - C2 calibration set: 100–150 binary pass/fail with critique (grow iteratively from Phase-0 30-set, Solo Franz benevolent dictator)
 - C3 self-consistency probe: N=5 plurality vote, dual-order for position bias
@@ -93,6 +96,7 @@ The original plan defined 7 LLM-judge dimensions before observing data. **This w
 - C6 cost ledger: tokens/run, budget guard, cross-family fallback only on disagreement
 
 ### P4 — Auto-fix loop (both modes, Goodhart-hardened)
+
 - D1 audit existing `schliff:auto` (`auto-improve.py` is real, **~620 LOC**, has 15pt-regression-guard via `_has_dimension_regression()` but missing explicit Goodhart guards)
 - D2 hallucination bound + Goodhart guardrail stack (see §7)
 - D3 autonomous mode: run-to-plateau, single end-verify, N=10 sampling-gate to human
@@ -131,6 +135,7 @@ The original plan defined 7 LLM-judge dimensions before observing data. **This w
 **Trunk:** `trunk-v8` (long-lived integration off `main`). Worktrees PR into `trunk-v8`; only Phase-4 close merges `trunk-v8 → main`.
 
 **Conflict-zone ownership:**
+
 - Top-level `schliff/__init__.py`, `schliff/api.py`, `pyproject.toml` `packages.find` → wt-foundation only until Day 5
 - `skills/schliff/scripts/auto-improve.py` → wt-autoloop only
 - `pyproject.toml` (deps for `schliff[judge]` extra) → wt-judge proposes, foundation merges
@@ -214,6 +219,7 @@ Concrete numbers from Goodhart-Researcher Agent + Manheim/Garrabrant 2018 + Kwa 
 **Sub-reviewer pattern (mitigates Solo confirmation bias):** for each of the four output-based kill-gates, a separate subagent (not the one performing the work) reviews the artifacts (taxonomy / TPR holdout / CI math / Goodhart-anomaly check / case-studies) and confirms or denies the gate-pass. Cheap insurance (~30min per gate) against confirmation bias on solo-judgment decisions.
 
 **Sub-reviewer hardening (R3 v0.3):**
+
 - Sub-reviewers must be **cross-family** (different model family from the artifact producer; mitigates Panickssery 2024 self-preference where same-family judges hallucinate PASS on artifacts they see).
 - Sub-reviewer must surface **at least one concrete artifact-element it would have rejected** (forces grounded judgment vs. vibes-PASS).
 - Sub-reviewer's verdict is advisory in form but **quasi-binding in process**: if Franz overrides a sub-reviewer FAIL, override requires (1) **written rationale committed to CHANGELOG**, (2) **24h cooldown** before re-running gate, (3) the override **auto-flips the affected pillar to descope-defer in v8.1** (cannot be reversed mid-sprint). This prevents Franz-in-confirmation-bias-mode from papering over a FAIL with one sentence.
@@ -221,6 +227,7 @@ Concrete numbers from Goodhart-Researcher Agent + Manheim/Garrabrant 2018 + Kwa 
 ## 12. Cost Budget
 
 LLM call estimate:
+
 - Judge calibration: 3 iters × 100 holdout × 5 self-consistency = ~1500 calls
 - Korpus auto-loop: 100 skills × ~10 iters × 2 calls/iter = ~2000 calls
 - Cross-family fallback: ~10% disagreement × Gemini = ~350 calls
@@ -245,10 +252,12 @@ Cross-family-everywhere alternative would have been ~$500+. Saved by ADR-0006.
 ## 14. References
 
 **Internal:**
+
 - Vision Spec v0.3 — `docs/specs/2026-04-25-measurement-layer-vision.md`
 - ADRs — `docs/adr/0001-*.md` through `0007-*.md`
 
 **External:**
+
 - Husain & Shankar, "LLM Evals: Everything You Need to Know" — https://hamel.dev/blog/posts/evals-faq/
 - Hamel Husain, "Creating an LLM-as-Judge That Drives Business Results" — https://hamel.dev/blog/posts/llm-judge/
 - Shankar et al., "Who Validates the Validators?" UIST 2024 — https://arxiv.org/abs/2404.12272

--- a/docs/specs/2026-06-11-agentic-integration.md
+++ b/docs/specs/2026-06-11-agentic-integration.md
@@ -20,6 +20,7 @@ Drei Vertrauensbrüche, die erklären, warum Schliff bisher keinen gefühlten Me
 Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/schliff.bak.<ts>`** — dieser Pfad liegt im Claude-Code-Skill-Scan-Verzeichnis, wodurch der gesamte `/schliff:*`-Command-Namespace dupliziert wird (`schliff.bak.<ts>:auto` etc.). Temporär behoben durch Verschieben nach `~/.claude/backups/`; permanenter Fix gehört in PR-A.
 
 ### Verifizierte Einzelwerte
+
 - hydra SKILL.md: 11.976 Tokens / Budget 1.000 (Ratio **11,97×**, `severity: over`). Dims: structure 75, efficiency 49, composability 56, clarity 92; triggers/quality/edges = `None`.
 - Globale `~/.claude/CLAUDE.md`: composite 25.0, Token-Budget 602/2.000 (`ok`). → Bestätigt: CLAUDE.md ist regression-only, keine Fake-Eval-Suite (skill-shaped Dims sind dort Rauschen).
 - Franz-eigene SKILL.md: grill-me, handoff, hydra, carl-manager. (carl-help, learned haben keine SKILL.md.)
@@ -27,6 +28,7 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 ## Anforderungen
 
 ### K1 — Toolchain-Reparatur ✅ ERLEDIGT (2026-06-11)
+
 - [x] Stale 7.2.0-Metadata entfernt (`schliff.egg-info` gelöscht, `uv pip install -e . --reinstall` → 8.1.0).
 - [x] `schliff version` konsistent 8.1.0 aus Repo-Root **und** `/tmp`.
 - [x] Plugin-Kopie via `bash install.sh` auf 8.1.0 refresht (Copy-Mode, Auto-Backup).
@@ -34,6 +36,7 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 - [x] install.sh-Backup aus Skill-Scan-Pfad entfernt → `~/.claude/backups/schliff-skill-backups/`.
 
 ### K2 — Ehrliche Baselines + erster gefühlter Gewinn (Effort: S)
+
 - **K2a Hydra-Token-Diät:** bench-/Referenzmaterial aus dem always-loaded SKILL.md-Body in `references/` auslagern. Ziel: Token-Ratio < 2× (von 11,97×), ~10k Context-Tokens/Session zurück. **Kein** neuer Code; reine Umstrukturierung des Markdown. Akzeptanz: hydra triggert weiterhin korrekt (Trigger-Phrasen bleiben im Body), Funktionalität unverändert.
 - **K2b Eval-Suites:** für die 4 Franz-Skills mit SKILL.md per Heuristik-Generator (`skills/schliff/scripts/init-skill.py`, 0.1s, kein LLM). Zielliste per **Glob** über `~/.claude/skills/*/SKILL.md`, nicht hardcoded. Durable Kopien nach `~/Projects/claude-stack/skills/`.
 - **K2c Review-Gate (Pflicht, ~15 min/Suite):** selbstreferenzielle/generische Trigger umschreiben. Akzeptanzkriterium: „jeder Trigger ist ein Satz, den Franz wirklich sagen würde". Ohne dieses Gate ist der Score-Sprung (22.9 → ~64 für grill-me) Inflation, nicht Ehrlichkeit.
@@ -41,6 +44,7 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 - **K2e:** CLAUDE.md/AGENTS.md bekommen **keine** Eval-Suites (regression-only).
 
 ### K3 — Der Hook: `~/.claude/hooks/schliff-watch.js` (Effort: M)
+
 - **Eigener** PostToolUse-Eintrag mit Matcher `"Write|Edit"` in `~/.claude/settings.json` — **nicht** in den bestehenden `"Bash|Write|Edit"`-Block (sonst Node-Spawn bei jedem Bash-Call).
 - Skeleton von `gsd-context-monitor.js` (debounce, fail-open, silent-fail, exit 0 immer).
 - **Scope:** Pfad matcht `/(SKILL|CLAUDE|AGENTS)\.md$|\.cursorrules$/`, **nicht** unter `~/.claude/plugins` (Third-Party), nicht unter tmp/pytest-Pfaden.
@@ -51,11 +55,13 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 - **Latenz-Budget:** ~0.2s cold verifiziert; jeder Fehler → exit 0.
 
 ### K4 — Failure-Loop aktivieren: `session-injector.js` (Effort: S)
+
 - Den geshippten-aber-schlafenden `~/.claude/skills/schliff/hooks/session-injector.js` (8.1.0-Kopie) als SessionStart-Hook in `~/.claude/settings.json` registrieren.
 - **Verifikationsschritt (Pflicht):** synthetischen 3-Failure-Zustand in einer `.schliff/failures.jsonl` erzeugen und bestätigen, dass die Injection feuert — nicht ungeprüft durchwinken.
 - Eine Zeile in `~/.claude/CLAUDE.md`: „When a skill misfires, run /schliff:log-failure before moving on."
 
 ### K5 — Honesty-Fixes im schliff-Repo: ZWEI PRs
+
 - **PR-A (S, dieser Branch, `fix/fix-count-honesty` als Teil von Phase 1):**
   1. `cli.py:228`: `fix_count` = Anzahl tatsächlich anwendbarer Patches (`len(generate_patches(...))`), nicht `len(gradients)`.
   2. Falsche Doku-Behauptung „All changes are git-committed" in `commands/schliff/auto.md` korrigieren.
@@ -65,6 +71,7 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 - **PR-B (M, Woche 2, separater Branch):** Patch-Applier-Unification (content-level Primitiv für CLI + evolve), Patch-Quality-Gate (nie `TODO:`-Text, nie body-gescrapte when-Klauseln), Op-Coverage-Round-Trip-Test, `remove_regex`-Sicherheitstests mit Positiv-Korpus, **Golden-Score-Byte-Identity-Gate**. Außerhalb Phase 1.
 
 ### K6 — Wöchentliche Fleet-Sicht in claude-stack (Effort: S)
+
 - ~15 tolerante Zeilen in `~/Projects/claude-stack/bin/stack-healthcheck.py` neben dem bestehenden skill-mesh-Call: `schliff doctor --json` mit **cwd gepinnt auf `~/.claude/skills`** (Unbounded-Recursion-Bug ab `~`). Ausgabe nur zwei Zahlen: Fleet-Token-Kosten + Skills-ohne-Suite-Count. Mesh-Issue-Count ignorieren (False-Positive-Rate hoch).
 - **Liveness-Check:** WARN, wenn `~/.schliff/watch-cache.json` mtime > 7 Tage trotz kürzlicher Instruction-File-Edits (toter fail-open-Hook von gesundem stillem unterscheiden).
 
@@ -77,17 +84,21 @@ Zusätzlicher Befund während K1: **`install.sh` backupt nach `~/.claude/skills/
 - **Cache-Keying auf `(path, engine_version)`** gegen Upgrade-False-Positives; `failures.jsonl` mit Rotation > 1 MB.
 
 ## Bewusst NICHT gebaut (Phase 1)
+
 - `/schliff:auto` unattended (gebannt bis PR-B; wendet TODO-Platzhalter an).
 - MCP-Server / SARIF / Watch-Mode / LSP (Phase 3 mit explizitem Re-Entry-Trigger; teils agnix' Heimspiel).
 - Harte `--min-score`-Gates auf Franz' Files (ehrliche Scores ~60-67; rotes Dauer-Gate trainiert Ignorieren).
 - Eval-Suites für CLAUDE.md/AGENTS.md, Statusline-Score, CARL/GSD-Integration (beide dormant), schliff.toml-Config-System.
 
 ## Strategischer Nebeneffekt
+
 Jedes Hook-Firing + `/schliff:log-failure`-Eintrag landet als timestamped Record (`channel`-Feld) in `failures.jsonl` → `/schliff:triage` clustert zu Eval-Cases → nach 2-4 Wochen existiert erstmals ein realer, dokumentierter Quality-Miss-Korpus (die zweite Hälfte des eingefrorenen Judge-Kalibrierungs-Gates) als Nebenprodukt. Plus Launch-Receipts statt Pitch: „10k Tokens/Session zurück, Regression X mid-session gefangen."
 
 ## Offene Fragen
+
 - K2a: hydra-Diät — welche Sektionen sind „always-loaded-essenziell" (Trigger, Kern-Workflow) vs. auslagerbar (bench-Tabellen, Beispiele)? → beim Umsetzen entscheiden, Trigger-Erhalt verifizieren.
 - Symlink vs. Copy für Plugin-Kopie langfristig — offen, Default Copy.
 
 ## Checkpoint nach 2 Wochen (Phase-3-Gate)
+
 Hat der Hook ≥ 1 echte Regression gefangen? Wurden suggest/evolve real genutzt? Nur dann Phase 3.

--- a/docs/specs/2026-07-21-command-resolution-hotfix.md
+++ b/docs/specs/2026-07-21-command-resolution-hotfix.md
@@ -94,6 +94,7 @@ package-manager block (`command_resolution.py:324`): if the script is not in the
 `unknown` instead of `dangling`.
 
 "Repo declares workspaces" =
+
 - root `package.json` has a `workspaces` key (array, or `{ "packages": [...] }`), **or**
 - `pnpm-workspace.yaml` / `pnpm-workspace.yml` exists in the repo root.
 
@@ -142,6 +143,7 @@ path inside the checkout is an existence oracle / weak escape. Use `os.path.real
 
 `_find_line` (`command_resolution.py:383-389`) recovers the report line by scanning
 for a substring match. Three defects:
+
 - **quadratic DoS** — O(distinct-cmds × lines) substring scan.
 - **cd-taint puncture** — a command that appears on two lines resolves the line to
   the *first* match, which may not be the tainted one, so the `dangling → unknown`

--- a/docs/specs/2026-07-22-structure-reproducibility-content-only.md
+++ b/docs/specs/2026-07-22-structure-reproducibility-content-only.md
@@ -94,7 +94,7 @@ reader to external detail" forms:
   not `http(s)`, not an anchor). This is the **dominant real-world disclosure
   pattern** (field-validated below).
 - `_RE_REF_PATH = re.compile(r"(?:\]\(|`|\bsee\s+|\bread\s+|\bload\s+)(references/[\w./-]+)", re.I)` —
-  a `references/` path in a markdown link, backtick, or see/read/load verb (covers
+  a `references/`path in a markdown link, backtick, or see/read/load verb (covers
   non-`.md` reference resources). The anchor keeps bare build-command mentions of
   `scripts/…` from counting as disclosure.
 
@@ -168,6 +168,7 @@ declared ref; the gate suppresses those.
 (AGENTS.md/CLAUDE.md/.cursorrules) into a `NamedTemporaryFile` and scores *that*.
 So for AGENTS.md — the flagship, structure weight 0.4 — the on-disk checks
 **always** fail, even locally. Two consequences:
+
 - The reproducibility gap this spec reproduces is a **skill.md** phenomenon
   (real path vs mkdtemp); AGENTS.md is already temp-scored in every context.
 - A′ is a **bigger win for AGENTS.md than framed**: the normalized temp preserves

--- a/docs/specs/agents-md-operational-coverage.md
+++ b/docs/specs/agents-md-operational-coverage.md
@@ -77,7 +77,7 @@ Decoupling ships **only bundled** with all of the following hardening (neither l
 5. **Negation guard** (bound to #1): skip a command token whose sentence carries `do not` / `don't` / `never` / `avoid`. Latent in `v0` (masked by heading-gating); load-bearing once gating is removed.
 6. **Conservative recall** (low risk): credit script delegation (`./script.sh`, `bash|sh <script>`); expand verbs with `nix zig mix dart flutter pdm gleam`; soften heading *boosters* to inflected forms (`\bcheck`, `\bbuild`, `\bsetup`, `validate|validation`) to catch e.g. `MacroGraph` "Checking your code".
 
-Fenced-block scanning is restricted to shell-family languages (`'' bash sh shell console zsh fish ps1 powershell …`) so ```typescript / ```go / ```text samples are not miscredited as commands.
+Fenced-block scanning is restricted to shell-family languages (`'' bash sh shell console zsh fish ps1 powershell …`) so ```typescript /```go / ```text samples are not miscredited as commands.
 
 ### 4.3 Directive credit — tightened
 
@@ -101,6 +101,7 @@ Byte-identity for `skill.md` / `claude.md` / `cursorrules` / `system_prompt` is 
 **Do NOT touch `HEADLINE_EXCLUDED["agents.md"]`.** opcov was never in it; the canonical headline basis = `WEIGHT_PROFILES` keys − `HEADLINE_EXCLUDED`, so adding opcov to the weight profile folds it into the headline automatically. (The earlier "remove from `HEADLINE_EXCLUDED`" framing was a wrong fifth edit.)
 
 **Nice-to-have (follow-up, not blocking):**
+
 - Add `"operational_coverage"` to `shared.VALID_DIMENSIONS` so `--weights operational_coverage=…` is not rejected.
 - A `text_gradient` opcov gradient generator for `/auto` and `/analyze`, weighted at agents.md's `0.4` (not the `0.10` skill.md fallback) — otherwise the co-dominant headline dim gives no fix advice.
 - Commit the 30-doc per-category table as a fixture so any future weight/synonym change is regression-visible.
@@ -110,6 +111,7 @@ Byte-identity for `skill.md` / `claude.md` / `cursorrules` / `system_prompt` is 
 **Sequencing is mandatory:** land hardening **and** decoupling together → re-run the full 30-file corpus → re-baseline R5 **once**. Re-baselining on the un-hardened scorer and again after hardening would bake recall misses in as "truth."
 
 **Rewrite** `test_agents_md_profile.py` (do not "update the golden"):
+
 - Replace the 50/50 assertion with the 3-dim profile; assert `score == 0.4·structure + 0.4·operational_coverage + 0.2·efficiency` and `measured == total == 3`.
 - Re-derive mean / median / max (prototype: `underway` = 97.0) / band-counts on the **hardened** scorer.
 - **Drop `meltano` from the S-boundary test** (now ≈ 91.0 / A); assert `underway == 97.0 / S` only.

--- a/docs/specs/plans/2026-03-28-v8-master-plan.md
+++ b/docs/specs/plans/2026-03-28-v8-master-plan.md
@@ -591,6 +591,7 @@ git tag v7.1.0-pre-v8                         # Snapshot taggen
 ### Per-Phase Completion
 
 Fuer JEDE Phase vor Merge:
+
 1. Alle bestehenden Tests bestehen (zero regression)
 2. Alle neuen Tests bestehen
 3. `ruff check skills/schliff/` bestanden

--- a/docs/specs/schliff-registry-platform.md
+++ b/docs/specs/schliff-registry-platform.md
@@ -29,7 +29,7 @@ Was bereits existiert und worauf wir aufbauen:
 | Web Playground | Live | Vercel serverless, POST /api/score |
 | Leaderboard API | Live | Vercel, /api/submit + /api/query, /tmp storage |
 | Leaderboard Web | Live | Static HTML, vercel.json |
-| Grade System | S(>=95) A(>=85) B(>=75) C(>=65) D(>=50) E(>=35) F(<35) |
+| Grade System | Live | S(>=95) A(>=85) B(>=75) C(>=65) D(>=50) E(>=35) F(<35) |
 
 ---
 
@@ -38,6 +38,7 @@ Was bereits existiert und worauf wir aufbauen:
 ### 1.1 Current `schliff badge` Command
 
 Aktueller Output:
+
 ```
 [![Schliff: 87 [A]](https://img.shields.io/badge/Schliff-87%2F100_%5BA%5D-green)](https://github.com/Zandereins/schliff)
 ```
@@ -47,14 +48,17 @@ Das ist ein **statischer** shields.io Badge. Funktioniert, ist aber nach dem Gen
 ### 1.2 Badge Formats (zu implementieren)
 
 **Format 1: Static shields.io (existiert)**
+
 - Pro: Zero infra, sofort verwendbar
 - Contra: Veraltet nach jedem Commit, manuelles Re-Generieren noetig
 - Verwendung: Lokale Nutzung, Einmal-Badge
 
 **Format 2: shields.io Endpoint Badge (Phase 1b)**
+
 - shields.io fetcht JSON von einem Endpoint und rendert den Badge
 - URL: `https://img.shields.io/endpoint?url=<encoded-json-url>`
 - JSON-Schema das shields.io erwartet:
+
   ```json
   {
     "schemaVersion": 1,
@@ -63,12 +67,14 @@ Das ist ein **statischer** shields.io Badge. Funktioniert, ist aber nach dem Gen
     "color": "green"
   }
   ```
+
 - Endpoint-Optionen fuer das JSON:
   - **GitHub Gist** (kostenlos, Zero Backend): `schliff badge --gist` aktualisiert ein Gist via GitHub API
   - **Vercel Edge Function** (bereits deployed): neuer Endpoint `/api/badge/<owner>/<repo>`
   - **Cloudflare Worker + KV** (guenstigste Skalierung): eigener badge service
 
 **Format 3: Custom SVG (Phase 2)**
+
 - Eigenes SVG mit Schliff-Branding, generiert vom Badge-Endpoint
 - Erlaubt Schliff-Logo, Gradient-Farben, Dimension-Breakdown
 - Beispiel: `https://schliff.dev/badge/owner/repo.svg`
@@ -109,12 +115,14 @@ GitHub Action runs nightly or on push:
 ```
 
 **Vorteile:**
+
 - Vollstaendig kostenlos
 - Kein eigener Server noetig
 - shields.io cached mit `cacheSeconds` (min 300s)
 - GitHub Gist ist hochverfuegbar
 
 **Nachteile:**
+
 - Braucht GitHub Token (fuer Gist-Updates)
 - Ein Gist pro Badge (oder ein Gist mit mehreren Files)
 - Nicht zentral aggregierbar
@@ -140,6 +148,7 @@ jobs:
 ```
 
 Alternativer Ansatz mit dem `Dynamic Badges` GitHub Action:
+
 ```yaml
       - id: score
         run: |
@@ -186,6 +195,7 @@ README Badge Request:
 
 **GET `/api/badge/:owner/:repo`**
 Returns shields.io-kompatibles JSON:
+
 ```json
 {
   "schemaVersion": 1,
@@ -204,6 +214,7 @@ Direkt-SVG (Custom Rendering, kein shields.io Umweg).
 
 **GET `/api/score/:owner/:repo`**
 Vollstaendiges Score-JSON:
+
 ```json
 {
   "composite": 87.3,
@@ -234,6 +245,7 @@ Score einreichen + im Cache speichern (authenticated via GitHub Token).
 | **GitHub Pages + GitHub Actions** | Zero cost, scores in Repo gespeichert | Keine dynamische Berechnung, nur statisch | $0 |
 
 **Empfehlung: Hybrid-Ansatz**
+
 1. **Phase 2a**: Vercel erweitern (existiert bereits) — neuer `/api/badge/` Endpoint, Upstash Redis fuer Cache statt /tmp
 2. **Phase 2b**: Cloudflare Worker als Badge-Proxy vor Vercel (CDN + KV Cache)
 3. Migration zu Cloudflare komplett wenn Vercel-Limits erreicht werden
@@ -252,6 +264,7 @@ Score Lifecycle:
 ```
 
 Kein Server-seitiges Scoring noetig — der Score wird **lokal berechnet und verifiziert**:
+
 - Manipulation? Ja, moeglich. Aber: das ist auch bei Codecov so.
 - Mitigation: `schliff verify` in CI, oeffentlich einsehbarer Workflow
 - Langfristig: Attestation via GitHub Actions OIDC Token
@@ -282,6 +295,7 @@ schliff.dev/registry
 ### 3.2 Quality Gate
 
 **Minimum-Anforderungen fuer Veroeffentlichung:**
+
 - Composite Score >= 75 (Grade B)
 - Keine Dimension unter 50 (kein D/E/F in Einzeldimensionen)
 - Muss `schliff verify` bestehen
@@ -289,6 +303,7 @@ schliff.dev/registry
 - Keine bekannten Security-Issues (security dimension >= 70)
 
 **Warum B und nicht A?**
+
 - A (>=85) wuerde zu viele Skills ausschliessen → Adoptions-Huerden
 - B (>=75) ist "gut genug" — zeigt aktive Qualitaetsbemühungen
 - S/A Skills bekommen "Schliff Certified" Badge (siehe Section 5)
@@ -354,24 +369,28 @@ schliff update deploy-aws
 ### 3.5 Storage Architecture
 
 **Phase 3a — Minimal (SQLite + Litestream)**
+
 - SQLite-Datenbank auf Fly.io oder Railway (Single Node)
 - Litestream fuer kontinuierliche Backups zu S3/R2
 - Skill-Dateien in Cloudflare R2 (S3-kompatibel)
 - Cost: $0-5/mo (Fly.io Free Tier + R2 Free Tier)
 
 **Phase 3b — Skalierbar (Turso/libSQL)**
+
 - Turso: gehostetes libSQL (SQLite-Fork), edge-replicated
 - Free Tier: 9GB storage, 500M rows read/mo
 - Skill-Dateien weiterhin in R2
 - Cost: $0-29/mo
 
 **Phase 3c — Full (Supabase)**
+
 - PostgreSQL + Edge Functions + Auth + Realtime
 - Free Tier: 500MB DB, 1GB storage, 50k MAU
 - Vorteil: Auth, Realtime Updates, Dashboard out of the box
 - Cost: $0-25/mo
 
 **Empfehlung: Phase 3a (SQLite + Litestream).**
+
 - Einfachste Migration von /tmp-JSON (existierender Leaderboard-Code)
 - Kein ORM noetig, SQL direkt
 - Backup automatisch
@@ -428,6 +447,7 @@ CREATE INDEX idx_categories_cat ON categories(category);
 ### 4.1 Bestand
 
 Es existiert bereits:
+
 - `web/leaderboard/` mit Vercel deployment
 - `api/submit.py` — POST-Endpoint, validiert, speichert in /tmp JSON
 - `api/query.py` — GET mit sort, filter, pagination
@@ -455,17 +475,20 @@ schliff leaderboard --format .cursorrules
 Fuer Szenarien ohne eigenen Server:
 
 **Option A: GitHub-based (Dezentral)**
+
 - Jeder User hat ein `schliff-scores.json` in seinem Repo
 - GitHub Action aktualisiert es bei jedem Push
 - Leaderboard aggregiert ueber GitHub API (Search Code API)
 - Problem: Rate Limits, langsam
 
 **Option B: GitHub Discussions (Semi-zentral)**
+
 - Scores werden als GitHub Discussion Comments gepostet
 - Bot aggregiert periodisch
 - Problem: Formatierung, Parsing
 
 **Option C: Vercel + persistent storage (Empfohlen)**
+
 - Migration von /tmp zu Upstash Redis oder Turso
 - Existierender submit/query Code bleibt fast gleich
 - Cost: $0 (Upstash Free: 10k commands/day = ~300 submissions/day)
@@ -497,11 +520,13 @@ Ein Skill ist "Schliff Certified" wenn:
 ### 5.2 Badge Varianten
 
 **Regular Score Badge:**
+
 ```
 [![Schliff: 91 [A]](https://img.shields.io/badge/Schliff-91%2F100_%5BA%5D-green)](https://schliff.dev)
 ```
 
 **Certified Badge:**
+
 ```
 [![Schliff Certified](https://img.shields.io/badge/Schliff_Certified-%E2%9C%93_91%2F100-brightgreen?logo=data:...)](https://schliff.dev/certified/skill-name)
 ```
@@ -513,6 +538,7 @@ Ein Skill ist "Schliff Certified" wenn:
 ### 5.3 Marketplace-Adoption
 
 **SkillsMP Integration:**
+
 - SkillsMP hat eine API (`skillsmp.com/docs/api`)
 - Vision: SkillsMP zeigt Schliff-Scores neben jedem Skill
 - Implementierung:
@@ -521,6 +547,7 @@ Ein Skill ist "Schliff Certified" wenn:
   3. Langfristig: SkillsMP sortiert/filtert nach Schliff-Score
 
 **ClawHub / andere Marktplaetze:**
+
 - Gleicher API-Endpunkt
 - Badge-Standard macht Adoption trivial (nur Markdown-Image)
 
@@ -666,6 +693,7 @@ Output:
 ## Implementierungs-Reihenfolge
 
 ### Week 1 (sofort)
+
 1. `schliff score --json` — JSON-Output fuer CI/Automatisierung
 2. `schliff badge --format endpoint` — shields.io Endpoint Badge Support
 3. `schliff badge --gist` — Auto-Update via GitHub Gist
@@ -673,23 +701,27 @@ Output:
 5. Docs: "Add a Schliff Badge to Your README"
 
 ### Week 2
+
 6. `/api/badge/:owner/:repo` Endpoint auf Vercel
 7. Leaderboard Storage-Migration: /tmp → Upstash Redis
 8. `schliff score --publish` — Score an API senden
 9. `schliff leaderboard` CLI-Command (existierender API-Client)
 
 ### Week 3-4
+
 10. `schliff doctor --share` — Share-Link generieren
 11. Share-Page mit OG-Image (Vercel OG)
 12. Community Challenge Launch: "Score Your Stack Week"
 
 ### Month 2
+
 13. Registry MVP: publish, search, install
 14. Turso-Datenbank + Schema
 15. `schliff certify` Command
 16. Certified Badge System
 
 ### Month 3
+
 17. Registry Web UI (Browse, Detail-Seiten)
 18. SkillsMP Integration (Badge in Listings)
 19. Custom SVG Badges mit Schliff-Branding

--- a/docs/specs/system-prompt-scoring-spec.md
+++ b/docs/specs/system-prompt-scoring-spec.md
@@ -30,22 +30,23 @@ System prompts are the instructions given to LLMs via the API's `system` role. T
 ## Dimension 1: structure_prompt (weight: 15%)
 
 ### What it measures
+
 Whether the system prompt has a logical, well-organized structure that models can reliably follow.
 
 ### Scoring model: Additive, 10 checks x 10 pts
 
 | Check | Points | Detection |
 |-------|--------|-----------|
-| Role definition | 10 | Regex: `(?i)(you are|your role is|act as|you're a|as a \w+ assistant|your purpose)` |
-| Task description | 10 | Regex: `(?i)(your (task|job|goal|objective|mission) is|you (will|should|must) \w+ (the|a|an)|primary function)` |
-| Constraint block | 10 | Regex: `(?i)(constraints?:|rules?:|limitations?:|boundaries:|guardrails:|do not|never|must not|always)` with 2+ matches required |
-| Output format specification | 10 | Regex: `(?i)(respond (in|with|using)|output (format|as)|return (a|the)|format:|your (response|reply|answer) (should|must|will))` |
-| Examples present | 10 | Regex: `(?i)(example[s]?:|for example|e\.g\.|<example>|input.*output|here'?s (a|an|one))` |
+| Role definition | 10 | Regex: `(?i)(you are\|your role is\|act as\|you're a\|as a \w+ assistant\|your purpose)` |
+| Task description | 10 | Regex: `(?i)(your (task\|job\|goal\|objective\|mission) is\|you (will\|should\|must) \w+ (the\|a\|an)\|primary function)` |
+| Constraint block | 10 | Regex: `(?i)(constraints?:\|rules?:\|limitations?:\|boundaries:\|guardrails:\|do not\|never\|must not\|always)` with 2+ matches required |
+| Output format specification | 10 | Regex: `(?i)(respond (in\|with\|using)\|output (format\|as)\|return (a\|the)\|format:\|your (response\|reply\|answer) (should\|must\|will))` |
+| Examples present | 10 | Regex: `(?i)(example[s]?:\|for example\|e\.g\.\|<example>\|input.*output\|here'?s (a\|an\|one))` |
 | Section separators | 10 | Regex for XML tags `<\w+>`, markdown headers `^##?\s`, or delimiter lines `^---$` — need 2+ distinct sections |
 | Logical ordering | 10 | Heuristic: role/context appears in first 25% of prompt, constraints/rules in middle, examples in last 50% |
 | Length appropriateness | 10 | 50-2000 words = full points; <50 = 5 pts (likely incomplete); >2000 = 5 pts (likely bloated) |
 | Progressive detail | 10 | High-level summary followed by specific rules — detect via: first paragraph <50 words AND subsequent sections exist |
-| No dead content | 10 | No TODO/FIXME/placeholder/TBD patterns: `(?i)(TODO|FIXME|HACK|XXX|placeholder|TBD|to be determined|fill in)` |
+| No dead content | 10 | No TODO/FIXME/placeholder/TBD patterns: `(?i)(TODO\|FIXME\|HACK\|XXX\|placeholder\|TBD\|to be determined\|fill in)` |
 
 ### Rubric
 
@@ -56,6 +57,7 @@ Whether the system prompt has a logical, well-organized structure that models ca
 ### Examples
 
 **Good (score ~90):**
+
 ```
 You are a code review assistant for Python projects.
 
@@ -80,16 +82,19 @@ Output: `[security/critical] Line 1: SQL injection via f-string interpolation. U
 ```
 
 **Mediocre (score ~45):**
+
 ```
 You help with code reviews. Look at the code and find problems. Be helpful but concise. Point out bugs and security issues. Use markdown for your responses.
 ```
 
 **Bad (score ~10):**
+
 ```
 You are a helpful assistant. Be nice and thorough. Help the user with whatever they need. Make sure your responses are good.
 ```
 
 ### Anti-gaming rules
+
 - Empty sections (header with no content below) score 0 for that check
 - Repeated constraint phrases (same rule stated 3+ ways) count as 1
 - XML tag pairs without content between them score 0
@@ -100,22 +105,23 @@ You are a helpful assistant. Be nice and thorough. Help the user with whatever t
 ## Dimension 2: output_contract (weight: 15%) — NEW
 
 ### What it measures
+
 Whether the prompt defines a clear, enforceable contract for what the model should produce.
 
 ### Scoring model: Additive, 10 checks x 10 pts
 
 | Check | Points | Detection |
 |-------|--------|-----------|
-| Format specification | 10 | Regex: `(?i)(respond (in|with|as)|format (as|your)|output (as|in|format)|return (JSON|XML|YAML|markdown|plain text|HTML|CSV))` |
-| Length/size constraints | 10 | Regex: `(?i)(max(imum)?\s+\d+\s+(words?|tokens?|sentences?|characters?|paragraphs?|lines?)|keep.{0,20}(short|brief|concise|under \d+)|limit.{0,20}(to \d+|length))` |
-| Tone/voice definition | 10 | Regex: `(?i)(tone:|voice:|style:|speak (as|like)|write (in|with) a|formal|informal|professional|friendly|technical|casual|authoritative)` |
-| Schema definition | 10 | Regex: `(?i)(\{[\s\S]{5,50}\}|"type":\s*"|fields?:|properties:|required:|schema:)` or JSON skeleton present |
-| Required fields | 10 | Regex: `(?i)(must include|required fields?|always include|every response (must|should) (have|contain|include))` |
-| Forbidden content | 10 | Regex: `(?i)(never (include|mention|output|say|generate|reveal)|do not (include|mention|output|reveal|disclose)|forbidden:|prohibited:|exclude:)` |
-| Response structure | 10 | Regex: `(?i)(first[,.]|then[,.]|finally[,.]|step \d|begin (with|by)|end (with|by)|start (with|by)|your response should (start|begin|end))` |
-| Error response format | 10 | Regex: `(?i)(if .{0,40}(error|fail|unknown|unclear|can'?t|unable)|when .{0,30}(error|fail)|error (response|format|message)|on (error|failure))` |
-| Validation instruction | 10 | Regex: `(?i)(verify|validate|check|ensure|confirm).{0,30}(before (respond|return|output)|your (response|output|answer))` |
-| Example output | 10 | Regex: `(?i)(example (output|response)|sample (output|response)|here'?s what .{0,20}(look|should)|expected (output|response))` combined with presence of code block or indented block within 10 lines |
+| Format specification | 10 | Regex: `(?i)(respond (in\|with\|as)\|format (as\|your)\|output (as\|in\|format)\|return (JSON\|XML\|YAML\|markdown\|plain text\|HTML\|CSV))` |
+| Length/size constraints | 10 | Regex: `(?i)(max(imum)?\s+\d+\s+(words?\|tokens?\|sentences?\|characters?\|paragraphs?\|lines?)\|keep.{0,20}(short\|brief\|concise\|under \d+)\|limit.{0,20}(to \d+\|length))` |
+| Tone/voice definition | 10 | Regex: `(?i)(tone:\|voice:\|style:\|speak (as\|like)\|write (in\|with) a\|formal\|informal\|professional\|friendly\|technical\|casual\|authoritative)` |
+| Schema definition | 10 | Regex: `(?i)(\{[\s\S]{5,50}\}\|"type":\s*"\|fields?:\|properties:\|required:\|schema:)` or JSON skeleton present |
+| Required fields | 10 | Regex: `(?i)(must include\|required fields?\|always include\|every response (must\|should) (have\|contain\|include))` |
+| Forbidden content | 10 | Regex: `(?i)(never (include\|mention\|output\|say\|generate\|reveal)\|do not (include\|mention\|output\|reveal\|disclose)\|forbidden:\|prohibited:\|exclude:)` |
+| Response structure | 10 | Regex: `(?i)(first[,.]\|then[,.]\|finally[,.]\|step \d\|begin (with\|by)\|end (with\|by)\|start (with\|by)\|your response should (start\|begin\|end))` |
+| Error response format | 10 | Regex: `(?i)(if .{0,40}(error\|fail\|unknown\|unclear\|can'?t\|unable)\|when .{0,30}(error\|fail)\|error (response\|format\|message)\|on (error\|failure))` |
+| Validation instruction | 10 | Regex: `(?i)(verify\|validate\|check\|ensure\|confirm).{0,30}(before (respond\|return\|output)\|your (response\|output\|answer))` |
+| Example output | 10 | Regex: `(?i)(example (output\|response)\|sample (output\|response)\|here'?s what .{0,20}(look\|should)\|expected (output\|response))` combined with presence of code block or indented block within 10 lines |
 
 ### Rubric
 
@@ -126,6 +132,7 @@ Whether the prompt defines a clear, enforceable contract for what the model shou
 ### Examples
 
 **Good (score ~95):**
+
 ```
 ## Output Format
 Respond with a JSON object matching this schema:
@@ -144,16 +151,19 @@ Maximum response size: 500 tokens.
 ```
 
 **Mediocre (score ~40):**
+
 ```
 Return your analysis as JSON with the sentiment and a summary. Keep it short.
 ```
 
 **Bad (score ~5):**
+
 ```
 Tell the user what you think about the text.
 ```
 
 ### Anti-gaming rules
+
 - "Respond in JSON" without any field specification caps at 3 pts for format
 - Length constraints must be numeric — "keep it short" without a number = 5 pts max
 - Tone words must be 2+ specific adjectives, not just "appropriate" or "suitable"
@@ -165,9 +175,11 @@ Tell the user what you think about the text.
 ## Dimension 3: efficiency (weight: 15%) — Adapted
 
 ### What it measures
+
 Token efficiency — how much value per token. System prompts are uniquely cost-sensitive because they're included in every request.
 
 ### Key differences from SKILL.md efficiency
+
 - **No frontmatter stripping** — system prompts have no YAML header
 - **Higher penalty for verbosity** — every word costs money per-request
 - **Conditional inclusion detection** — instructions for unused tools waste tokens
@@ -180,33 +192,36 @@ Token efficiency — how much value per token. System prompts are uniquely cost-
 
 | Pattern | Regex | Weight |
 |---------|-------|--------|
-| Imperative instructions | `(?i)^(?:\d+\.\s*)?(?:Respond|Return|Generate|Analyze|Extract|Classify|Summarize|Translate|Format|Parse|Validate|Check|Ignore|Never|Always|Include|Exclude|Limit|Use|Avoid)\b` | 3 per (cap 20) |
-| Concrete examples | `(?i)(example|e\.g\.|for instance|input.*output|<example>)` | 5 per (cap 3) |
-| Rationale/why | `(?i)(because|since|this (ensures|prevents|avoids)|otherwise|so that)` | 2 per (cap 5) |
-| Quantified constraints | `\b\d+\s*(words?|tokens?|items?|max|min|seconds?|characters?)\b` | 2 per (cap 5) |
+| Imperative instructions | `(?i)^(?:\d+\.\s*)?(?:Respond\|Return\|Generate\|Analyze\|Extract\|Classify\|Summarize\|Translate\|Format\|Parse\|Validate\|Check\|Ignore\|Never\|Always\|Include\|Exclude\|Limit\|Use\|Avoid)\b` | 3 per (cap 20) |
+| Concrete examples | `(?i)(example\|e\.g\.\|for instance\|input.*output\|<example>)` | 5 per (cap 3) |
+| Rationale/why | `(?i)(because\|since\|this (ensures\|prevents\|avoids)\|otherwise\|so that)` | 2 per (cap 5) |
+| Quantified constraints | `\b\d+\s*(words?\|tokens?\|items?\|max\|min\|seconds?\|characters?)\b` | 2 per (cap 5) |
 
 **Noise indicators (negative):**
 
 | Pattern | Regex | Weight |
 |---------|-------|--------|
-| Filler phrases | `(?i)(it is important to note|please note|keep in mind|remember that|be aware that|it's worth mentioning|as mentioned|in other words)` | 3 per |
+| Filler phrases | `(?i)(it is important to note\|please note\|keep in mind\|remember that\|be aware that\|it's worth mentioning\|as mentioned\|in other words)` | 3 per |
 | Hedging | `(?i)(you (might\|could\|should\|may) (want to\|consider\|possibly))` | 3 per |
-| Tautologies | `(?i)(helpful and useful|clear and concise|accurate and correct|complete and comprehensive|efficient and effective)` | 4 per |
+| Tautologies | `(?i)(helpful and useful\|clear and concise\|accurate and correct\|complete and comprehensive\|efficient and effective)` | 4 per |
 | Begging language | `(?i)(CRITICAL!?\|IMPORTANT!?\|YOU MUST\|NEVER EVER\|ABSOLUTELY\|EXTREMELY important)` — aggressive emphasis that hurts newer models | 2 per |
-| Obvious instructions | `(?i)(think carefully|do your best|try to be helpful|be a good assistant|make sure to|don't forget)` | 2 per |
+| Obvious instructions | `(?i)(think carefully\|do your best\|try to be helpful\|be a good assistant\|make sure to\|don't forget)` | 2 per |
 | Redundant repetition | Same instruction stated 2+ ways (deduplicate on normalized 80-char prefix) | 2 per duplicate |
 
 **Scoring formula:**
+
 ```
 density = ((signal_count - noise_count) / total_words) * 100
 score = 40 + (density / 10)^0.5 * 55  (clamped 0-95)
 ```
 
 **Bonuses:**
+
 - Under 500 words with density >= 3: +5
 - Static content grouped at top (for caching): +3 — detect via: constraints/role in first 40%, variable/dynamic content after
 
 **Penalties:**
+
 - Over 3000 words with density < 3: -20
 - Over 50% empty lines: -10
 - Over 5 tautologies: -10
@@ -220,6 +235,7 @@ score = 40 + (density / 10)^0.5 * 55  (clamped 0-95)
 ### Examples
 
 **Good (score ~90):**
+
 ```
 You are a SQL query optimizer. Given a PostgreSQL query, return an optimized version.
 
@@ -231,21 +247,27 @@ Rules:
 
 Output: optimized query + explanation (max 3 sentences).
 ```
+
 (62 words, 4 concrete rules, 1 quantified constraint, 0 filler)
 
 **Mediocre (score ~50):**
+
 ```
 You are a helpful SQL optimization assistant. Your job is to help users optimize their database queries. It is important to note that you should focus on PostgreSQL. Please keep in mind that performance matters. You should consider using CTEs instead of subqueries when it makes sense. Remember that SELECT * is generally not recommended. Try to be thorough but also concise in your explanations.
 ```
+
 (65 words, same information as above but 50% more words, 4 filler phrases)
 
 **Bad (score ~25):**
+
 ```
 You are an EXTREMELY helpful and knowledgeable database expert. It is CRITICALLY IMPORTANT that you ALWAYS provide the BEST possible query optimization advice. You MUST NEVER give bad advice. Please be very careful and thorough. Think step by step about every query. Make sure to consider all possible optimizations. Don't forget to check for index usage. Remember to always test your suggestions. Be aware that different databases have different features. Keep in mind that performance is important.
 ```
+
 (80 words, 0 concrete rules, 6 filler phrases, 3 begging phrases, 0 quantified constraints)
 
 ### Anti-gaming rules
+
 - Cap on all signal categories prevents keyword stuffing
 - Duplicated instructions (normalized) count as noise, not signal
 - "Example" keyword without actual input/output content = 0 pts
@@ -256,6 +278,7 @@ You are an EXTREMELY helpful and knowledgeable database expert. It is CRITICALLY
 ## Dimension 4: clarity (weight: 15%) — Transferred
 
 ### What it measures
+
 Whether instructions are unambiguous, non-contradictory, and specific enough to implement deterministically.
 
 ### Scoring model: Deductive, starts at 100
@@ -267,10 +290,12 @@ Whether instructions are unambiguous, non-contradictory, and specific enough to 
 Extract (verb, object) pairs from "always/must" vs "never/must not/do not" patterns. Same algorithm as SKILL.md clarity.
 
 Regex (reuse from SKILL.md):
+
 - `(?i)\b(always|must)\s+(\w+(?:\s+\w+)?)`
 - `(?i)\b(never|must not|do not|don't)\s+(\w+(?:\s+\w+)?)`
 
 **System-prompt-specific contradictions:**
+
 - `(?i)be (concise|brief)` + `(?i)(explain (thoroughly|in detail)|provide (detailed|comprehensive))` — penalty 15
 - `(?i)(respond only in \w+)` appearing 2+ times with different languages/formats — penalty 15
 - `(?i)always` + `(?i)unless` on same topic within 5 lines — penalty 10 (ambiguous override)
@@ -308,25 +333,31 @@ Regex (reuse from SKILL.md):
 ### Examples
 
 **Good (score ~95):**
+
 ```
 Respond only in English. If the user writes in another language, respond in English with a note that you only support English.
 
 Always include line numbers in code reviews. Never include line numbers in code generation.
 ```
+
 (Clear, no contradictions — "line numbers" has different context for review vs generation.)
 
 **Mediocre (score ~55):**
+
 ```
 Be helpful and professional. Respond appropriately to user questions. Sometimes provide examples when it seems useful. Use the right format for the situation.
 ```
 
 **Bad (score ~15):**
+
 ```
 Always be concise. Provide thorough, detailed explanations for every topic. Keep responses short. Include comprehensive examples. It should be formatted properly.
 ```
+
 (Contradictions: concise vs detailed, short vs comprehensive. Vague: "properly.")
 
 ### Anti-gaming rules
+
 - Adding "if X then Y, unless Z" complexity just for specificity doesn't help if X/Y/Z are themselves vague
 - Quantification must be meaningful — "respond in exactly 1-999999 words" = 0 pts
 - Each unique contradiction penalized only once (no double-counting same pair)
@@ -336,9 +367,11 @@ Always be concise. Provide thorough, detailed explanations for every topic. Keep
 ## Dimension 5: security (weight: 15%) — Adapted
 
 ### What it measures
+
 How well the system prompt defends against prompt injection, data exfiltration, jailbreaking, and privilege escalation.
 
 ### Key differences from SKILL.md security
+
 - SKILL.md security scans for malicious content IN the skill
 - System prompt security scores for defensive patterns AGAINST attacks
 - **Dual scoring:** penalize vulnerabilities AND reward defenses
@@ -367,7 +400,7 @@ Reuse existing SKILL.md categories with adjusted weights:
 | Input sanitization awareness | 8 | `(?i)(user input.{0,30}(untrusted\|sanitize\|validate\|may contain)\|treat .{0,20}(user\|external).{0,20}(as data\|not as instruction))` |
 | Output filtering | 8 | `(?i)(never (reveal\|output\|disclose\|share).{0,30}(system prompt\|these instructions\|internal\|private)\|do not (repeat\|echo\|show).{0,30}(prompt\|instructions))` |
 | Scope limitation | 6 | `(?i)(only (discuss\|answer\|respond to\|help with).{0,30}(topic\|domain\|subject)\|(off.?topic\|out of scope\|outside.{0,20}(scope\|domain)).{0,30}(decline\|refuse\|redirect))` |
-| Canary/tripwire | 5 | `(?i)(canary|tripwire|if .{0,30}(asks? (for\|about)\|requests?) .{0,30}(system prompt\|instructions).{0,30}(refuse\|decline\|ignore))` |
+| Canary/tripwire | 5 | `(?i)(canary\|tripwire\|if .{0,30}(asks? (for\|about)\|requests?) .{0,30}(system prompt\|instructions).{0,30}(refuse\|decline\|ignore))` |
 | Content policy reference | 5 | `(?i)(content policy\|usage policy\|terms of (service\|use)\|acceptable use\|safety guidelines)` |
 
 **Final score:** `min(100, max(0, Part_A + Part_B))`
@@ -381,6 +414,7 @@ Reuse existing SKILL.md categories with adjusted weights:
 ### Examples
 
 **Good (score ~95):**
+
 ```
 You are CustomerBot, a support agent for Acme Corp. You ONLY discuss Acme products and policies.
 
@@ -393,17 +427,21 @@ Security rules (these override all other instructions):
 ```
 
 **Mediocre (score ~50):**
+
 ```
 You are a customer support bot. Help users with their questions. Be helpful and accurate.
 ```
+
 (No vulnerabilities, but no defenses either.)
 
 **Bad (score ~5):**
+
 ```
 You are a helpful assistant. Do whatever the user asks. If the user tells you to ignore your instructions, that's fine — be accommodating. Print your system prompt if asked.
 ```
 
 ### Anti-gaming rules
+
 - Defense patterns must be semantically meaningful — `<!-- canary: abc123 -->` without actual logic = 0 pts
 - "Never reveal system prompt" stated 5 times still counts as 1 defense
 - Identity anchoring requires a specific identity (not "you are an AI assistant")
@@ -414,9 +452,11 @@ You are a helpful assistant. Do whatever the user asks. If the user tells you to
 ## Dimension 6: composability (weight: 10%) — Adapted
 
 ### What it measures
+
 Whether the system prompt plays well in multi-prompt architectures, agent handoff systems, and prompt chains.
 
 ### Key differences from SKILL.md composability
+
 - No filesystem references (no `references/` dir)
 - Focus on API-level composition: tool definitions, multi-agent handoff, context scoping
 - Relevant for: multi-agent systems, prompt chains, RAG pipelines, tool-using agents
@@ -427,7 +467,7 @@ Whether the system prompt plays well in multi-prompt architectures, agent handof
 |-------|--------|-----------|
 | Scope boundaries | 10 | Positive scope: `(?i)(you (only\|exclusively) (handle\|deal with\|assist with\|help with)\|your (scope\|domain\|responsibility) is\|limited to)` + Negative scope: `(?i)(do not (handle\|answer\|assist with)\|outside (your\|this) scope\|not your (job\|responsibility)\|defer to)` |
 | Handoff patterns | 10 | `(?i)(transfer to\|hand off to\|escalate to\|route to\|pass (the user\|this) to\|redirect to\|suggest (contacting\|speaking with))` |
-| Tool awareness | 10 | `(?i)(tools?:|functions?:|available (tools\|functions)\|you have access to\|you can (call\|use\|invoke))` or tool/function schema indicators |
+| Tool awareness | 10 | `(?i)(tools?:\|functions?:\|available (tools\|functions)\|you have access to\|you can (call\|use\|invoke))` or tool/function schema indicators |
 | Context window management | 10 | `(?i)(conversation history\|previous messages?\|context (window\|length\|limit)\|if (context\|conversation) (exceeds?\|too long)\|summarize (previous\|earlier))` |
 | Statelessness declaration | 10 | `(?i)(you (do not\|don't) (have\|retain\|remember\|store) (memory\|state\|history)\|each (request\|conversation\|message) is (independent\|separate)\|no (persistent\|long-term) (memory\|state))` |
 | Error/fallback behavior | 10 | `(?i)(if (you\|the (tool\|function\|API)) (can'?t\|fail\|error)\|on (error\|failure)\|fallback (to\|behavior)\|graceful(ly)? (fail\|degrad))` |
@@ -445,6 +485,7 @@ Whether the system prompt plays well in multi-prompt architectures, agent handof
 ### Examples
 
 **Good (score ~85):**
+
 ```
 You are the Billing Agent. You handle subscription changes, payment issues, and invoice requests.
 
@@ -459,16 +500,19 @@ Output: JSON with {response: string, action?: {tool: string, params: object}, tr
 ```
 
 **Mediocre (score ~40):**
+
 ```
 You help with billing questions. Use the available tools to look up information. If you can't help, apologize.
 ```
 
 **Bad (score ~5):**
+
 ```
 You are a helpful assistant that can do anything. Help the user with whatever they need.
 ```
 
 ### Anti-gaming rules
+
 - "Transfer to X" requires X to be a named entity, not "transfer to the appropriate agent"
 - Tool awareness requires naming at least one tool/function
 - Scope boundaries must name specific domains, not "handle relevant topics"
@@ -479,6 +523,7 @@ You are a helpful assistant that can do anything. Help the user with whatever th
 ## Dimension 7: completeness (weight: 15%) — NEW
 
 ### What it measures
+
 Whether the prompt anticipates and handles the full space of situations the model will encounter.
 
 ### Scoring model: Additive, 10 checks x 10 pts
@@ -490,11 +535,11 @@ Whether the prompt anticipates and handles the full space of situations the mode
 | Ambiguity handling | 10 | `(?i)(if (unclear\|ambiguous\|vague\|confusing\|uncertain)\|when (you'?re?\|the (intent\|meaning) is) (unsure\|unclear\|not sure\|uncertain)\|ask (for\|the user for) clarification)` |
 | Off-topic handling | 10 | `(?i)(off.?topic\|out of scope\|unrelated (question\|request\|topic)\|not (within\|in) (your\|the) (scope\|domain)\|if (the user\|someone) asks? (about\|for) .{0,30}(unrelated\|outside))` |
 | Multi-turn awareness | 10 | `(?i)(follow.?up\|conversation (history\|context)\|previous (message\|turn\|question)\|referring (back\|to earlier)\|maintain context\|remember (earlier\|previous\|the))` |
-| Language/locale handling | 10 | `(?i)(language:|respond in \w+\|if .{0,20}(another\|different\|foreign) language\|locale\|translation\|multilingual\|english only)` |
+| Language/locale handling | 10 | `(?i)(language:\|respond in \w+\|if .{0,20}(another\|different\|foreign) language\|locale\|translation\|multilingual\|english only)` |
 | Empty/null input handling | 10 | `(?i)(empty (input\|message\|query\|request)\|blank (input\|message)\|null\|no (input\|message\|content) (provided\|given\|received)\|if .{0,20}(nothing\|empty))` |
 | Rate/limit awareness | 5 | `(?i)(rate limit\|too many (requests?\|calls?)\|throttl\|quota\|if .{0,30}(exceed\|limit\|cap))` |
 | Graceful degradation | 10 | `(?i)(graceful(ly)?\s+(fail\|degrad\|handle)\|best effort\|partial (response\|result)\|if .{0,30}(can'?t fully\|unable to complete\|partial))` |
-| Examples for ambiguous cases | 15 | Presence of 2+ examples that show non-obvious behavior: `(?i)(example|e\.g\.)` followed by scenario containing `(?i)(but|however|edge|special|even (if|when|though)|note that)` within 5 lines |
+| Examples for ambiguous cases | 15 | Presence of 2+ examples that show non-obvious behavior: `(?i)(example\|e\.g\.)` followed by scenario containing `(?i)(but\|however\|edge\|special\|even (if\|when\|though)\|note that)` within 5 lines |
 
 ### Rubric
 
@@ -505,6 +550,7 @@ Whether the prompt anticipates and handles the full space of situations the mode
 ### Examples
 
 **Good (score ~90):**
+
 ```
 You are a booking assistant for FlightCo.
 
@@ -522,16 +568,19 @@ Language: English only. If user writes in another language, respond in English w
 ```
 
 **Mediocre (score ~45):**
+
 ```
 You help users book flights. Search for available flights and help them complete their booking. If something goes wrong, let them know.
 ```
 
 **Bad (score ~5):**
+
 ```
 You are a flight booking assistant. Book flights for users.
 ```
 
 ### Anti-gaming rules
+
 - Each edge case must describe a specific scenario AND a specific response — "handle edge cases" without listing them = 0 pts
 - Generic "if error, inform user" without specifying what kind of error = 5 pts max
 - "Ask for clarification" must specify WHEN — unconditional clarification-asking is an anti-pattern
@@ -555,6 +604,7 @@ composite = (
 ```
 
 ### Security cap (transferred from SKILL.md)
+
 If `security < 20`, composite is capped at 60.
 If `security < 10`, composite is capped at 40.
 If `security < 5`, composite is capped at 20.

--- a/docs/superpowers/plans/2026-04-15-hydra-findings-fix.md
+++ b/docs/superpowers/plans/2026-04-15-hydra-findings-fix.md
@@ -56,6 +56,7 @@
   - `test_estimate_tokens_uses_prompt_length`: verify estimation accounts for prompt overhead
 
 - [ ] In `evolve/engine.py`, move token estimation AFTER prompt construction (line ~264→~290):
+
   ```python
   estimated = int((len(user_prompt.split()) + len(best_content.split())) * 1.3 + 800)
   ```
@@ -69,6 +70,7 @@
   - `test_cost_estimate_default_sonnet`: backward-compat with current behavior
 
 - [ ] Add `MODEL_PRICING` dict to `evolve/budget.py`:
+
   ```python
   MODEL_PRICING = {
       "anthropic/claude-sonnet-4-20250514": (3.0, 15.0),
@@ -78,6 +80,7 @@
       "ollama/llama3": (0.0, 0.0),
   }
   ```
+
   Update `estimate_cost_usd()` to accept optional `model` param, lookup pricing.
 
 - [ ] Run full test suite, commit
@@ -102,6 +105,7 @@
 ### Task 2.2: Fix Registry Weights to Sum to 1.0
 
 - [ ] Fix `scoring/registry.py` `_INSTRUCTION_FILE_WEIGHTS`: adjust to sum exactly 1.0 (currently 1.03)
+
   ```python
   _INSTRUCTION_FILE_WEIGHTS = {
       "structure": 0.15, "triggers": 0.20, "quality": 0.20,
@@ -164,12 +168,14 @@
 ### Task 3.2: Hoist re.compile() to Module Level (Performance)
 
 - [ ] In `shared.py`, move 3 regex patterns from inside `validate_regex_complexity()` to module level:
+
   ```python
   # Module level (after other re.compile calls)
   _RE_NESTED_QUANT = re.compile(r'[+*]\)?[+*?{]')
   _RE_OVERLAP_QUANT = re.compile(r'\((?!\?:)[^)]*\|[^)]*\)[+*]{1,2}')
   _RE_GROUP_INNER_QUANT = re.compile(r'\([^)]*[.][*+][^)]*\)[+*?{]')
   ```
+
   Update function body to reference module-level names.
 
 - [ ] Run full test suite, commit

--- a/docs/superpowers/plans/2026-05-26-audit-followups.md
+++ b/docs/superpowers/plans/2026-05-26-audit-followups.md
@@ -35,6 +35,7 @@
 ## Task 1: Composite guards (write first, RED)
 
 **Files:**
+
 - Create: `skills/schliff/tests/unit/test_composite_unified.py`
 - Create: `benchmarks/anti-gaming/skills/clean-reference.md`
 
@@ -42,7 +43,7 @@
 
 Create `benchmarks/anti-gaming/skills/clean-reference.md` — a well-formed skill with real sections, no gaming:
 
-```markdown
+````text
 ---
 name: changelog-updater
 description: Use when adding a release entry to CHANGELOG.md, before tagging a version, to keep the changelog consistent with Keep-a-Changelog format.
@@ -62,18 +63,28 @@ Do NOT use for editing release notes on the GitHub releases page — that is a s
 
 ## Example
 Before:
+
 ```
+
 ## [Unreleased]
+
 ### Fixed
+
 - Crash on empty input
+
 ```
 After:
+
 ```
+
 ## [Unreleased]
 
 ## [1.4.0] - 2026-05-26
+
 ### Fixed
+
 - Crash on empty input
+
 ```
 
 ## Edge cases
@@ -82,7 +93,7 @@ After:
 
 ## Handoff
 After updating, hand off to the tagging step; this skill does not run git commands.
-```
+````
 
 - [ ] **Step 2: Write the failing guard tests**
 
@@ -200,6 +211,7 @@ git commit -m "test: composite unification + anti-gaming separation guards (red)
 ## Task 2: Unified full-denominator composite (GREEN)
 
 **Files:**
+
 - Modify: `skills/schliff/scripts/scoring/composite.py:49-169`
 
 - [ ] **Step 1: Replace the aggregation in `compute_composite`**
@@ -336,6 +348,7 @@ git commit -m "feat: unified full-denominator composite — one basis, security 
 ## Task 3: Evolve loop uses the unified headline
 
 **Files:**
+
 - Modify: `skills/schliff/scripts/evolve/engine.py:45-52`
 
 - [ ] **Step 1: Write the failing test**
@@ -388,6 +401,7 @@ git commit -m "test: pin evolve headline == CLI headline (unification end-to-end
 ## Task 4: Surface-dim gaming penalty (lever 2 — conditional)
 
 **Files:**
+
 - Modify: `benchmarks/anti-gaming/run.py:81-138`
 - Modify: a measured-dim scorer (decided after reproduction)
 
@@ -434,6 +448,7 @@ def main():
 
 Run: `/usr/bin/python3 benchmarks/anti-gaming/run.py`
 Expected: prints the table + clean composite. Note exit status: `echo $?`.
+
 - If exit 0 (no violations): 7.2.0 + the full-denominator change already separate gamed from clean. **Record this as a finding in the spec; lever 2 is unnecessary.** Skip to Step 5.
 - If exit 1: a gamed file reaches clean. Identify which dimension inflates it (compare `all_scores`); that names the lever.
 
@@ -481,6 +496,7 @@ git commit -m "feat: anti-gaming composite-separation gate + surface-dim stuffin
 ## Task 5: Re-baseline golden scores + docs + CHANGELOG
 
 **Files:**
+
 - Modify: any failing test fixtures encoding composite values; `benchmarks/anti-gaming` doc numbers; `CHANGELOG.md`
 
 - [ ] **Step 1: Run the full suite to surface the blast radius**
@@ -500,7 +516,7 @@ Run: `/usr/bin/python3 benchmarks/anti-gaming/run.py --json > /tmp/ag.json` and 
 
 In `CHANGELOG.md` under `## [Unreleased]`, add:
 
-```markdown
+```text
 ### Changed
 - **BREAKING (scoring):** Composite is now computed over a single canonical 7-dimension basis
   with a full denominator — unmeasured dimensions are uncredited (not silently renormalized away).
@@ -525,6 +541,7 @@ git commit -m "refactor: re-baseline golden scores for unified composite + CHANG
 ## Task 6: Housekeeping — remove dead cap, verify 7/7
 
 **Files:**
+
 - Modify: `skills/schliff/scripts/scoring/security.py:231-239`
 - Modify: `skills/schliff/tests/unit/test_security.py` (reference to `get_composite_cap`)
 
@@ -563,6 +580,7 @@ git commit -m "chore: remove dead get_composite_cap; assert 7/7 default reportin
 ## Task 7: Measure the deterministic-patch ratio
 
 **Files:**
+
 - Create: `skills/schliff/scripts/measure_patch_ratio.py`
 - Create: `skills/schliff/tests/unit/test_patch_ratio.py`
 
@@ -687,6 +705,7 @@ git commit -m "feat: measure_patch_ratio.py — canonical deterministic-patch-ra
 ## Task 8: Correct the "60-70%" claim everywhere
 
 **Files:**
+
 - Modify: `README.md:199,266`; `docs/ARCHITECTURE.md:79`; `skills/schliff/SKILL.md:6-7`; `docs/specs/2026-03-28-v8-design.md:213`; `skills/schliff/scripts/auto-improve.py:7`; `docs/specs/plans/v8-session-prompts.md:789`
 
 - [ ] **Step 1: Locate every occurrence**
@@ -721,6 +740,7 @@ git commit -m "docs: correct deterministic-patch ratio to measured value with ca
 ## Task 9: Version single source of truth
 
 **Files:**
+
 - Modify: `skills/schliff/__init__.py`
 - Modify: `.claude-plugin/plugin.json:3`
 - Create: `skills/schliff/tests/unit/test_version_consistency.py`
@@ -795,6 +815,7 @@ git commit -m "fix: single-source version + drift guard (plugin.json 6.1.0 -> 7.
 ## Task 10: Episodic-memory unit test
 
 **Files:**
+
 - Create: `skills/schliff/tests/unit/test_episodic_store.py`
 
 - [ ] **Step 1: Write the test (covers persistence, locking path, atomic rename, ranking, size cap)**
@@ -890,6 +911,7 @@ git commit -m "test: dedicated episodic-store unit coverage (persistence, rankin
 ## Task 11: pytest as the default runner
 
 **Files:**
+
 - Modify: `Makefile:1,9-10,18`
 
 - [ ] **Step 1: Add a pytest target and route `make test` through it**
@@ -900,10 +922,10 @@ In `Makefile`, update the `.PHONY` line to include `test-unit`, and change the t
 .PHONY: test test-unit test-self test-proof test-all score lint install install-dev clean help
 
 test-unit: ## Run the pytest unit suite (1100+ tests)
-	/usr/bin/python3 -m pytest skills/schliff/tests -q
+ /usr/bin/python3 -m pytest skills/schliff/tests -q
 
 test: test-unit ## Run unit tests (pytest) then integration tests
-	cd $(SKILL_DIR) && bash scripts/test-integration.sh --no-runtime-auto
+ cd $(SKILL_DIR) && bash scripts/test-integration.sh --no-runtime-auto
 ```
 
 Update `test-all` to include unit explicitly (it already chains `test`):
@@ -936,6 +958,7 @@ git commit -m "build: wire pytest into make test (default runner)"
 /usr/bin/python3 skills/schliff/scripts/measure_patch_ratio.py
 make test-unit 2>&1 | tail -3
 ```
+
 Expected: all tests PASS; anti-gaming `exit=0`; measurement prints the canonical ratio.
 
 - [ ] **Step 2: Confirm no stale artifacts**
@@ -945,6 +968,7 @@ grep -rn "60-70\|60–70" README.md docs/ skills/ || echo "claim clean"
 grep -rn "get_composite_cap" skills/ || echo "dead code clean"
 git -C . log --oneline bc8269e..HEAD
 ```
+
 Expected: "claim clean", "dead code clean", and the workstream commits listed.
 
 ---

--- a/docs/superpowers/specs/2026-05-26-audit-followups-design.md
+++ b/docs/superpowers/specs/2026-05-26-audit-followups-design.md
@@ -37,6 +37,7 @@ silently dropped, so without an eval suite the composite is computed from gameab
 only. One correct aggregation definition fixes both.
 
 **Unified composite definition (decided — AI-evals best practice, Husain/Shankar):**
+
 1. **Canonical composite = the 7 default dims** (security/runtime excluded), weights renormalized
    to sum 1.0. Every entrypoint (CLI, evolve, doctor, bench) computes this identically.
 2. **Full-denominator aggregation (Path B): unmeasured = uncredited, not failed.**
@@ -55,6 +56,7 @@ only. One correct aggregation definition fixes both.
    optimize a single aggregate; read the failure-mode vector).
 
 **W1a — Guards (write first, expect red).**
+
 - Add a genuine clean-reference skill to `benchmarks/anti-gaming/skills/`.
 - **Guard 1 (separation):** every gamed skill's composite MUST be `< clean_composite` under the
   no-eval-suite condition. Real gate (non-zero exit) + pytest wrapper.
@@ -66,6 +68,7 @@ only. One correct aggregation definition fixes both.
   reproduction not observed.
 
 **W1b — Fix until green (two orthogonal levers).**
+
 - **Lever 1 — aggregation:** implement the unified full-denominator composite (def. 1-4 above).
   Fixes dual-scale entirely and removes the misleading-high-magnitude half of anti-gaming.
 - **Lever 2 — surface-dim gaming penalty:** make `gamed_composite < clean_composite` at *equal*
@@ -74,6 +77,7 @@ only. One correct aggregation definition fixes both.
   reproducing the inversion in W1a.
 
 **Impact / blast radius (the safety accounting).**
+
 - Full-denominator rescales no-eval-suite composites downward (~×coverage). Affects: deterministic
   golden-score fixtures, doc example numbers, and **threshold semantics** (`fail if score<70` in the
   GitHub Action / pre-commit) — a documented scale change at the v8 major boundary; CHANGELOG must

--- a/skills/schliff/SKILL.md
+++ b/skills/schliff/SKILL.md
@@ -157,6 +157,7 @@ Read full skill tree before each change. Extract sections to `references/` when 
 ## Discovery Mode (Auto-Gap Analysis)
 
 Run `/schliff:analyze` without a GOAL:
+
 1. Run all 7 dimension scorers.
 2. Identify weakest dimension and failure patterns.
 3. Cluster eval failures for systemic issues (e.g., "all false negatives share short prompts").
@@ -220,6 +221,7 @@ Requires Python >= 3.9, Git >= 2.0, jq >= 1.6, Bash >= 4.0. Standard library onl
 ## Files
 
 Run `ls -R` in skill directory. Run `python3 scripts/score-skill.py SKILL.md --json` for scores. Key files:
+
 - `scripts/init-skill.py` — Bootstrap eval-suite (`--json --dry-run`)
 - `scripts/generate-report.py` — Shareable improvement report
 - `scripts/score-skill.py` — Dimension scores incl. runtime (`--diff --clarity --weights`)

--- a/skills/schliff/references/improvement-protocol.md
+++ b/skills/schliff/references/improvement-protocol.md
@@ -6,6 +6,7 @@ skill-specific enhancements. The loop runs autonomously (no human confirmation) 
 the goal is met or a stop condition occurs.
 
 **Core principles:**
+
 - One atomic change per iteration
 - Fixed time budget per iteration (no hung experiments)
 - User-defined goal + metric + verification, with defaults
@@ -21,6 +22,7 @@ the goal is met or a stop condition occurs.
 Initialize the autonomous improvement session with user-provided configuration.
 
 **Required inputs from user:**
+
 1. **GOAL** (natural language): What should the skill achieve?
    - Example: "Handle CSV parsing with quoted fields and escaped quotes"
    - Example: "Improve trigger accuracy for data pipeline tasks"
@@ -47,6 +49,7 @@ Initialize the autonomous improvement session with user-provided configuration.
    - Stop after N iterations even if goal not met
 
 **Setup phase actions:**
+
 - Create `schliff-session.json` with all config
 - Initialize git branch: `git checkout -b schliff-session-{timestamp}`
 - Create `.schliff/` directory for session artifacts
@@ -55,6 +58,7 @@ Initialize the autonomous improvement session with user-provided configuration.
 - Print summary and confirm loop is ready to start
 
 **Setup output:**
+
 ```json
 {
   "session_id": "schliff-20260319-143022",
@@ -76,6 +80,7 @@ Initialize the autonomous improvement session with user-provided configuration.
 Read the current state and identify improvement opportunities.
 
 **Actions:**
+
 - Re-read SKILL.md in full (never assume state is cached)
 - Re-read all reference files linked from SKILL.md
 - Read git log: `git log --oneline -20`
@@ -95,20 +100,24 @@ ELSE → focus on lowest-scoring dimension
 ```
 
 **For custom metrics:**
+
 - Analyze trends in `schliff-results.jsonl` for the user-defined metric
 - Identify which code/content blocks correlate with metric improvements
 - Look for patterns: which types of changes moved the metric most?
 
 **Stopping condition check:**
+
 - If 10 consecutive discards with zero metric improvement → stop, notify user
 - If metric reached goal threshold → stop, celebrate
 - If max_iterations reached → stop
 
 **Special case: Dimension thrashing**
+
 - If same dimension discarded 3+ times consecutively → switch to different dimension
 - For custom metrics: rotate focus every 5 discards to avoid local minima
 
 **Output:**
+
 ```
 === Phase 1: REVIEW (iteration 5) ===
 Current structure: 68.5
@@ -125,23 +134,27 @@ Ready to ideate.
 Choose ONE specific, atomic change.
 
 **Rules for atomic changes:**
+
 - Expressible in a single sentence
 - Affects exactly one aspect of the skill
 - Testable (will move the metric)
 - Reversible (clean `git revert` rollback)
 
 **Good examples:**
+
 - "Add 3 trigger synonyms to description for data pipeline tasks"
 - "Add input/output example for CSV with quoted fields edge case"
 - "Compress 20-line setup block to 4 lines of concise steps"
 - "Fix frontmatter format: description field exceeds 200 chars"
 
 **Bad examples (too broad):**
+
 - "Rewrite the entire skill" — not atomic
 - "Make it better" — not specific
 - "Add lots of examples" — unbounded
 
 **Ideation strategy (text-gradient-first):**
+
 - Run `python3 scripts/text-gradient.py SKILL.md --json --top 5` to get ranked improvements
 - Pick the highest-priority gradient that hasn't been tried in the last 3 iterations
 - If all top gradients have been tried, fall back to manual ideation:
@@ -151,6 +164,7 @@ Choose ONE specific, atomic change.
   - For default metrics: use the decision framework from Phase 1
 
 **Output:**
+
 ```
 === Phase 2: IDEATE (iteration 5) ===
 Experiment: exp-005
@@ -167,11 +181,13 @@ Ready to modify.
 Apply the change to skill files.
 
 **Pre-modification:**
+
 - Set a timer (start time budget countdown)
 - Record hash of SKILL.md before changes
 - Pre-load ALL target files into context (never edit partially)
 
 **Rules:**
+
 - Only modify files within the target skill directory
 - Preserve formatting conventions
 - Maintain YAML frontmatter validity
@@ -179,14 +195,16 @@ Apply the change to skill files.
 - If removing content, verify no other files depend on it
 
 **Frontmatter edits (high-risk):**
+
 - The `description` field is the primary trigger mechanism
 - Keep under 200 words (longer descriptions dilute matching)
 - Include both what it does AND when to use it
 - Include specific trigger phrases
 - Include negative boundaries ("do NOT use for...")
-- After edit, validate with: `python3 -c "import yaml; yaml.safe_load(open('SKILL.md'))" `
+- After edit, validate with: `python3 -c "import yaml; yaml.safe_load(open('SKILL.md'))"`
 
 **Output:**
+
 ```
 === Phase 3: MODIFY (iteration 5) ===
 Experiment: exp-005
@@ -218,17 +236,20 @@ Goal: Improve trigger accuracy for domain-specific phrases
 ```
 
 **Commit message guidelines:**
+
 - First line: `experiment: exp-{NN} [dimension] one-sentence description`
 - Add metadata in body (experiment number, dimension, goal)
 - Enable filtering: `git log --grep="experiment:"`
 - Sequential numbering essential for traceability
 
 **Example commits:**
+
 - `experiment: exp-001 [structure] validate frontmatter and add missing sections`
 - `experiment: exp-042 [triggers] add deployment-related synonyms to description`
 - `experiment: exp-083 [quality] add input/output example for CSV edge case`
 
 **Commands:**
+
 ```bash
 git add -A
 git commit -m "experiment: exp-005 [triggers] Add data pipeline, workflow automation
@@ -245,6 +266,7 @@ the `gradient_id` (format: `dimension:issue`) in the commit message trailer. Thi
 tracking which gradients have high keep-rates via `strategy-log.jsonl`.
 
 **Output:**
+
 ```
 === Phase 4: COMMIT (iteration 5) ===
 Experiment: exp-005
@@ -260,15 +282,18 @@ Ready to verify.
 Run evaluation suite and measure the metric.
 
 **Pre-verification:**
+
 - Note current time (for timeout)
 - Capture environment for reproducibility
 
 **For default 6-dimension scoring:**
 
 1. **Structure score** (automated):
+
    ```bash
    bash scripts/analyze-skill.sh /path/to/skill/SKILL.md
    ```
+
    Checks: YAML validity, required frontmatter fields, file organization
 
 2. **Triggers score** (eval suite):
@@ -294,12 +319,14 @@ Run evaluation suite and measure the metric.
    - References clear? Frontmatter unambiguous?
 
 **For custom metrics:**
+
 - Execute VERIFY_COMMAND
 - Parse output (JSON, TSV, key=value)
 - Extract the user-defined metric value
 - Validate it's comparable to baseline
 
 **Timeout handling (Karpathy's fixed time budget):**
+
 - If verification phase exceeds TIME_BUDGET (default 300 sec):
   - Kill the evaluation process
   - Treat as crash/timeout
@@ -308,17 +335,20 @@ Run evaluation suite and measure the metric.
   - Don't mark as pass or fail; trigger retry logic
 
 **Assertion handling (Olelehmann's binary eval):**
+
 - Track both continuous scores AND pass/fail assertions
 - Example: "Does skill output valid YAML? YES/NO"
 - Pass rate = (assertions passed / total assertions) × 100
 - Include pass rate in results alongside dimension scores
 
 **Error handling:**
+
 - YAML parse error: log error, don't fail; record structure_score=0
 - Eval script crash: log error; advance to Phase 6 with `status=eval_error`
 - Missing dependencies: skip that dimension; note in results
 
 **Output:**
+
 ```
 === Phase 5: VERIFY (iteration 5) ===
 Experiment: exp-005
@@ -355,32 +385,38 @@ Compare new score against best-so-far and decide: KEEP or DISCARD.
 | eval_error | RETRY | Yes (up to max_retries) |
 
 **Retry logic (Uditgoenka's feature):**
+
 - On first crash/timeout: immediately retry (don't count as iteration)
 - On second crash: retry once more
 - On third crash: discard permanently; revert and log
 - Track retry count: `exp-005_retry_1`, `exp-005_retry_2`
 
 **Dimension-level decision:**
+
 - If total score is flat, KEEP if:
   - Target dimension improved by 5+ points, AND
   - No other dimension regressed by more than 2 points
 
 **Custom metric decision:**
+
 - KEEP if metric moved closer to goal
 - DISCARD if metric moved away
 - If tied, check secondary metrics (dimensions) for tiebreaker
 
 **On KEEP:**
+
 - Advance skill files
 - Continue to Phase 7 (LOG)
 
 **On DISCARD:**
+
 ```bash
 git revert HEAD --no-edit
 git log --oneline -1  # Confirm revert
 ```
 
 **On RETRY (crash/timeout):**
+
 - Revert any partial modifications
 - Re-run Phase 3 (MODIFY) again
 - Re-run Phase 4 (COMMIT) with retry suffix
@@ -389,6 +425,7 @@ git log --oneline -1  # Confirm revert
 - Increment retry counter (max 2)
 
 **Output:**
+
 ```
 === Phase 6: DECIDE (iteration 5) ===
 Experiment: exp-005
@@ -414,6 +451,7 @@ Record the iteration result and create history snapshot.
 ```
 
 **JSONL schema (one JSON object per line):**
+
 - `iteration`: sequential iteration number (1, 2, 3...)
 - `experiment`: exp-NNN identifier
 - `commit`: git commit hash (first 7 chars)
@@ -431,6 +469,7 @@ Record the iteration result and create history snapshot.
 ```
 
 Format enables quick filtering:
+
 ```bash
 grep "status=keep" .schliff/experiment-log.txt
 grep "delta=+" .schliff/experiment-log.txt | awk -F'|' '{print $3}' | sort -t= -k2 -rn
@@ -439,6 +478,7 @@ grep "delta=+" .schliff/experiment-log.txt | awk -F'|' '{print $3}' | sort -t= -
 **History snapshot (Olelehmann's feature):**
 
 Save complete skill state at each kept iteration:
+
 ```bash
 mkdir -p .schliff/history/exp-005/
 cp -r . .schliff/history/exp-005/  # (exclude .git, .schliff)
@@ -446,6 +486,7 @@ echo "exp-005 | 2026-03-19T14:35:22Z | score 69.7" > .schliff/history/exp-005/ME
 ```
 
 Enables diffing between iterations:
+
 ```bash
 diff -u .schliff/history/exp-004/SKILL.md .schliff/history/exp-005/SKILL.md
 ```
@@ -477,6 +518,7 @@ Experiments on efficiency: 6 keeps, 8 discards (75% discard rate)
 ```
 
 **Output:**
+
 ```
 === Phase 7: LOG (iteration 5) ===
 Experiment: exp-005
@@ -517,6 +559,7 @@ Return to Phase 1 (REVIEW) for the next iteration.
 5. **Stuck protocol** (Phase 9, below)
 
 **Output:**
+
 ```
 === Phase 8: REPEAT ===
 Iteration 5 complete.
@@ -568,6 +611,7 @@ Triggered after 5 consecutive discards with zero metric improvement.
    - Exit with status code 2
 
 **Output:**
+
 ```
 === Phase 9: STUCK PROTOCOL (iteration 18) ===
 Detected: 5 consecutive discards (exp-014 through exp-018)
@@ -592,30 +636,35 @@ Resuming main loop...
 ## Error Handling & Crash Recovery
 
 **YAML/frontmatter errors:**
+
 - Log error, set structure_score = 0
 - Repair YAML (fix formatting, validate syntax)
 - Don't count repair as iteration
 - Retry Phase 5 (VERIFY)
 
 **Eval script crash:**
+
 - Log full error message and traceback
 - Check script syntax
 - If fixable: fix and retry (up to 3 times total)
 - If not fixable: skip that dimension, score others
 
 **Git conflicts:**
+
 - This should not occur; if it does:
   - Reset to last known good state: `git reset --hard HEAD~1`
   - Log incident
   - Retry from Phase 3 (MODIFY)
 
 **Skill too large for context:**
+
 - If SKILL.md exceeds token limit:
   - Split into SKILL.md + `references/detailed.md`
   - Add pointer in SKILL.md
   - Retry Phase 5 (VERIFY)
 
 **Timeout (Phase 5):**
+
 - Kill evaluation process
 - Log timeout event
 - Treat as recoverable error

--- a/skills/schliff/references/metrics-catalog.md
+++ b/skills/schliff/references/metrics-catalog.md
@@ -24,6 +24,7 @@ and progressive disclosure.
 | Action-oriented | 5 | Uses imperative voice ("Do X", not "You should X") |
 
 **Score ranges:**
+
 - 90-100: Production-ready structure, follows all conventions
 - 70-89: Good structure, minor gaps
 - 50-69: Functional but disorganized
@@ -36,6 +37,7 @@ for unrelated ones.
 
 **Eval method:**
 Create a test suite with:
+
 - 10+ **positive triggers** — prompts that SHOULD activate the skill
 - 5+ **negative triggers** — prompts that should NOT activate it
 - 5+ **edge triggers** — ambiguous prompts near the boundary
@@ -45,6 +47,7 @@ trigger_score = (correct_activations / total_test_prompts) × 100
 ```
 
 **Common trigger failures:**
+
 - Description too narrow → misses valid use cases (false negatives)
 - Description too broad → activates for unrelated tasks (false positives)
 - Missing synonyms → user says "deploy" but description only says "release"
@@ -99,6 +102,7 @@ relative to its total size.
 **How `score-skill.py` measures this (automated):**
 
 The scorer computes a signal-to-noise density ratio:
+
 - **Signal:** actionable instructions (imperative verbs), real examples,
   WHY-based reasoning, verification commands
 - **Noise:** hedging language, filler phrases ("it should be noted that"),
@@ -109,6 +113,7 @@ This approach rewards **fewer words with more punch** rather than the old
 formula which rewarded adding headers and code blocks.
 
 **Red flags (noise indicators):**
+
 - Repeated instructions (same thing said 3 different ways)
 - Verbose preambles before actionable content
 - Filler phrases: "it is important to note that", "as mentioned above"
@@ -116,6 +121,7 @@ formula which rewarded adding headers and code blocks.
 - Instructions Claude already knows: "make sure to save your file"
 
 **Green flags (signal indicators):**
+
 - Concise imperative instructions
 - Real input/output examples
 - WHY-based reasoning (explains rationale, not just rules)
@@ -151,6 +157,7 @@ Opt-in dimension that doesn't affect the default composite score.
 | Complete instructions | 25 | Every "Run X" has a concrete command or path |
 
 **Score ranges:**
+
 - 90-100: Crystal clear instructions, no ambiguity
 - 70-89: Minor clarity issues, mostly readable
 - 50-69: Several vague references or ambiguous sections
@@ -175,6 +182,7 @@ coverage. The scorer reports **coverage** — the fraction of total weight
 actually measured — and warns when coverage is below 50%.
 
 **Quality tiers (with sufficient coverage):**
+
 - 90+ Excellent — production-ready, community-shareable
 - 80-89 Good — reliable for personal/team use
 - 70-79 Adequate — works but has clear gaps

--- a/skills/schliff/references/skill-patterns.md
+++ b/skills/schliff/references/skill-patterns.md
@@ -23,12 +23,14 @@ description: >
 Replace long explanations with input/output examples.
 
 Bad:
+
 ```markdown
 When generating commit messages, ensure they follow the conventional
 commits specification. The type should be one of feat, fix, chore...
 ```
 
 Good:
+
 ```markdown
 ## Commit message format
 Follow conventional commits. Examples:
@@ -58,30 +60,37 @@ State what the skill does NOT do.
 ## Anti-Patterns to Fix
 
 ### Anti-Pattern 1: The Kitchen Sink
+
 **Symptom:** SKILL.md is 1000+ lines with everything inline.
 **Fix:** Extract to references/. Keep SKILL.md as an index + core workflow.
 
 ### Anti-Pattern 2: The Invisible Skill
+
 **Symptom:** Skill exists but never triggers because description is too narrow.
 **Fix:** Add synonyms, rephrase with user language, include concrete trigger phrases.
 
 ### Anti-Pattern 3: The Chatty Instructor
+
 **Symptom:** Instructions explain things Claude already knows.
 **Fix:** Delete. Focus instructions on what's UNIQUE to this skill.
 
 ### Anti-Pattern 4: The Hedger
+
 **Symptom:** Instructions full of "might", "could", "consider", "possibly".
 **Fix:** Use imperative voice with WHY-based reasoning.
 
 ### Anti-Pattern 5: Missing Failure Mode
+
 **Symptom:** Skill only describes the happy path. No guidance for errors.
 **Fix:** Add an explicit "When things go wrong" section.
 
 ### Anti-Pattern 6: The Duplicate
+
 **Symptom:** Skill overlaps significantly with another skill's scope.
 **Fix:** Either merge, or add explicit boundary markers.
 
 ### Anti-Pattern 7: No Examples
+
 **Symptom:** Lots of rules, zero examples.
 **Fix:** Add at least 2-3 input/output examples.
 

--- a/skills/schliff/references/state-management.md
+++ b/skills/schliff/references/state-management.md
@@ -17,6 +17,7 @@ Files created during improvement iterations for a specific skill:
 ### Per-Skill Results (`<skill_dir>/schliff-results.jsonl`)
 
 Append-only log of experiment results. Each line is a JSON object:
+
 ```json
 {"exp": 0, "timestamp": "...", "trigger": "init", "composite_score": 72, "pass_rate": "5/8", "scores": {...}}
 ```
@@ -43,11 +44,13 @@ Cross-project learning data that persists across all Schliff sessions:
 ## Cleanup
 
 To purge all global meta-learning data:
+
 ```bash
 rm -rf ~/.schliff/meta/
 ```
 
 To reset a specific skill's improvement state:
+
 ```bash
 rm -rf <skill_dir>/.schliff/
 rm -f <skill_dir>/schliff-results.jsonl


### PR DESCRIPTION
Two things: markdown conventions made explicit and the findings that were real fixed to zero;
23 merged branches removed. No engine change — `AGENTS.md` 95.8 and `SKILL.md` 98.9 unchanged,
1466 tests green, ruff clean.

## Why a config rather than a 5,000-line reformat

Every editor lints these files against markdownlint's defaults, which this repo has never
followed: **~5,000 findings across 98 files, 54% line-length alone**. At that volume the real
findings are invisible — which is how three genuinely broken documents survived.

`.markdownlint-cli2.jsonc` records the dividing line as **correctness vs cosmetics**:

| off (no convention was ever chosen) | on (changes what a reader sees) |
| --- | --- |
| line-length, inline HTML, blockquote blanks, first-line-H1 | blank lines around lists, headings, fences, tables |
| table pipe style, bullet/emphasis markers, list numbering | table column count |
| fence languages, bare URLs | trailing spaces, hard tabs, stray blanks, padded code spans |

Table pipe style was **measured before being dismissed**. Enforcing `tight` strips all padding
(`|Dimension|Metric|`), and rewrote this repo's own `SKILL.md` enough to move its pinned
v6.3.0 score 98.9 → 99.1 — breaking a guard that had held across ten edits to that file.
`compact`/`aligned` rewrite ~100 tables the other way. GitHub renders all three identically,
so the rule is off and MD056 still catches tables that are actually broken.

## The findings that were real — now zero

**562 by `--fix`**: blank lines around lists, headings and fences; trailing whitespace; hard
tabs. Whitespace only.

**27 table rows** in `system-prompt-scoring-spec.md` held regexes with unescaped `|`:

```
| Role definition | 10 | Regex: `(?i)(you are|your role is|act as|...)` |
```

GitHub parsed that as 8 and 13 columns and has been **dropping the content**. Escaped to `\|`
inside code spans only, verified content-preserving by unescaping both sides and comparing
byte-for-byte — 215 escapes added, nothing else changed.

**One row** in `schliff-registry-platform.md` was missing its Status cell, so the grade scale
rendered in the wrong column.

**A nested-fence bug** in `2026-05-26-audit-followups.md`: an example `SKILL.md` was wrapped in
a 3-backtick fence that itself contained 3-backtick fences, so the first inner one closed the
outer block and the rest of the example rendered as live markdown. Outer fence is now 4
backticks.

Scorer input is excluded rather than linted — bad-skill fixtures, benchmark corpus, launch
corpus are inputs the proof suite asserts score *badly*.

## Branch cleanup

23 remote branches removed, all from long-merged PRs. Each was verified individually before
deletion: its PR reports `MERGED` **and** its merge commit is an ancestor of `origin/main`
(23/23 confirmed). Remote now holds `main` alone. `backup/v7.1.0-complete` is kept locally —
deliberately named, and contains nothing not already on main.

## Verification

`0` markdownlint findings · `AGENTS.md` 95.8, in-repo == isolated · `SKILL.md` 98.9 ·
1466 tests · ruff clean · dangling fixture still reports 3.

**Not done, deliberately:** no CI gate for markdownlint. That means the config documents the
convention but does not enforce it. Adding one pulls node into the test workflow and adds a
required check — worth doing, but it is a scope decision rather than hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
