### PR TITLE
ci: gate markdown in the existing lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,22 @@ jobs:
       - name: Run ruff (enforcing — baseline is clean)
         run: ruff check --output-format=github skills/schliff/scripts/
 
+      # Markdown gate. Conventions live in .markdownlint-cli2.jsonc, which
+      # records which rules this repo deliberately ignores and which it treats
+      # as correctness (a short table row silently drops data on GitHub; a
+      # missing blank line merges a list into the paragraph above).
+      #
+      # No setup-node: GitHub-hosted runners ship Node, and pinning the linter
+      # version is what buys reproducibility here — same reasoning as the
+      # `ruff==0.15.8` pin above.
+      #
+      # File list comes from git rather than a glob, so CI lints exactly the
+      # tracked files. A `**/*.md` glob would additionally catch build/ and
+      # .hydra/ artifacts locally while missing them in a fresh checkout, i.e.
+      # local and CI would disagree.
+      - name: Run markdownlint (enforcing — baseline is clean)
+        run: git ls-files '*.md' | xargs npx --yes markdownlint-cli2@0.23.2
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ wiring is broken — check `SCORER_REGISTRY["agents.md"]`.
 
 ## Code style
 
-- Ruff is the authority (`pyproject.toml`: E, F, W, I; line length 120). Run `make lint` before pushing.
+- Ruff is the authority (`pyproject.toml`: E, F, W, I; line length 120). Run `make lint` before pushing — it gates Python and markdown (`.markdownlint-cli2.jsonc`), exactly as CI does.
 - Core engine code (`skills/schliff/scripts/`) is stdlib-only — never add a runtime dependency there, because "pip install schliff, zero deps" is the product promise CI and the README both make.
 - Scorers must be deterministic: no `time`, `random`, `os.environ` reads, or network in any scoring path, because same-input-same-score is the core guarantee. Tests pin this (`test_purity_no_forbidden_imports`).
 - Prefer explicit error handling; no silent `except: pass` in scoring code.
@@ -65,6 +65,7 @@ wiring is broken — check `SCORER_REGISTRY["agents.md"]`.
 ## Gotchas
 
 - **Never run blanket `ruff --fix`** on existing modules: F401 "unused" imports in `skills/schliff/scripts/` are real re-exports — removing them breaks the CLI (23 tests). Fix only files you authored.
+- **Never lint or reformat scorer input** — `benchmarks/`, `demo/`, test fixtures and the corpora are controlled inputs whose scores are asserted; `.markdownlint-cli2.jsonc` excludes them for that reason.
 - The version lives in **three lockstep sources** (`pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`), gated by `test_version_consistency.py`. Bump all three together.
 - Changing any scorer re-baselines the corpus golden tests (`test_agents_md_profile.py` pins mean/median/band counts on 30 real files). Re-derive the numbers from the engine — never hand-tweak them.
 - `playground/public/index.html` has its inline `<script>` pinned by a CSP `sha256-…` hash in `playground/vercel.json`. Any edit to the inline script requires recomputing the hash, or the deployed page breaks silently.

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ score: ## Score Schliff's own SKILL.md
 score-json: ## Score with JSON output
 	cd $(SKILL_DIR) && python3 scripts/score-skill.py SKILL.md --json
 
-lint: ## Run ruff linter on scripts
+lint: ## Run ruff on scripts + markdownlint on tracked docs (same as CI)
 	ruff check $(SKILL_DIR)/scripts/ || echo "Install ruff: pip install ruff"
+	git ls-files '*.md' | xargs npx --yes markdownlint-cli2@0.23.2 \
+	  || echo "markdown lint needs node (npx); see .markdownlint-cli2.jsonc"
 
 install: ## Install Schliff (copy mode)
 	bash install.sh

--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ schliff v8.7.0
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
-  efficiency            ████████░░   79/100  good
+  efficiency            ████████░░   78/100  good
   composability         ██████████   95/100  excellent
   clarity               ██████████  100/100  perfect
 
-  Structural Score  ███████████████████░  95.8/100  [S]
+  Structural Score  ███████████████████░  95.6/100  [S]
 
-  Tokens: 996 / 3,000 (ok)
+  Tokens: 1,065 / 3,000 (ok)
   Format: agents.md (normalized)
 ```
 
-No model produced that number. Run it on another laptop and you get 95.8 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
+No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
 *The quick-start and case-study numbers here are reproducible from released `schliff==8.7.0` (`pip install schliff==8.7.0`); the hydra field run below is dated to the version it was measured on. No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 


### PR DESCRIPTION
Follow-up to #141: the conventions are documented and the repo is at 0 findings, but a config
without a gate drifts back — and this repo is edited mostly by agents that never see an
editor's squiggles.

## Where it goes, and why that matters

A **step in the existing `lint` job**, not a new job. Branch protection requires exactly
`[lint, test (3.10-3.13), test-macos]`, so this enforces the rule **without touching the
required-check list** and without an admin change. `lint` goes from ~10s to roughly 25s.

**No `setup-node`.** GitHub-hosted runners ship Node, and what buys reproducibility here is
pinning the linter — `markdownlint-cli2@0.23.2`, the same reasoning as the `ruff==0.15.8`
pin one step above. One less action to pin and let Dependabot chase.

**File list from `git ls-files`, not a `**/*.md` glob.** Measured, not assumed: the glob also
picks up `build/`, `.hydra/` and `.pytest_cache` artifacts locally — all of which have
findings — while a fresh CI checkout contains none of them. Local and CI would disagree in
exactly the confusing direction. Deriving the list from git keeps `.gitignore` as the single
source of truth instead of duplicating it into the lint config.

## Local parity

`make lint` now runs both, with ruff's existing graceful degradation. AGENTS.md already says
*"run `make lint` before pushing"*, so that habit now covers what CI checks rather than half
of it.

It also gains one gotcha, next to the existing `ruff --fix` warning:

> **Never lint or reformat scorer input** — `benchmarks/`, `demo/`, test fixtures and the
> corpora are controlled inputs whose scores are asserted.

Not hypothetical: the sweep in #141 edited two anti-gaming fixtures before review caught it.

## An honest cost

That gotcha costs 20 tokens and moves this repo's own AGENTS.md score **95.8 → 95.6**
(efficiency 79 → 78, 1,065/3,000 tokens).

Kept anyway. The README readout and the reproducibility line are updated to the real current
output instead of the content being trimmed to protect the number — verified byte-for-byte
against `schliff score AGENTS.md`. Trimming useful content to defend a self-reported score is
the failure mode this repo spent the day removing, just pointing the other way. The badge is
eventually-consistent and follows within its 24h cache window.

## Verification

`0` markdown findings · 1466 tests · ruff clean · README block == real CLI output ·
in-repo 95.6 == isolated 95.6 · dogfood gate exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
