### PR TITLE
chore(release): bump to 8.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [8.8.0] - 2026-07-27
+## [8.8.0] - 2026-07-28
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.8.0] - 2026-07-27
+
 ### Changed
 
 - **An unrecognised `<runner> run <target>` no longer counts as a build command
@@ -800,7 +802,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.6.3...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.0...HEAD
+[8.8.0]: https://github.com/Zandereins/schliff/compare/v8.7.0...v8.8.0
+[8.7.0]: https://github.com/Zandereins/schliff/compare/v8.6.3...v8.7.0
 [8.6.3]: https://github.com/Zandereins/schliff/compare/v8.6.2...v8.6.3
 [8.6.2]: https://github.com/Zandereins/schliff/compare/v8.6.1...v8.6.2
 [8.6.1]: https://github.com/Zandereins/schliff/compare/v8.6.0...v8.6.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.7.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -29,7 +29,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.7.0
+schliff v8.8.0
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -45,7 +45,7 @@ schliff v8.7.0
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.7.0` (`pip install schliff==8.7.0`); the hydra field run below is dated to the version it was measured on. No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.0` (`pip install schliff==8.8.0`); the hydra field run below is dated to the version it was measured on. No install? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -238,7 +238,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.7.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.8.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -274,7 +274,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.7.0
+    rev: v8.8.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.7.0.**
+**Current version: 8.8.0.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.7.0"
+version = "8.8.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.7.0"
+__version__ = "8.8.0"


### PR DESCRIPTION
Ships the #133 scoring fix (#139): an unrecognised `<runner> run <target>` no longer counts
as a build command. **Minor bump**, matching 8.7.0's precedent — that release was also
score-moving (structure reproducibility, #10).

## What changes for users

`operational_coverage` stops crediting `build` for a target it never inspected. Files that
documented no build step stop being scored as if they did. Over the 30-file AGENTS.md corpus
exactly one file moved; `check-commands` behaviour is unchanged, proven set-identical over
259 real instruction files in #139.

**Output contract:** `schliff check-commands --json` may now emit `"family": "unclassified"`.
`status` is unchanged and nothing was removed, but consumers switching on `family` should
treat it as an open set.

## Version sources

Three lockstep sources bumped (`pyproject.toml`, `.claude-plugin/plugin.json`,
`skills/schliff/__init__.py`), gated by `test_version_consistency`. Secondary refs: PyPI badge
cache-bust, score readout header, reproducibility line, action-pin and pre-commit examples,
`docs/README` current version.

**Also repairs a footer defect 8.7.0 left behind:** the `[Unreleased]` compare link still
pointed at `v8.6.3` and no `[8.7.0]` link existed. Both fixed, so the ladder is unbroken.

## Verified against the built wheel, not the source tree

| check | result |
| --- | --- |
| `python -m build` + `twine check` | both PASSED |
| publish.yml smoke gate (the one repaired in #134) | `python -P -c "import skills.schliff"` from a cwd outside the repo → exit 0 |
| README readout vs `schliff score AGENTS.md` from the installed 8.8.0 wheel | byte-identical — 95.6, efficiency 78, 1,065 tokens |
| "reproducible from released X" claim | holds across the bump: AGENTS.md scores 95.6 on released 8.7.0 too, since its four runner-delegated commands are all exact-vocabulary hits that #133 does not touch |
| suite / ruff / markdown | 1466 tests · clean · 0 findings |

This is the first release to run the repaired smoke gate. Before #134 that gate imported the
source tree and would have passed on an empty wheel.

## After merge

1. `gh release create v8.8.0` → `publish.yml` fires on `release: published` (OIDC trusted
   publishing) → PyPI
2. verify `pip install schliff==8.8.0`
3. playground: bump pin + `uv lock --upgrade-package schliff` + `vercel --prod`
4. leaderboard: seed version + `vercel --prod`

Steps 3 and 4 need PyPI to resolve 8.8.0 first, so they are deliberately not in this PR.
**No `action.yml` change → the `v1` float tag is not re-pointed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
