### PR TITLE
fix: three review findings — hidden leaderboard row, JS interpolation, temp-dir leak

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -200,14 +200,26 @@ runs:
     - name: Comment on PR
       if: inputs.comment-on-pr == 'true' && github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # Values reach the script through the environment, never spliced into
+        # its source. `minimum-score` is the one that matters: it is workflow-
+        # author input, so a quote in it would have closed the string literal
+        # and everything after it would have been evaluated as code. RESULT_B64
+        # and GRADE are engine output with safe charsets, moved along with it so
+        # the step has no interpolation left to audit. Same reasoning as the
+        # `env: MINIMUM` + `os.environ` pattern in "Check minimum score" above.
+        RESULT_B64: ${{ steps.score.outputs.result_b64 }}
+        GRADE: ${{ steps.score.outputs.grade }}
+        MINIMUM_SCORE: ${{ inputs.minimum-score }}
+        DANGLING_B64: ${{ steps.dangling.outputs.dangling_b64 }}
       with:
         script: |
-          const b64 = '${{ steps.score.outputs.result_b64 }}';
+          const b64 = process.env.RESULT_B64 || '';
           const result = JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
           const score = result.composite_score;
           const dims = result.dimensions;
-          const grade = '${{ steps.score.outputs.grade }}';
-          const minimum = parseFloat('${{ inputs.minimum-score }}') || 0;
+          const grade = process.env.GRADE || '';
+          const minimum = parseFloat(process.env.MINIMUM_SCORE) || 0;
           const passed = minimum === 0 || score >= minimum;
           const icon = score >= 95 ? '🟢' : score >= 75 ? '🟡' : '🔴';
 
@@ -266,7 +278,7 @@ runs:
           // db64 is EMPTY in the common case (no danglings, step skipped, or old
           // engine); a bare JSON.parse(Buffer.from('',...)) throws SyntaxError and
           // would abort this whole step, killing the score comment too. Guard it.
-          const db64 = '${{ steps.dangling.outputs.dangling_b64 }}';
+          const db64 = process.env.DANGLING_B64 || '';
           let dangling = [];
           if (db64) {
             try {

--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -14,6 +14,7 @@ cost of a single scoring run.
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 from http.server import BaseHTTPRequestHandler
@@ -123,11 +124,10 @@ def _run_scoring(content: str, filename: str) -> dict:
             "engine_version": _ENGINE_VERSION,
         }
     finally:
-        try:
-            os.unlink(skill_path)
-            os.rmdir(tmp_dir)
-        except OSError:
-            pass
+        # rmtree, not unlink+rmdir: if the file write itself failed (e.g.
+        # ENOSPC), unlink raises and rmdir never runs, leaking the mkdtemp dir
+        # on a warm instance's persistent /tmp. Same pattern as badge.py.
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 class handler(BaseHTTPRequestHandler):

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -34,7 +34,7 @@
       "clarity": 100,
       "security": 75
     },
-    "version": "2.1.0",
+    "version": "8.8.0",
     "submitted_at": "2026-03-24T15:30:00Z"
   }
 ]


### PR DESCRIPTION
Findings 1–3 from the data & feature review. 1466 tests, ruff clean, 0 markdown findings.

## 1 — The leaderboard showed only its own row

Not a filter bug, a **seed data defect**. `version` is contractually the schliff *engine*
version: `query.py` and `submit.py` both derive the scoring-model epoch from it
(`_score_model_for(body["version"])`) so v7-and-earlier composites never co-rank with v8+.
The shieldclaw row carried `2.1.0` — the *skill's* own version — which reads as major 2 →
epoch 1 → filtered out of the default view.

The single curated showcase entry has been invisible. A visitor saw a leaderboard containing
nothing but the project itself.

Corrected to the engine version that produces the row, verified against the released 8.8.0
wheel **in place** with the sibling eval suite:

| | seed | wheel |
| --- | --- | --- |
| composite | 94.6 | 94.6 |
| structure / triggers / edges / clarity | 100 | 100 |
| quality | 90 | 90 |
| efficiency | 83 | 83 |
| composability | 86 | 86 |
| security | 75 | 75 (from `scoring.security`) |

`security` is not in `score --json`'s dimensions — it is advisory and excluded from the
headline composite — but the leaderboard UI displays it, so it was checked via the scorer
directly. Both rows now resolve to epoch 2.

## 2 — `action.yml` spliced values into github-script source

`minimum-score` is workflow-author input, so a quote in it closed the string literal and
everything after was evaluated as code. Latent and not PR-reachable, but the correct pattern
was already two steps above: *Check minimum score* passes `env: MINIMUM` and reads
`os.environ`.

The comment step now does the same — `RESULT_B64`, `GRADE`, `MINIMUM_SCORE` and
`DANGLING_B64` all arrive through the environment. That last one surfaced only by extracting
the script out of the YAML and grepping it; reading the diff had missed it. The step now has
**zero interpolation left to audit**.

Verified by *executing* the script, not just parsing it: stubbed `github`/`context`, mock
env — the comment renders with the right score, grade and minimum, and the dangling path
renders both commands with their line numbers. `node --check` passes.

## 3 — `playground/api/score.py` leaked a temp dir

`os.unlink()` and `os.rmdir()` shared one `try`, so a failed write made unlink raise and
rmdir never ran. `badge.py:138` already had the fix one file over. Demonstrated both
directions: the old pattern leaves the directory behind, `shutil.rmtree(ignore_errors=True)`
removes it.

## After merge

Findings 1 and 3 are inert until deployed — `vercel --prod` for leaderboard and playground
respectively. **`action.yml` changed, so the `v1` float tag wants re-pointing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)