### PR TITLE
chore(release): v8.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.8.1] - 2026-07-29
+
 ### Fixed
 
 - **Three security patterns fired on ordinary prose.** They were found by running the
@@ -875,7 +877,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.1...HEAD
+[8.8.1]: https://github.com/Zandereins/schliff/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Zandereins/schliff/compare/v8.7.0...v8.8.0
 [8.7.0]: https://github.com/Zandereins/schliff/compare/v8.6.3...v8.7.0
 [8.6.3]: https://github.com/Zandereins/schliff/compare/v8.6.2...v8.6.3

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.1)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -33,7 +33,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.8.0
+schliff v8.8.1
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -49,7 +49,7 @@ schliff v8.8.0
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.0` (`pip install schliff==8.8.0` or `uvx schliff@8.8.0`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.1` (`pip install schliff==8.8.1` or `uvx schliff@8.8.1`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -242,7 +242,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.8.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.8.1'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -278,7 +278,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.8.0
+    rev: v8.8.1
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.8.0.**
+**Current version: 8.8.1.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.8.0"
+version = "8.8.1"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.8.0"
+__version__ = "8.8.1"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.8.0",
+    "version": "8.8.1",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {
@@ -34,7 +34,7 @@
       "clarity": 100,
       "security": 75
     },
-    "version": "8.8.0",
+    "version": "8.8.1",
     "submitted_at": "2026-03-24T15:30:00Z"
   }
 ]


### PR DESCRIPTION
Patch release carrying the four security-pattern precision fixes from #148 and #149. No feature change, no behaviour change beyond those fixes.

## Why a patch release

The shipped 8.8.0 engine emits a false security warning on **27 of 670** real community skills (measured on the frozen field corpus; the hand-adjudicated true-positive count on that corpus is **zero**). After #148 + #149 that is **6**, and of those six one is a genuinely malicious test fixture and one an openly declared red-team skill.

## Version sources

Three lockstep sources bumped, gated by `test_version_consistency`: `pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`.

Secondary refs in the same commit: README PyPI badge `&v=` cache-bust, hero example header, the reproducibility line (`pip install` + `uvx` pins), the action `schliff-version` example, the pre-commit `rev:`, `docs/README.md` current version, and both leaderboard seed entries.

## Ground truth re-verified BEFORE bumping any claim

Every number this release claims is reproducible was re-run against the post-fix engine first:

| claim | expected | measured |
| --- | --- | --- |
| README hero (`AGENTS.md`) | 95.6 / S, 1,065 tokens | **byte-identical**, per-dim 100/100/78/95/100 |
| case study, isolated | 28.7 / F | **28.7 / F** |
| case study, with eval suite | 84.5 / B | **84.5 / B** |
| case study, after fixes | 94.6 / A | **94.6 / A** |
| seed: schliff security | 100 | **100** |
| seed: shieldclaw security | 75 | **75** (`injection` 25 — a prompt-injection-defense skill legitimately contains the strings) |

No shown number moved. Only version strings did.

## Deliberately not in this PR

`playground/pyproject.toml` still pins `schliff==8.8.0`. Its bump needs the hash of the **published** wheel, so it follows as a separate change after PyPI has the release — together with `uv lock --refresh-package schliff` and the prod deploy, per the deploy runbook.

## Gates

1517 tests, 43 version-consistency assertions, ruff (pinned 0.15.8) clean, markdownlint clean.