### PR TITLE
chore(web): pin playground engine to 8.8.1

### DIFF
--- a/playground/pyproject.toml
+++ b/playground/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "app"
 version = "0.1.0"
-dependencies = [ "schliff==8.8.0" ]
+dependencies = [ "schliff==8.8.1" ]
 requires-python = "~=3.12.0"

--- a/playground/uv.lock
+++ b/playground/uv.lock
@@ -11,13 +11,13 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "schliff", specifier = "==8.8.0" }]
+requires-dist = [{ name = "schliff", specifier = "==8.8.1" }]
 
 [[package]]
 name = "schliff"
-version = "8.8.0"
+version = "8.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/e9/d201ac3e431b9538bd4073897bc350f8a624fa670817d14daf2203718cf7/schliff-8.8.0.tar.gz", hash = "sha256:eb592bdbd6cec7fbc476706c4a337f90bd2499be3d4f6567b4dae8a0f59f6a3e", size = 255570, upload-time = "2026-07-28T06:52:42.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/97/26154d2d77d402698467c3cdab483b34a388795c831252a00345efc59728/schliff-8.8.1.tar.gz", hash = "sha256:cd9a4bf444f99a2fcb315d2fc747301adfe38677c883768e3ddcf97086aed948", size = 256886, upload-time = "2026-07-29T07:57:07.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/3f/8d1aa842e55864c9b0660a6ab33a6f2c5f1f162faba01642b9e8e3217f10/schliff-8.8.0-py3-none-any.whl", hash = "sha256:e935f690613df4072d717da3f3563eff3fbad52a31d1a8c94fb1440a8060bb4f", size = 293282, upload-time = "2026-07-28T06:52:41.276Z" },
+    { url = "https://files.pythonhosted.org/packages/06/99/c02efec8f619fecb426c37f10f757a0545495d636633dcd20cde96c6e395/schliff-8.8.1-py3-none-any.whl", hash = "sha256:daa37d77aab62fb74cecc07003fc57af22a76def3be434fcb0640f5f570fd057", size = 294586, upload-time = "2026-07-29T07:57:05.726Z" },
 ]


### PR DESCRIPTION
Post-publish half of the 8.8.1 release. Bumps `playground/pyproject.toml` and regenerates `playground/uv.lock`.

The lock is the **source of truth** for Vercel's Python builder — it is consumed in preference to `requirements.txt`, and a stale one has previously shipped a ReDoS-vulnerable engine to prod. So the hashes are asserted against PyPI's published digests rather than trusted from the resolver:

| artifact | sha256 |
| --- | --- |
| `schliff-8.8.1-py3-none-any.whl` | `daa37d77aab62fb74cecc07003fc57af22a76def3be434fcb0640f5f570fd057` |
| `schliff-8.8.1.tar.gz` | `cd9a4bf444f99a2fcb315d2fc747301adfe38677c883768e3ddcf97086aed948` |

Verified: locked version 8.8.1, both hashes present, no stale `8.8.0` reference anywhere in the lock.

The leaderboard seed was already bumped in the release PR (#150). **Both surfaces stay on the old engine until a prod deploy** — the pin and seed bumps are inert on their own. Deploys follow immediately after merge, with a live-version assertion on each.