### PR TITLE
chore(release): v8.8.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.8.2] - 2026-07-29
+
 ### Fixed
 
 - **The exfil sink could be walked around by wrapping the interpreter.** 8.8.1 narrowed
@@ -928,7 +930,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.1...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.2...HEAD
+[8.8.2]: https://github.com/Zandereins/schliff/compare/v8.8.1...v8.8.2
 [8.8.1]: https://github.com/Zandereins/schliff/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Zandereins/schliff/compare/v8.7.0...v8.8.0
 [8.7.0]: https://github.com/Zandereins/schliff/compare/v8.6.3...v8.7.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.1)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.2)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -33,7 +33,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.8.1
+schliff v8.8.2
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -49,7 +49,7 @@ schliff v8.8.1
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.1` (`pip install schliff==8.8.1` or `uvx schliff@8.8.1`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.2` (`pip install schliff==8.8.2` or `uvx schliff@8.8.2`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -242,7 +242,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.8.1'` in the
+lead an older pinned install; pin it with `schliff-version: '8.8.2'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -278,7 +278,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.8.1
+    rev: v8.8.2
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.8.1.**
+**Current version: 8.8.2.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.8.1"
+version = "8.8.2"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.8.1"
+__version__ = "8.8.2"

--- a/web/leaderboard/data/submissions.json
+++ b/web/leaderboard/data/submissions.json
@@ -15,7 +15,7 @@
       "clarity": 100,
       "security": 100
     },
-    "version": "8.8.1",
+    "version": "8.8.2",
     "submitted_at": "2026-03-25T10:00:00Z"
   },
   {
@@ -34,7 +34,7 @@
       "clarity": 100,
       "security": 75
     },
-    "version": "8.8.1",
+    "version": "8.8.2",
     "submitted_at": "2026-03-24T15:30:00Z"
   }
 ]


### PR DESCRIPTION
Patch release carrying #152 and #153. **This one closes a regression 8.8.1 introduced itself.**

## Why this is more urgent than 8.8.1 was

8.8.1 narrowed the exfil sink to executing consumers — but required the interpreter **flush against the pipe**. Verified against the 8.8.0 source read from the tag:

| shape | 8.8.0 | 8.8.1 (shipped now) | main |
| --- | --- | --- | --- |
| `curl … \| sudo bash` | caught | **missed** | caught |
| `curl … \| /bin/bash` | caught | **missed** | caught |
| `curl … \| iex` · `\| php` | caught | **missed** | caught |

8.8.0 caught them incidentally, via the bare-pipe sink that also produced all the noise. That does not change the outcome: **the version currently on PyPI detects this class worse than its predecessor.** 8.8.1 was a comfort fix; this is a correctness fix.

## Enumerated, not guessed

The second round differenced **all 164 verb × sink combinations** against the 8.8.0 pattern and kept only the genuine losses — which also separated real evasions from intended narrowing. Every remaining difference versus 8.8.0 is now either caught, or deliberately benign (`| jq`, `| grep`, `| less`, `| column -t`, `| head`).

## Ground truth re-verified before bumping any claim

| claim | expected | measured |
| --- | --- | --- |
| README hero | 95.6 / S, 1,065 tokens | **byte-identical** |
| case study, isolated | 28.7 / F | **28.7 / F** |
| case study, with eval suite | 84.5 / B | **84.5 / B** |
| case study, after | 94.6 / A | **94.6 / A** |
| seed security: schliff / shieldclaw | 100 / 75 | **100 / 75** |

No shown number moved. Only version strings did.

Corpus gate held through both widenings: stock counts byte-identical at 44, every category ±0. ReDoS re-verified linear after each.

## Not in this PR

`playground/pyproject.toml` stays at 8.8.1 — its pin needs the hash of the published wheel and follows post-publish with `uv lock --refresh-package schliff` and the prod deploys.

1540 tests, 43 version-consistency assertions, ruff clean, markdownlint clean.