### PR TITLE
fix(skill): make the agent-facing card executable, and doctor take a dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,7 +191,11 @@ jobs:
           COMPOSITE=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['composite_score'])")
           echo "Composite score: $COMPOSITE"
           echo "composite_score=$COMPOSITE" >> "$GITHUB_OUTPUT"
-          python3 -c "import sys; assert float(sys.argv[1]) >= 90, f'Score {sys.argv[1]} below threshold'" "$COMPOSITE"
+          # Same floor, and the same reasoning, as scripts/test-self.sh — keep the
+          # two in step. The previous 90 was only ever met by a circular
+          # measurement: the eval suite beside this card had been extracted from
+          # the card, so it scored it 100%.
+          python3 -c "import sys; assert float(sys.argv[1]) >= 85, f'Score {sys.argv[1]} below threshold'" "$COMPOSITE"
 
       - name: Run eval suite
         working-directory: skills/schliff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The bundled eval suite measured its own source, so it measured nothing.** All 108
+  `contains` assertions in `skills/schliff/eval-suite.json` appear verbatim in the
+  241-line card the suite was generated from; only 54 of them appear in the prompt they
+  were filed under. A suite extracted from an artifact scores that artifact 100% by
+  construction — which is exactly what it did, reporting 119/119 and a composite of
+  98.9 for a card that a real agent scored 0 of 8 on.
+
+  The 44 trigger prompts and 14 edge cases are unchanged. The test cases are re-derived
+  from their prompts and from the public CLI surface: 4 cases, 13 assertions, each one
+  answering "what would a card need to contain for an agent to do what this prompt
+  asks". Against this card they pass 13/13; against a minimal placeholder card, 1/13 —
+  so they discriminate rather than describe.
+
+  Test cases whose prompts asked for things that do not exist were dropped rather than
+  satisfied: there is no `discovery mode` and no `high-ROI` ranking (zero occurrences
+  in `scripts/`), and no custom-metric interface. The 241-line card and its original
+  suite are kept intact as frozen fixtures under
+  `skills/schliff/tests/fixtures/self-skill-baseline/`.
+
+- **Loop documentation now lives with the loop.** Ten of the suite's test cases probed
+  the autonomous improvement loop but asserted against `SKILL.md`, forcing the
+  agent-facing card to carry the vocabulary of a subsystem reachable only through the
+  `/schliff:*` plugin commands. That coverage moved to
+  `tests/unit/test_command_docs_document_the_loop.py`, which gates the command docs
+  that actually own the behaviour.
+
+- **Self-test floors measure the property instead of a proxy.** `test-self.sh`'s
+  composite floor drops 90 → 85 (matching the same assert in `test.yml`, which was
+  skipped rather than passing on the red run), because the 90 was only ever met by the
+  circular measurement above. The `>= 100 lines` guard is replaced by `structure >= 90`:
+  it was rejecting a deliberate 99-line trim while accepting padding. Measured on this
+  card and two degradations — full 95, worked examples stripped 85, gutted to bare
+  commands 75 — so the replacement catches both losses the line count caught.
+
+### Fixed
+
+- **`/schliff:auto` documented a flag that does not exist and a state file it does not
+  write.** `commands/schliff/auto.md` listed `--resume`, which `auto-improve.py` rejects
+  with `unrecognized arguments` and exit 2 — the same defect class as the `doctor <dir>`
+  fix above it. It attributed the loop's history to `.schliff/history.jsonl`, which
+  belongs to `verify --history`; the loop writes `.schliff/auto-improve-state.jsonl`.
+  Its invocation assumed a working directory of `skills/schliff`.
+
+  It also implied parallel worktree experimentation. `auto-improve.py` detects the stuck
+  condition and prints `Triggering parallel branching…`, then continues in-process — no
+  branch, no worktree. The doc now says so, and a test asserts it keeps saying so.
+
+  Added, all verified by running the driver first: the cross-session episode store
+  (`~/.schliff/meta/episodes.jsonl`, recalled before iterating and written after), the
+  per-iteration record shape, the undocumented three-consecutive-errors stop, and the
+  real output format.
+
 ## [8.8.2] - 2026-07-29
 
 ### Fixed

--- a/commands/schliff/auto.md
+++ b/commands/schliff/auto.md
@@ -22,25 +22,27 @@ Run the autonomous, script-driven improvement loop on a skill.
 
    If eval suite is missing: "Run `/schliff:init <path>` first to generate an eval suite."
 
-3. Run the autonomous improvement loop:
+3. Run the autonomous improvement loop. The driver is not on the `uvx` command
+   surface — it ships as a script inside this plugin directory, so give its path
+   from the schliff checkout root. The script resolves its own imports, so any
+   working directory is fine:
 
    ```bash
-   python3 scripts/auto-improve.py /path/to/SKILL.md --json
+   python3 skills/schliff/scripts/auto-improve.py /path/to/SKILL.md --json
    ```
 
-4. Monitor output and present progress as it runs:
+4. Monitor output and present progress as it runs. With `--verbose` the driver
+   prints one line per iteration and a summary block at the end — report what it
+   actually emitted, do not reformat it into invented numbers:
 
    ```
-   === Schliff Auto-Improve ===
-   Skill: [name]
+   Iter  1:  ██████░░░░░░░░░░░░░░  29.3/100  [-0.7]  ✗ discard (composability)
 
-   Iteration 1: 72 → 75 (+3) ✓ KEEP
-   Iteration 2: 75 → 74 (-1) ✗ REVERT
-   Iteration 3: 75 → 78 (+3) ✓ KEEP
-   ...
-   Stopped: Plateau detected (EMA ROI < 0.1)
-
-   Final: 72 → 82 (+10 points in 8 iterations)
+     Schliff Auto-Improve Complete
+     ──────────────────────────────────────────────────
+     Score:  29 → 29/100  ██████░░░░░░░░░░░░░░  (+0.0)  [F]
+     Iters:  3  |  Kept: 0  |  Time: 0s
+     Stop:   max_iterations
    ```
 
 5. After completion, show the summary from the JSON output.
@@ -49,21 +51,49 @@ Run the autonomous, script-driven improvement loop on a skill.
 
 - `--max-iterations N`: Maximum number of improvement iterations (default: 30)
 - `--dry-run`: Show what would be changed without modifying files
-- `--resume`: Resume a previously interrupted auto-improve session
+- `--json`: Emit the run summary as JSON
+- `--verbose` / `-v`: Print each iteration to stderr as it happens
+
+There is no resume flag. Re-running on the same skill appends to the state file
+below rather than truncating it, and iteration numbers continue upward from the
+last recorded run — so an interrupted session's iterations stay readable, but a
+second run is a second run, not a continuation of the first one's decisions.
 
 ## Stopping Conditions
 
 The loop stops automatically when:
 
 - Composite score reaches 98+
-- All dimensions reach 90+
-- EMA-based ROI drops below 0.1 for 5 consecutive iterations
+- Every measured dimension reaches 90+ (dimensions reported as `-1` are unmeasured
+  and do not count)
+- EMA-based ROI stays below 0.1 across the last 5 keep/discard iterations
+- Three consecutive iterations error — the file is treated as not patchable
 - Maximum iterations reached
+
+## Where the run is recorded
+
+- `<skill-dir>/.schliff/auto-improve-state.jsonl` — one line per iteration:
+  `iteration`, `status` (`baseline` / `keep` / `discard` / `error`), `composite`,
+  `dimensions`, `delta`, `patch_applied`, `timestamp`. This is the loop's own
+  state file. It is not the same file as `verify --history`, which defaults to
+  `.schliff/history.jsonl` and records gate results, not iterations.
+- `~/.schliff/meta/episodes.jsonl` — cross-session memory. Before iterating, the
+  loop recalls the top 3 past episodes for this skill; after a run it stores the
+  outcome. This is what makes a second session on the same skill start informed
+  rather than cold.
+
+## Sequential only
+
+When the loop detects it is stuck — 5+ consecutive discards, or a gap to target
+above 15 points — it reports the condition and **keeps going sequentially**. It
+does not branch, and it creates no git worktrees. If you see
+`Triggering parallel branching…` in the output, that is the trigger firing, not
+work being distributed. Do not promise the user parallel candidate branches here.
 
 ## Notes
 
 - Each iteration makes ONE atomic change, scores, and keeps or reverts
-- Score history is tracked in `.schliff/history.jsonl`; file changes are NOT auto-committed to git — commit yourself to preserve them
+- File changes are NOT auto-committed to git — commit yourself to preserve them
 - Deterministic patches (frontmatter fixes, TODO cleanup) are applied directly
 - Non-deterministic improvements may invoke Claude for generation
 - Use `--dry-run` to preview without modifying files

--- a/skills/schliff/SKILL.md
+++ b/skills/schliff/SKILL.md
@@ -1,241 +1,99 @@
 ---
 name: schliff
 description: >
-  Deterministic skill linter and scoring engine for Claude Code — the Ruff for
-  SKILL.md files. 7-dimension structural scoring (structure, triggers, quality,
-  edges, efficiency, composability, clarity) with anti-gaming detection, ~32%
-  rule-based patches, and cross-session episodic memory. An autoresearch loop
-  that measures first, then fixes — not the other way around. Use for linting,
-  scoring, and autonomously improving any Claude Code skill: trigger accuracy,
-  output quality, edge coverage, token efficiency, composability, or custom
-  metrics. Works with community, custom, project-local, or global skills.
-  Trigger phrases: "make this skill better", "optimize my skill", "iterate on
-  this skill overnight", "improve [metric] from X to Y", "audit skill",
-  "review my skill", "harden skill", "benchmark skill", "lint my skill",
-  "score my skill", or paste SKILL.md for auto-analysis. Also use when user
-  shares skill without explicit instructions. Do NOT use for brand-new skills
-  from scratch — use skill-creator first, then come to Schliff. Do NOT use for
-  SQL query tuning. Do NOT use for prompt template authoring.
+  Deterministic linter and scorer for instruction files — SKILL.md, AGENTS.md,
+  CLAUDE.md. No model in the loop: the same bytes score the same everywhere.
+  Use for linting, scoring, auditing or CI-gating an instruction file, and for
+  checking whether the commands a file promises actually resolve in the repo.
+  Trigger phrases: "lint my skill", "score my skill", "audit skill",
+  "review my skill", "harden skill", "make this skill better",
+  "optimize my skill", "improve [metric] from X to Y", "benchmark skill",
+  "check my AGENTS.md", "is my AGENTS.md lying", or paste a SKILL.md for
+  auto-analysis. Also use when a user shares an instruction file without
+  explicit instructions. Do NOT use for authoring a file from scratch — use a
+  skill-creator first, then schliff. Do NOT use for application-code linting,
+  SQL tuning, or runtime behaviour testing.
 ---
 
-# Schliff — Skill Measurement & Iteration Framework
+# schliff — deterministic instruction-file linter
 
-Constraint + clear metric + disciplined iteration = compounding gains. The composite score measures structural quality (file organization, keyword coverage, eval suite breadth) — not runtime effectiveness. Use `--runtime` to validate actual behavior.
+Zero install, no API key, no model in the loop — the same bytes score the same
+everywhere.
 
-## Quick Start (Only 2 Inputs Required)
+## Commands
 
-```bash
-/schliff
-Target: path/to/SKILL.md
-Goal: Make the skill trigger correctly for deployment scenarios
+These run anywhere `uv` is available: no plugin, no checkout. Add `--json` to any
+of them for machine-readable output.
+
+- `uvx schliff score <file>` — score one instruction file, per-dimension breakdown
+- `uvx schliff doctor --skill-dirs <dir>` — grade every skill in a directory
+- `uvx schliff verify <file> --min-score 75` — CI gate; exits 1 below the threshold
+- `uvx schliff check-commands <file> --repo <dir>` — do the file's commands resolve?
+- `uvx schliff suggest <file>` — ranked fixes with estimated score impact
+- `uvx schliff badge <file>` — markdown score badge
+- `uvx schliff compare <a> <b>` — two files side by side
+- `uvx schliff demo` — score a built-in bad skill to see the output shape
+
+Pin the version in CI: `uvx schliff@8.8.2 verify <file> --min-score 75`.
+
+## Examples
+
+Example 1 — score a skill:
+
+```
+$ uvx schliff score SKILL.md
+  structure      85/100    triggers   95/100    quality  92/100
+  Structural Score  84.5/100  [B]        Tokens: 1,031 / 1,000 (over)
 ```
 
-Defaults: Metric=composite_score, Verify=score-skill.py, Iterations=30.
+Grades run S · A · B · C · D · E · F. `4/7 dims` in the readout means no eval
+suite was found beside the file, so only the deterministic dimensions could be
+measured and the score is capped — a coverage statement, not a quality verdict.
+`verify` scales its threshold by that same coverage, so a missing eval suite
+never fails CI on its own.
 
-## Core Loop (NEVER Pauses)
+Example 2 — is the file telling the truth?
 
 ```
-INPUT: Skill path + GOAL + PRIMARY METRIC + VERIFY method + time budget
-SETUP: Read ALL files → Analyze → Generate eval suite → Baseline (#0)
-LOOP (N iterations, continues until goal met or budget exhausted):
-  Exp N: Review skill + results + git history
-  → Pick ONE atomic change (based on gaps + history)
-  → Edit SKILL.md or references
-  → Commit: "schliff exp-N: [description]"
-  → Run VERIFY, compute PRIMARY METRIC
-  → Improved? Keep. Worse? Revert. Error? Fix or skip.
-  → Append to history/ with diffs
-  CONSTRAINT: Fixed iterations prevent infinite loops; autonomous mode =
-  NO prompts between iterations, just continuous improvement.
+$ uvx schliff check-commands AGENTS.md --repo .
+  resolved   'make test'      make target 'test' defined in Makefile
+  dangling   'npm run lint'   package.json has no script 'lint'
 ```
 
-## When to Use
+`dangling` is claimed only when absence is provable; anything unresolvable is
+reported `unknown`, never as a defect.
 
-- **Skill not triggering** → Run `/schliff` on trigger-accuracy metric
-- **Wrong/incomplete outputs** → Set goal, metric = binary eval pass rate
-- **Harden for edge cases** → Focus on edge-coverage metric
-- **Skill too verbose** → Optimize token-efficiency metric
-- **Don't know what's wrong** → Run `/schliff:analyze` for auto-discovery
-- **Any custom goal** → Define GOAL, pick/create METRIC, set VERIFY command
+## Workflow
 
-Do NOT use for creating new skills from scratch — use skill-creator first. Do NOT use for SQL query tuning or prompt template authoring.
+1. `uvx schliff doctor --skill-dirs <dir>` — find the worst file.
+2. `uvx schliff suggest <file>` — see the ranked fixes and their impact.
+3. Apply them, then `uvx schliff score <file>` to confirm the delta.
+4. Gate it: `uvx schliff verify <file> --min-score 75` in CI.
 
-## Interface: GOAL + METRIC + VERIFY
+## If the schliff plugin is installed
 
-```bash
-/schliff
-Target: .claude/skills/my-skill/SKILL.md
-Goal: Fix skill to handle deployment scenarios correctly
-Metric: Binary eval pass rate %
-Verify: bash scripts/run-eval.sh
-Time budget: 2 hours
-Iterations: 30
-```
+Only inside a Claude Code plugin install — unavailable on the `uvx` path above:
+`/schliff:analyze` · `/schliff:doctor` · `/schliff:init` · `/schliff:bench` ·
+`/schliff:eval` · `/schliff:report` · `/schliff:mesh` · `/schliff:triage` ·
+`/schliff:auto`
 
-**Regression guards** — prevent one dimension from regressing while improving another:
+## Contract
 
-```bash
-/schliff
-Target: .claude/skills/deploy/SKILL.md
-Goal: Maximize trigger accuracy
-Metric: Trigger pass rate
-Verify: python3 scripts/score-skill.py SKILL.md --json
-Constraint: efficiency >= 80, composability >= 90
-```
+Expects one instruction-file path, or `--skill-dirs <dir>` for `doctor`. Produces
+per-dimension scores, a composite grade, and a gate-usable exit code. Errors go
+to stderr as one line with a non-zero exit.
 
-## Quality Dimensions (Configurable via `--weights`)
+## Scope
 
-| Dimension | Metric | How | Limitation |
-|-----------|--------|-----|------------|
-| **Structure** | Frontmatter lint score | `score-skill.py` | File quality, not instruction correctness |
-| **Trigger accuracy** | Keyword overlap | TF-IDF heuristic | Does not predict actual triggering |
-| **Output quality** | Eval assertion breadth | Test cases | Does not verify runtime output |
-| **Edge coverage** | Edge-case definitions | Edge test suite | Does not verify runtime handling |
-| **Token efficiency** | Signal/noise density | `score-skill.py` | Cannot assess content usefulness |
-| **Composability** | Scope boundaries | Static analysis | Cannot verify multi-skill interaction |
-| **Clarity** *(default)* | Contradiction + ambiguity | `score-skill.py` (`--no-clarity` to opt out) | Pattern-based, not semantic |
+Use when measuring or gating the quality or honesty of an instruction file.
+Do not use for authoring from scratch, application-code linting, or runtime
+behaviour testing. schliff measures — it does not write.
 
-See `references/metrics-catalog.md` for rubrics.
+## Handoffs
 
-## Custom Metrics
-
-Define any metric via a shell command returning a number:
-
-```bash
-Metric: "Time to first correct output (ms)"
-Verify: time bash scripts/run-eval.sh | grep "passed"
-```
-
-Validate custom metrics by running once before the loop, for example by checking the return code.
-
-## Subcommands
-
-| Command | Purpose |
-|---------|---------|
-| `/schliff:init` | Bootstrap eval-suite + baseline |
-| `/schliff` | Autonomous loop with GOAL + METRIC |
-| `/schliff:auto` | Self-driving auto-improve: deterministic patches in a loop |
-| `/schliff:analyze` | Skill analysis, gaps, anti-patterns, baseline |
-| `/schliff:bench` | Single evaluation run, current score |
-| `/schliff:eval` | Run eval suite, show results |
-| `/schliff:report` | Generate improvement summary + diffs |
-| `/schliff:mesh` | Scan skills for trigger overlap, broken handoffs, scope collisions |
-| `/schliff:triage` | Cluster logged failures, auto-generate fixes |
-| `/schliff:log-failure` | Log a skill failure for later triage |
-
-## Before the Loop (Setup Phase)
-
-1. Read ALL files — SKILL.md + references + related skills.
-2. Parse GOAL + METRIC + VERIFY from input. Use defaults if unspecified.
-3. Run baseline — Execute VERIFY, record initial metric as exp #0.
-4. Generate eval suite if none exists. Use SKILL.md examples as seeds.
-5. Validate eval suite — Run once, verify assertions parse correctly.
-6. Show gap analysis with estimated iterations. Start NEVER-PAUSE mode on confirm.
-
-## Autonomous Loop (Eight-Phase Protocol)
-
-Per `references/improvement-protocol.md`. Immutable rules:
-
-1. ONE change per experiment. Run `git diff` to verify scope, because atomic edits isolate causation.
-2. Run VERIFY, check number, keep or discard. This prevents subjective drift.
-3. Revert on regression: `git revert HEAD`. This ensures safe experimentation.
-4. Re-read ALL files before each change. This prevents contradictions.
-5. Descriptive commits: `schliff exp-7: add deployment edge cases`.
-6. Stuck (5+ discards): re-read files, review history, try the opposite. This avoids local optima.
-7. Never modify VERIFY during loop. Metric is fixed; skill is the variable.
-8. Log everything to `history/` — diffs, metrics, keep/discard status.
-9. **Plateau guard:** Every 5 iterations, compare composite against 5-back. Delta < 1.0 → switch strategy or stop.
-
-## Cross-Session Learning
-
-Read `history/results.jsonl` at loop start. Parse keep/discard per strategy, compute success rates, prioritize high-ROI strategies. < 1 point over 5 iterations triggers stop suggestion. Visualize with `scripts/progress.py`.
-
-## Multi-File Skills
-
-Read full skill tree before each change. Extract sections to `references/` when SKILL.md exceeds 400 lines. Verify cross-file references after each edit. For agents: treat system prompt as SKILL.md, tool definitions as references.
-
-## Discovery Mode (Auto-Gap Analysis)
-
-Run `/schliff:analyze` without a GOAL:
-
-1. Run all 7 dimension scorers.
-2. Identify weakest dimension and failure patterns.
-3. Cluster eval failures for systemic issues (e.g., "all false negatives share short prompts").
-4. Propose ranked improvements with estimated iteration cost.
-5. Suggest GOAL + METRIC + VERIFY. User confirms or overrides.
-
-Use when user says "my skill needs work" without specifying what, e.g., `/schliff:analyze path/to/SKILL.md`.
-
-## Parallel Experimentation
-
-Create 3 candidates on separate `git worktree` branches, run VERIFY on all, keep highest improvement. Use when stuck (5+ discards) or gap > 15 points. Fallback to sequential if worktree unavailable.
-
-## Noisy Metrics
-
-When metrics fluctuate (>5%): run VERIFY 3x, use median, keep only if improvement > 2x noise floor. Revert to best checkpoint if composite dropped > 2 points despite individual keeps.
-
-## Cost Tracking
-
-`run-eval.sh --log` records duration, tokens, delta, status per run. ROI = `delta / iterations_spent`. Stop when last 5 iterations gained < 0.5 points. Cross-session ROI via `progress.py --json`.
-
-## Self-Evolving Eval Suites
-
-Every 10 iterations: classify tests as mastered/blocked/flaky via `classify_eval_health()`. Reduce mastered test weight. Log mutations to `history/`. Run eval evolution BETWEEN sessions (preserves Rule 7).
-
-## Improvement Strategies (Dynamic)
-
-Select based on gap analysis. Pick first dimension with gap > 10 points:
-
-1. Fix structural issues — Run `python3 scripts/score-skill.py SKILL.md --json`.
-2. Expand triggers — Add synonyms, edge cases, negative boundaries.
-3. Add input/output examples — Write 3+ concrete before/after pairs.
-4. Add edge-case handling — Test with malformed input, missing context, empty files.
-5. Optimize density — Remove redundancy, compress verbose phrasing.
-6. Extract references — Move deep content to `references/`.
-7. Verify composability — Check handoff points, run with adjacent skills.
-
-See `references/metrics-catalog.md` for patterns per dimension.
-
-## Example Session
-
-```bash
-Goal: Trigger accuracy from 60% to 90%
-Verify: bash scripts/run-eval.sh | grep "PASS" | wc -l
-
-Exp 1: Add synonyms to description → 65% → Keep
-Exp 2: Add negative trigger examples → 70% → Keep
-Exp 3: Compress verbose setup section → 68% → Discard (revert)
-Exp 4: Add edge case for partial audit → 75% → Keep
-```
-
-Parse `history/results.jsonl` between sessions. Compare keep rates to prioritize high-ROI changes next session.
-
-## Lineage
-
-`/skill-creator` → v1 → `/schliff` → autonomous grinding → merge. Roll back via `git log --oneline history/`. For crashing skills: use `systematic-debugging` instead, then return to Schliff.
-
-## Requirements
-
-Requires Python >= 3.9, Git >= 2.0, jq >= 1.6, Bash >= 4.0. Standard library only. All `/schliff:*` commands are namespaced. Deterministic scorer, safe to re-run. If scoring fails, returns structured error.
-
-## Files
-
-Run `ls -R` in skill directory. Run `python3 scripts/score-skill.py SKILL.md --json` for scores. Key files:
-
-- `scripts/init-skill.py` — Bootstrap eval-suite (`--json --dry-run`)
-- `scripts/generate-report.py` — Shareable improvement report
-- `scripts/score-skill.py` — Dimension scores incl. runtime (`--diff --clarity --weights`)
-- `scripts/text-gradient.py` — Invert scorer issues into fix list (`--json --top N --apply --dry-run`)
-- `scripts/auto-improve.py` — Autonomous loop (`--max-iterations N --dry-run --resume`)
-- `scripts/skill-mesh.py` — Multi-skill conflict detection (`--incremental`)
-- `scripts/meta-report.py` — Strategy predictor + auto-calibration
-- `scripts/episodic-store.py` — Cross-session memory (`--store --recall --synthesize`)
-- `scripts/parallel-runner.py` — Worktree parallel experimentation (`--strategies --auto`)
-- `scripts/runtime-evaluator.py` — Invoke Claude with test prompts, check output
-- `scripts/analyze-skill.sh` — Legacy linter (score-skill.py has this built-in)
-- `scripts/run-eval.sh` — Run eval suite (`--runtime` auto-enabled if claude CLI available)
-- `scripts/progress.py` — Convergence charts + strategy analysis (`--emit-meta`)
-- `hooks/session-injector.js` — SessionStart hook: surfaces untriaged failures
-- `references/improvement-protocol.md` — Full 9-phase loop spec
-- `references/metrics-catalog.md` — Scoring rubrics + custom metrics
-- `templates/eval-suite-template.json` — Eval skeleton for new skills
+- No file to score yet → instead use a skill-creator skill to author one, then
+  come back to schliff to measure it.
+- Score plateaus after the suggested fixes → then use a skill-authoring or
+  writing skill; the remaining gap is content, not structure.
+- `check-commands` reports `dangling` → fix the file or the repo, re-run it.
+- Any non-zero exit → report the stderr line verbatim; it names the cause.

--- a/skills/schliff/eval-suite.json
+++ b/skills/schliff/eval-suite.json
@@ -328,8 +328,8 @@
           "description": "'tell me what's wrong with it' is answered by the ranked-fix command, not by the score alone"
         },
         {
-          "type": "pattern",
-          "value": "(?i)dimension",
+          "type": "contains",
+          "value": "dimension",
           "description": "schliff's answer to 'what is wrong' is per-dimension, so the card must say the readout is dimensional"
         },
         {
@@ -395,7 +395,7 @@
         },
         {
           "type": "pattern",
-          "value": "(?i)(apply|fix)",
+          "value": "[Aa]pply|[Ff]ix",
           "description": "The prompt asks to run an iteration, not just to read one — the card must say a change gets applied"
         },
         {
@@ -445,8 +445,8 @@
           "description": "'Benchmark my skill at <path>' — the card must name the command that scores a file"
         },
         {
-          "type": "pattern",
-          "value": "(?i)dimension",
+          "type": "contains",
+          "value": "dimension",
           "description": "The prompt asks for all six dimensions, so the card must present scores as per-dimension"
         },
         {
@@ -502,7 +502,7 @@
         },
         {
           "type": "pattern",
-          "value": "(?i)(rank|impact|priorit|first)",
+          "value": "[Rr]ank|[Ii]mpact|[Pp]riorit|[Ff]irst",
           "description": "'first' asks for an ordering — the card must say the fixes come ordered, by impact"
         }
       ]

--- a/skills/schliff/eval-suite.json
+++ b/skills/schliff/eval-suite.json
@@ -316,27 +316,26 @@
     {
       "id": "tc-1",
       "prompt": "Analyze my skill at .claude/skills/deploy/SKILL.md and tell me what's wrong with it",
-      "input_files": [],
       "assertions": [
         {
           "type": "contains",
-          "value": "structure",
-          "description": "Report includes structure dimension"
+          "value": "score",
+          "description": "Prompt points at one file and asks for analysis — the card must name the command that scores a single file"
         },
         {
           "type": "contains",
-          "value": "trigger",
-          "description": "Report includes trigger analysis"
+          "value": "suggest",
+          "description": "'tell me what's wrong with it' is answered by the ranked-fix command, not by the score alone"
         },
         {
-          "type": "contains",
-          "value": "score-skill.py",
-          "description": "SKILL.md references the scoring script"
+          "type": "pattern",
+          "value": "(?i)dimension",
+          "description": "schliff's answer to 'what is wrong' is per-dimension, so the card must say the readout is dimensional"
         },
         {
           "type": "excludes",
           "value": "TODO",
-          "description": "No placeholder text in output"
+          "description": "A card shipped with placeholder text cannot be followed"
         },
         {
           "type": "response_excludes",
@@ -378,22 +377,26 @@
     {
       "id": "tc-2",
       "prompt": "Run one improvement iteration on my skill — focus on trigger accuracy",
-      "input_files": [],
       "assertions": [
         {
           "type": "contains",
-          "value": "description",
-          "description": "Mentions modifying the description"
+          "value": "triggers",
+          "description": "Prompt names trigger accuracy as the target — it must be a nameable, measurable dimension"
         },
         {
           "type": "contains",
-          "value": "commit",
-          "description": "Makes a git commit"
+          "value": "suggest",
+          "description": "One iteration needs a change to apply; the card must name where the proposal comes from"
+        },
+        {
+          "type": "contains",
+          "value": "score",
+          "description": "An iteration is measure -> change -> measure; the card must name the re-measure step"
         },
         {
           "type": "pattern",
-          "value": "(keep|discard|revert)",
-          "description": "Makes a keep/discard/revert decision"
+          "value": "(?i)(apply|fix)",
+          "description": "The prompt asks to run an iteration, not just to read one — the card must say a change gets applied"
         },
         {
           "type": "response_excludes",
@@ -435,32 +438,21 @@
     {
       "id": "tc-3",
       "prompt": "Benchmark my skill at skills/testing/SKILL.md and show me scores for all six dimensions",
-      "input_files": [],
       "assertions": [
         {
           "type": "contains",
-          "value": "structure",
-          "description": "Reports structure score"
-        },
-        {
-          "type": "contains",
-          "value": "trigger",
-          "description": "Reports trigger accuracy score"
-        },
-        {
-          "type": "contains",
-          "value": "token",
-          "description": "Reports token efficiency"
+          "value": "score",
+          "description": "'Benchmark my skill at <path>' — the card must name the command that scores a file"
         },
         {
           "type": "pattern",
-          "value": "\\d+",
-          "description": "Contains numeric scores"
+          "value": "(?i)dimension",
+          "description": "The prompt asks for all six dimensions, so the card must present scores as per-dimension"
         },
         {
-          "type": "contains",
-          "value": "composability",
-          "description": "SKILL.md covers composability dimension"
+          "type": "pattern",
+          "value": "[0-9]+/100",
+          "description": "'show me scores' — the card must show the shape of a score, not only claim it produces one"
         },
         {
           "type": "response_excludes",
@@ -501,294 +493,18 @@
     },
     {
       "id": "tc-4",
-      "prompt": "Run the eval suite for my deploy skill and tell me which tests pass and which fail",
-      "input_files": [],
-      "assertions": [
-        {
-          "type": "contains",
-          "value": "run-eval.sh",
-          "description": "SKILL.md references the eval runner"
-        },
-        {
-          "type": "contains",
-          "value": "assertion",
-          "description": "SKILL.md mentions assertions"
-        },
-        {
-          "type": "response_excludes",
-          "value": "I cannot",
-          "description": "Runtime: does not refuse the task"
-        },
-        {
-          "type": "response_excludes",
-          "value": "I don't know",
-          "description": "Runtime: does not claim ignorance"
-        },
-        {
-          "type": "response_excludes",
-          "value": "I'm sorry",
-          "description": "Runtime: does not apologize instead of acting"
-        },
-        {
-          "type": "response_excludes",
-          "value": "not possible",
-          "description": "Runtime: does not claim impossibility"
-        },
-        {
-          "type": "response_excludes",
-          "value": "outside my",
-          "description": "Runtime: does not claim out of scope"
-        },
-        {
-          "type": "response_excludes",
-          "value": "I'm unable",
-          "description": "Runtime: does not claim inability"
-        },
-        {
-          "type": "response_excludes",
-          "value": "Traceback",
-          "description": "Runtime: no Python stack trace in output"
-        }
-      ]
-    },
-    {
-      "id": "tc-5",
-      "prompt": "Generate an improvement report for the last 10 experiments on my skill",
-      "input_files": [],
-      "assertions": [
-        {
-          "type": "pattern",
-          "value": "exp[- ]?\\d+",
-          "description": "References experiment numbers"
-        },
-        {
-          "type": "pattern",
-          "value": "(?i)(keep|discard|revert)",
-          "description": "Shows experiment outcomes"
-        },
-        {
-          "type": "contains",
-          "value": "baseline",
-          "description": "References the baseline measurement"
-        },
-        {
-          "type": "pattern",
-          "value": "\\d+%|\\d+/\\d+",
-          "description": "Includes metric values"
-        }
-      ]
-    },
-    {
-      "id": "tc-6",
-      "prompt": "Set up schliff on my skill: goal is 90% eval pass rate, verify with bash scripts/run-eval.sh, run 20 iterations",
-      "input_files": [],
-      "assertions": [
-        {
-          "type": "contains",
-          "value": "baseline",
-          "description": "Establishes baseline before iterating"
-        },
-        {
-          "type": "pattern",
-          "value": "exp[- ]?0|#0",
-          "description": "Records experiment zero"
-        },
-        {
-          "type": "pattern",
-          "value": "90%|90 ?%",
-          "description": "Acknowledges the 90% target"
-        },
-        {
-          "type": "contains",
-          "value": "iteration",
-          "description": "Mentions iterations"
-        }
-      ]
-    },
-    {
-      "id": "tc-7",
       "prompt": "My skill has a SKILL.md with no frontmatter, no examples, and no trigger phrases. Analyze it and tell me what to fix first.",
-      "input_files": [],
       "assertions": [
         {
-          "type": "pattern",
-          "value": "(?i)frontmatter",
-          "description": "Flags missing frontmatter"
+          "type": "contains",
+          "value": "suggest",
+          "description": "'tell me what to fix first' is exactly the ranked-fix command"
         },
         {
           "type": "pattern",
-          "value": "(?i)(example|trigger)",
-          "description": "Flags missing examples or triggers"
-        },
-        {
-          "type": "pattern",
-          "value": "(?i)(priority|first|critical|start)",
-          "description": "Provides prioritized recommendations"
+          "value": "(?i)(rank|impact|priorit|first)",
+          "description": "'first' asks for an ordering — the card must say the fixes come ordered, by impact"
         }
-      ]
-    },
-    {
-      "id": "tc-8",
-      "prompt": "My skill is stuck after 5 discards. Use parallel experimentation with worktree branches and keep the highest candidate.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "worktree", "description": "SKILL.md covers worktree parallel experimentation"},
-        {"type": "contains", "value": "branches", "description": "SKILL.md mentions branches for parallel runs"},
-        {"type": "contains", "value": "candidates", "description": "SKILL.md uses candidate terminology"},
-        {"type": "contains", "value": "highest", "description": "SKILL.md selects highest improvement"},
-        {"type": "contains", "value": "sequential", "description": "SKILL.md mentions sequential fallback"},
-        {"type": "contains", "value": "stuck", "description": "SKILL.md handles stuck state"},
-        {"type": "contains", "value": "separate", "description": "SKILL.md uses separate branches"},
-        {"type": "contains", "value": "Fallback", "description": "SKILL.md falls back to sequential when unavailable"}
-      ]
-    },
-    {
-      "id": "tc-9",
-      "prompt": "Use cross-session learning from history to prioritize strategies that succeeded before.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "session", "description": "SKILL.md covers cross-session learning"},
-        {"type": "contains", "value": "history", "description": "SKILL.md reads history for learning"},
-        {"type": "contains", "value": "results.jsonl", "description": "SKILL.md references results.jsonl file"},
-        {"type": "contains", "value": "success", "description": "SKILL.md tracks success rates"},
-        {"type": "contains", "value": "strategy", "description": "SKILL.md prioritizes strategies"},
-        {"type": "contains", "value": "parse", "description": "SKILL.md parses history data"},
-        {"type": "contains", "value": "record", "description": "SKILL.md records metrics per run"},
-        {"type": "contains", "value": "prioritize", "description": "SKILL.md prioritizes high-ROI strategies"},
-        {"type": "contains", "value": "rates", "description": "SKILL.md computes success rates"}
-      ]
-    },
-    {
-      "id": "tc-10",
-      "prompt": "Run discovery mode to analyze all dimensions and find the weakest scorer target.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "discovery", "description": "SKILL.md has discovery mode"},
-        {"type": "contains", "value": "dimension", "description": "SKILL.md analyzes dimensions"},
-        {"type": "contains", "value": "analyze", "description": "SKILL.md supports analysis"},
-        {"type": "contains", "value": "scorer", "description": "SKILL.md runs dimension scorers"},
-        {"type": "contains", "value": "script", "description": "SKILL.md references scoring scripts"},
-        {"type": "contains", "value": "target", "description": "SKILL.md identifies improvement targets"},
-        {"type": "contains", "value": "goal", "description": "SKILL.md suggests goals after analysis"},
-        {"type": "contains", "value": "mode", "description": "SKILL.md has discovery and auto modes"},
-        {"type": "contains", "value": "scorers", "description": "SKILL.md runs all 7 dimension scorers"},
-        {"type": "contains", "value": "high-ROI", "description": "SKILL.md prioritizes high-ROI strategies"}
-      ]
-    },
-    {
-      "id": "tc-11",
-      "prompt": "Define a custom metric using a bash command with json output and verify it.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "custom", "description": "SKILL.md supports custom metrics"},
-        {"type": "contains", "value": "metric", "description": "SKILL.md defines metric interface"},
-        {"type": "contains", "value": "json", "description": "SKILL.md supports JSON output"},
-        {"type": "contains", "value": "command", "description": "SKILL.md uses verify commands"},
-        {"type": "contains", "value": "verify", "description": "SKILL.md has verify interface"},
-        {"type": "contains", "value": "output", "description": "SKILL.md processes command output"},
-        {"type": "contains", "value": "execute", "description": "SKILL.md executes verify commands"},
-        {"type": "contains", "value": "bash", "description": "SKILL.md supports bash commands"}
-      ]
-    },
-    {
-      "id": "tc-12",
-      "prompt": "Harden my skill against malformed input, empty files, and missing context.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "edge", "description": "SKILL.md covers edge cases"},
-        {"type": "contains", "value": "malformed", "description": "SKILL.md tests malformed input"},
-        {"type": "contains", "value": "empty", "description": "SKILL.md handles empty files"},
-        {"type": "contains", "value": "input", "description": "SKILL.md tests input handling"},
-        {"type": "contains", "value": "file", "description": "SKILL.md processes skill files"},
-        {"type": "contains", "value": "missing", "description": "SKILL.md handles missing context"},
-        {"type": "contains", "value": "context", "description": "SKILL.md re-reads context before changes"},
-        {"type": "contains", "value": "case", "description": "SKILL.md defines edge case handling"},
-        {"type": "contains", "value": "none", "description": "SKILL.md handles none/missing eval suites"}
-      ]
-    },
-    {
-      "id": "tc-13",
-      "prompt": "Show the improvement loop scoring changes over time and check for regression.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "loop", "description": "SKILL.md runs improvement loop"},
-        {"type": "contains", "value": "scoring", "description": "SKILL.md tracks scoring progress"},
-        {"type": "contains", "value": "changes", "description": "SKILL.md tracks atomic changes"},
-        {"type": "contains", "value": "time", "description": "SKILL.md tracks time budgets"},
-        {"type": "contains", "value": "point", "description": "SKILL.md tracks point deltas"},
-        {"type": "contains", "value": "check", "description": "SKILL.md checks for regressions"},
-        {"type": "contains", "value": "current", "description": "SKILL.md shows current state"},
-        {"type": "contains", "value": "improve", "description": "SKILL.md drives improvements"},
-        {"type": "contains", "value": "once", "description": "SKILL.md runs verify once before loop"},
-        {"type": "contains", "value": "between", "description": "SKILL.md evolves eval suites between sessions"},
-        {"type": "contains", "value": "number", "description": "SKILL.md uses number for metric tracking"}
-      ]
-    },
-    {
-      "id": "tc-14",
-      "prompt": "Handle a multi-file skill with deep reference files in a directory, extract and move content.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "reference", "description": "SKILL.md handles reference files"},
-        {"type": "contains", "value": "extract", "description": "SKILL.md extracts content to references"},
-        {"type": "contains", "value": "content", "description": "SKILL.md manages skill content"},
-        {"type": "contains", "value": "directory", "description": "SKILL.md mentions directory structure"},
-        {"type": "contains", "value": "deep", "description": "SKILL.md handles deep content"},
-        {"type": "contains", "value": "move", "description": "SKILL.md moves sections to references"},
-        {"type": "contains", "value": "adjacent", "description": "SKILL.md checks adjacent skills"},
-        {"type": "contains", "value": "handoff", "description": "SKILL.md defines handoff points"},
-        {"type": "contains", "value": "references", "description": "SKILL.md manages reference file trees"}
-      ]
-    },
-    {
-      "id": "tc-15",
-      "prompt": "Run the test suite assertions on my deploy skill and show pass rate without manual steps.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "test", "description": "SKILL.md supports test suites"},
-        {"type": "contains", "value": "suite", "description": "SKILL.md uses eval suites"},
-        {"type": "contains", "value": "assertion", "description": "SKILL.md checks assertions"},
-        {"type": "contains", "value": "deploy", "description": "SKILL.md handles deploy skills"},
-        {"type": "contains", "value": "default", "description": "SKILL.md has default settings"},
-        {"type": "contains", "value": "user", "description": "SKILL.md interacts with user"},
-        {"type": "contains", "value": "pass", "description": "SKILL.md reports pass rate"},
-        {"type": "contains", "value": "without", "description": "SKILL.md works without manual input"},
-        {"type": "contains", "value": "assertions", "description": "SKILL.md validates assertions"},
-        {"type": "contains", "value": "path", "description": "SKILL.md requires skill path as input"}
-      ]
-    },
-    {
-      "id": "tc-16",
-      "prompt": "Generate an eval suite from seed examples with concrete pairs and initial coverage.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "seed", "description": "SKILL.md uses examples as seeds"},
-        {"type": "contains", "value": "examples", "description": "SKILL.md includes examples"},
-        {"type": "contains", "value": "concrete", "description": "SKILL.md suggests concrete pairs"},
-        {"type": "contains", "value": "pairs", "description": "SKILL.md creates before/after pairs"},
-        {"type": "contains", "value": "initial", "description": "SKILL.md establishes initial baseline"},
-        {"type": "contains", "value": "descriptive", "description": "SKILL.md requires descriptive commits"},
-        {"type": "contains", "value": "write", "description": "SKILL.md writes commit messages"},
-        {"type": "contains", "value": "says", "description": "SKILL.md handles when user says something vague"},
-        {"type": "contains", "value": "before", "description": "SKILL.md reads files before each change"}
-      ]
-    },
-    {
-      "id": "tc-17",
-      "prompt": "Show cost tracking and running time, then write a handoff for the next Claude session.",
-      "input_files": [],
-      "assertions": [
-        {"type": "contains", "value": "schliff", "description": "SKILL.md is the Schliff skill"},
-        {"type": "contains", "value": "running", "description": "SKILL.md tracks running experiments"},
-        {"type": "contains", "value": "claude", "description": "SKILL.md mentions Claude Code"},
-        {"type": "contains", "value": "grep", "description": "SKILL.md uses grep for output parsing"},
-        {"type": "contains", "value": "work", "description": "SKILL.md describes workflow"},
-        {"type": "contains", "value": "unavailable", "description": "SKILL.md handles unavailable resources"},
-        {"type": "contains", "value": "correct", "description": "SKILL.md ensures correct output"},
-        {"type": "contains", "value": "exists", "description": "SKILL.md checks if resources exist"},
-        {"type": "contains", "value": "return", "description": "SKILL.md returns structured error on failure"},
-        {"type": "contains", "value": "prevent", "description": "SKILL.md prevents contradictions and drift"},
-        {"type": "contains", "value": "next", "description": "SKILL.md supports handoff to next session"}
       ]
     }
   ],

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -410,8 +410,18 @@ def cmd_doctor(args: argparse.Namespace) -> None:
 
     verbose = getattr(args, "verbose", False)
     repo_root = getattr(args, "repo", None)
+
+    # Positional dirs are an alias for --skill-dirs. Refuse both rather than merge
+    # them: a silent union would make the scanned set depend on argument order.
+    positional = getattr(args, "dirs", None) or None
+    flagged = getattr(args, "skill_dirs", None) or None
+    if positional and flagged:
+        print("schliff doctor: give directories positionally or via --skill-dirs, "
+              "not both", file=sys.stderr)
+        raise SystemExit(2)
+
     report = doctor_mod.run_doctor(
-        skill_dirs=getattr(args, "skill_dirs", None),
+        skill_dirs=flagged or positional,
         verbose=verbose,
         repo_root=repo_root,
     )
@@ -1058,6 +1068,12 @@ def main():
     # doctor command
     doctor_parser = subparsers.add_parser("doctor", help="Scan all installed skills")
     doctor_parser.add_argument("--json", action="store_true", help="JSON output")
+    # A bare directory is what people actually type — schliff's only external adopter
+    # documented `schliff doctor <dir>` as his step 1 and it exited 2 with
+    # "unrecognized arguments". Positional dirs are an alias for --skill-dirs; giving
+    # both is an error rather than a silent merge, so the scanned set is never ambiguous.
+    doctor_parser.add_argument("dirs", nargs="*", default=None, metavar="DIR",
+                               help="Directories to scan (same as --skill-dirs)")
     doctor_parser.add_argument("--skill-dirs", nargs="+", default=None,
                                help="Directories to scan")
     doctor_parser.add_argument("--verbose", "-v", action="store_true",

--- a/skills/schliff/scripts/test-self.sh
+++ b/skills/schliff/scripts/test-self.sh
@@ -40,10 +40,18 @@ SELF_SCORE=$(python3 "$SCRIPT_DIR/score-skill.py" "$SKILL_DIR/SKILL.md" --json 2
 MEASURED=$(echo "$SELF_SCORE" | python3 -c "import sys,json; print(json.load(sys.stdin)['confidence']['measured'])" 2>/dev/null)
 [[ "$MEASURED" == "7" ]] && pass "All 7 dimensions measured" || fail "Expected 7 dimensions, got $MEASURED"
 
-# Composite should be >= 90 (Schliff should practice what it preaches)
+# Composite floor. This was 90 until the card was rewritten to be executable.
+# The 90 was never met by an independent measurement: the old card scored 98.9
+# against an eval suite whose 108 `contains` assertions were, all 108 of them,
+# lifted verbatim out of that same card. A suite extracted from an artifact
+# scores that artifact 100% by construction, so the number measured nothing.
+# With the suite re-derived from its prompts the card earns 87.4, and the
+# remaining gap is composability — which schliff proposes to close by stuffing
+# eval-suite keywords into a linter's description. That was declined, so the
+# floor is set below the honest score rather than the artifact bent up to it.
 COMPOSITE=$(echo "$SELF_SCORE" | python3 -c "import sys,json; print(json.load(sys.stdin)['composite_score'])" 2>/dev/null)
-python3 -c "import sys; exit(0 if float(sys.argv[1]) >= 90 else 1)" "$COMPOSITE" 2>/dev/null && \
-    pass "Composite >= 90 (got $COMPOSITE)" || fail "Composite $COMPOSITE < 90"
+python3 -c "import sys; exit(0 if float(sys.argv[1]) >= 85 else 1)" "$COMPOSITE" 2>/dev/null && \
+    pass "Composite >= 85 (got $COMPOSITE)" || fail "Composite $COMPOSITE < 85"
 
 # Each dimension should be >= 40 (D-grade floor)
 # Composability uses 10 granular checks since v6.0, so 50 is a valid mid-range score
@@ -134,15 +142,26 @@ print(len(c) if isinstance(c, list) else 0)
 [[ "$CONTRADICTIONS" == "0" ]] && pass "No contradictions in SKILL.md" || fail "$CONTRADICTIONS contradictions found"
 
 ##############################################################################
-section "Regression Guard: SKILL.md line count"
+section "Regression Guard: SKILL.md is not emptied out"
 ##############################################################################
 
 LINE_COUNT=$(wc -l < "$SKILL_DIR/SKILL.md" | tr -d ' ')
 python3 -c "import sys; exit(0 if int(sys.argv[1]) <= 300 else 1)" "$LINE_COUNT" 2>/dev/null && \
     pass "SKILL.md <= 300 lines ($LINE_COUNT)" || fail "SKILL.md has $LINE_COUNT lines (max 300)"
 
-python3 -c "import sys; exit(0 if int(sys.argv[1]) >= 100 else 1)" "$LINE_COUNT" 2>/dev/null && \
-    pass "SKILL.md >= 100 lines ($LINE_COUNT)" || fail "SKILL.md suspiciously short ($LINE_COUNT lines)"
+# The lower guard used to be ">= 100 lines". It measured length where it meant
+# completeness, and it proved it by rejecting a deliberate 99-line trim of a card
+# that a real agent could finally execute. `structure` measures the property
+# itself. Measured on this card and two degradations of it:
+#   full card 95  |  worked examples stripped 85  |  gutted to bare commands 75
+# so a floor of 90 catches both losses that the line count caught, and stops
+# rejecting a card for being short. Padding cannot satisfy it; content can.
+# Its twin lives in tests/unit/test_golden.py::test_self_structure_perfect — the
+# two run in separate CI steps and must be moved together.
+STRUCTURE=$(echo "$SELF_SCORE" | python3 -c "import sys,json; print(json.load(sys.stdin)['dimensions']['structure'])" 2>/dev/null)
+python3 -c "import sys; exit(0 if int(sys.argv[1]) >= 90 else 1)" "$STRUCTURE" 2>/dev/null && \
+    pass "SKILL.md structurally complete (structure=$STRUCTURE >= 90)" || \
+    fail "SKILL.md lost structure (structure=$STRUCTURE < 90) — sections or examples missing"
 
 ##############################################################################
 # --- Summary ---

--- a/skills/schliff/tests/fixtures/self-skill-baseline/SKILL.md
+++ b/skills/schliff/tests/fixtures/self-skill-baseline/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: schliff
+description: >
+  Deterministic skill linter and scoring engine for Claude Code — the Ruff for
+  SKILL.md files. 7-dimension structural scoring (structure, triggers, quality,
+  edges, efficiency, composability, clarity) with anti-gaming detection, ~32%
+  rule-based patches, and cross-session episodic memory. An autoresearch loop
+  that measures first, then fixes — not the other way around. Use for linting,
+  scoring, and autonomously improving any Claude Code skill: trigger accuracy,
+  output quality, edge coverage, token efficiency, composability, or custom
+  metrics. Works with community, custom, project-local, or global skills.
+  Trigger phrases: "make this skill better", "optimize my skill", "iterate on
+  this skill overnight", "improve [metric] from X to Y", "audit skill",
+  "review my skill", "harden skill", "benchmark skill", "lint my skill",
+  "score my skill", or paste SKILL.md for auto-analysis. Also use when user
+  shares skill without explicit instructions. Do NOT use for brand-new skills
+  from scratch — use skill-creator first, then come to Schliff. Do NOT use for
+  SQL query tuning. Do NOT use for prompt template authoring.
+---
+
+# Schliff — Skill Measurement & Iteration Framework
+
+Constraint + clear metric + disciplined iteration = compounding gains. The composite score measures structural quality (file organization, keyword coverage, eval suite breadth) — not runtime effectiveness. Use `--runtime` to validate actual behavior.
+
+## Quick Start (Only 2 Inputs Required)
+
+```bash
+/schliff
+Target: path/to/SKILL.md
+Goal: Make the skill trigger correctly for deployment scenarios
+```
+
+Defaults: Metric=composite_score, Verify=score-skill.py, Iterations=30.
+
+## Core Loop (NEVER Pauses)
+
+```
+INPUT: Skill path + GOAL + PRIMARY METRIC + VERIFY method + time budget
+SETUP: Read ALL files → Analyze → Generate eval suite → Baseline (#0)
+LOOP (N iterations, continues until goal met or budget exhausted):
+  Exp N: Review skill + results + git history
+  → Pick ONE atomic change (based on gaps + history)
+  → Edit SKILL.md or references
+  → Commit: "schliff exp-N: [description]"
+  → Run VERIFY, compute PRIMARY METRIC
+  → Improved? Keep. Worse? Revert. Error? Fix or skip.
+  → Append to history/ with diffs
+  CONSTRAINT: Fixed iterations prevent infinite loops; autonomous mode =
+  NO prompts between iterations, just continuous improvement.
+```
+
+## When to Use
+
+- **Skill not triggering** → Run `/schliff` on trigger-accuracy metric
+- **Wrong/incomplete outputs** → Set goal, metric = binary eval pass rate
+- **Harden for edge cases** → Focus on edge-coverage metric
+- **Skill too verbose** → Optimize token-efficiency metric
+- **Don't know what's wrong** → Run `/schliff:analyze` for auto-discovery
+- **Any custom goal** → Define GOAL, pick/create METRIC, set VERIFY command
+
+Do NOT use for creating new skills from scratch — use skill-creator first. Do NOT use for SQL query tuning or prompt template authoring.
+
+## Interface: GOAL + METRIC + VERIFY
+
+```bash
+/schliff
+Target: .claude/skills/my-skill/SKILL.md
+Goal: Fix skill to handle deployment scenarios correctly
+Metric: Binary eval pass rate %
+Verify: bash scripts/run-eval.sh
+Time budget: 2 hours
+Iterations: 30
+```
+
+**Regression guards** — prevent one dimension from regressing while improving another:
+
+```bash
+/schliff
+Target: .claude/skills/deploy/SKILL.md
+Goal: Maximize trigger accuracy
+Metric: Trigger pass rate
+Verify: python3 scripts/score-skill.py SKILL.md --json
+Constraint: efficiency >= 80, composability >= 90
+```
+
+## Quality Dimensions (Configurable via `--weights`)
+
+| Dimension | Metric | How | Limitation |
+|-----------|--------|-----|------------|
+| **Structure** | Frontmatter lint score | `score-skill.py` | File quality, not instruction correctness |
+| **Trigger accuracy** | Keyword overlap | TF-IDF heuristic | Does not predict actual triggering |
+| **Output quality** | Eval assertion breadth | Test cases | Does not verify runtime output |
+| **Edge coverage** | Edge-case definitions | Edge test suite | Does not verify runtime handling |
+| **Token efficiency** | Signal/noise density | `score-skill.py` | Cannot assess content usefulness |
+| **Composability** | Scope boundaries | Static analysis | Cannot verify multi-skill interaction |
+| **Clarity** *(default)* | Contradiction + ambiguity | `score-skill.py` (`--no-clarity` to opt out) | Pattern-based, not semantic |
+
+See `references/metrics-catalog.md` for rubrics.
+
+## Custom Metrics
+
+Define any metric via a shell command returning a number:
+
+```bash
+Metric: "Time to first correct output (ms)"
+Verify: time bash scripts/run-eval.sh | grep "passed"
+```
+
+Validate custom metrics by running once before the loop, for example by checking the return code.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `/schliff:init` | Bootstrap eval-suite + baseline |
+| `/schliff` | Autonomous loop with GOAL + METRIC |
+| `/schliff:auto` | Self-driving auto-improve: deterministic patches in a loop |
+| `/schliff:analyze` | Skill analysis, gaps, anti-patterns, baseline |
+| `/schliff:bench` | Single evaluation run, current score |
+| `/schliff:eval` | Run eval suite, show results |
+| `/schliff:report` | Generate improvement summary + diffs |
+| `/schliff:mesh` | Scan skills for trigger overlap, broken handoffs, scope collisions |
+| `/schliff:triage` | Cluster logged failures, auto-generate fixes |
+| `/schliff:log-failure` | Log a skill failure for later triage |
+
+## Before the Loop (Setup Phase)
+
+1. Read ALL files — SKILL.md + references + related skills.
+2. Parse GOAL + METRIC + VERIFY from input. Use defaults if unspecified.
+3. Run baseline — Execute VERIFY, record initial metric as exp #0.
+4. Generate eval suite if none exists. Use SKILL.md examples as seeds.
+5. Validate eval suite — Run once, verify assertions parse correctly.
+6. Show gap analysis with estimated iterations. Start NEVER-PAUSE mode on confirm.
+
+## Autonomous Loop (Eight-Phase Protocol)
+
+Per `references/improvement-protocol.md`. Immutable rules:
+
+1. ONE change per experiment. Run `git diff` to verify scope, because atomic edits isolate causation.
+2. Run VERIFY, check number, keep or discard. This prevents subjective drift.
+3. Revert on regression: `git revert HEAD`. This ensures safe experimentation.
+4. Re-read ALL files before each change. This prevents contradictions.
+5. Descriptive commits: `schliff exp-7: add deployment edge cases`.
+6. Stuck (5+ discards): re-read files, review history, try the opposite. This avoids local optima.
+7. Never modify VERIFY during loop. Metric is fixed; skill is the variable.
+8. Log everything to `history/` — diffs, metrics, keep/discard status.
+9. **Plateau guard:** Every 5 iterations, compare composite against 5-back. Delta < 1.0 → switch strategy or stop.
+
+## Cross-Session Learning
+
+Read `history/results.jsonl` at loop start. Parse keep/discard per strategy, compute success rates, prioritize high-ROI strategies. < 1 point over 5 iterations triggers stop suggestion. Visualize with `scripts/progress.py`.
+
+## Multi-File Skills
+
+Read full skill tree before each change. Extract sections to `references/` when SKILL.md exceeds 400 lines. Verify cross-file references after each edit. For agents: treat system prompt as SKILL.md, tool definitions as references.
+
+## Discovery Mode (Auto-Gap Analysis)
+
+Run `/schliff:analyze` without a GOAL:
+
+1. Run all 7 dimension scorers.
+2. Identify weakest dimension and failure patterns.
+3. Cluster eval failures for systemic issues (e.g., "all false negatives share short prompts").
+4. Propose ranked improvements with estimated iteration cost.
+5. Suggest GOAL + METRIC + VERIFY. User confirms or overrides.
+
+Use when user says "my skill needs work" without specifying what, e.g., `/schliff:analyze path/to/SKILL.md`.
+
+## Parallel Experimentation
+
+Create 3 candidates on separate `git worktree` branches, run VERIFY on all, keep highest improvement. Use when stuck (5+ discards) or gap > 15 points. Fallback to sequential if worktree unavailable.
+
+## Noisy Metrics
+
+When metrics fluctuate (>5%): run VERIFY 3x, use median, keep only if improvement > 2x noise floor. Revert to best checkpoint if composite dropped > 2 points despite individual keeps.
+
+## Cost Tracking
+
+`run-eval.sh --log` records duration, tokens, delta, status per run. ROI = `delta / iterations_spent`. Stop when last 5 iterations gained < 0.5 points. Cross-session ROI via `progress.py --json`.
+
+## Self-Evolving Eval Suites
+
+Every 10 iterations: classify tests as mastered/blocked/flaky via `classify_eval_health()`. Reduce mastered test weight. Log mutations to `history/`. Run eval evolution BETWEEN sessions (preserves Rule 7).
+
+## Improvement Strategies (Dynamic)
+
+Select based on gap analysis. Pick first dimension with gap > 10 points:
+
+1. Fix structural issues — Run `python3 scripts/score-skill.py SKILL.md --json`.
+2. Expand triggers — Add synonyms, edge cases, negative boundaries.
+3. Add input/output examples — Write 3+ concrete before/after pairs.
+4. Add edge-case handling — Test with malformed input, missing context, empty files.
+5. Optimize density — Remove redundancy, compress verbose phrasing.
+6. Extract references — Move deep content to `references/`.
+7. Verify composability — Check handoff points, run with adjacent skills.
+
+See `references/metrics-catalog.md` for patterns per dimension.
+
+## Example Session
+
+```bash
+Goal: Trigger accuracy from 60% to 90%
+Verify: bash scripts/run-eval.sh | grep "PASS" | wc -l
+
+Exp 1: Add synonyms to description → 65% → Keep
+Exp 2: Add negative trigger examples → 70% → Keep
+Exp 3: Compress verbose setup section → 68% → Discard (revert)
+Exp 4: Add edge case for partial audit → 75% → Keep
+```
+
+Parse `history/results.jsonl` between sessions. Compare keep rates to prioritize high-ROI changes next session.
+
+## Lineage
+
+`/skill-creator` → v1 → `/schliff` → autonomous grinding → merge. Roll back via `git log --oneline history/`. For crashing skills: use `systematic-debugging` instead, then return to Schliff.
+
+## Requirements
+
+Requires Python >= 3.9, Git >= 2.0, jq >= 1.6, Bash >= 4.0. Standard library only. All `/schliff:*` commands are namespaced. Deterministic scorer, safe to re-run. If scoring fails, returns structured error.
+
+## Files
+
+Run `ls -R` in skill directory. Run `python3 scripts/score-skill.py SKILL.md --json` for scores. Key files:
+
+- `scripts/init-skill.py` — Bootstrap eval-suite (`--json --dry-run`)
+- `scripts/generate-report.py` — Shareable improvement report
+- `scripts/score-skill.py` — Dimension scores incl. runtime (`--diff --clarity --weights`)
+- `scripts/text-gradient.py` — Invert scorer issues into fix list (`--json --top N --apply --dry-run`)
+- `scripts/auto-improve.py` — Autonomous loop (`--max-iterations N --dry-run --resume`)
+- `scripts/skill-mesh.py` — Multi-skill conflict detection (`--incremental`)
+- `scripts/meta-report.py` — Strategy predictor + auto-calibration
+- `scripts/episodic-store.py` — Cross-session memory (`--store --recall --synthesize`)
+- `scripts/parallel-runner.py` — Worktree parallel experimentation (`--strategies --auto`)
+- `scripts/runtime-evaluator.py` — Invoke Claude with test prompts, check output
+- `scripts/analyze-skill.sh` — Legacy linter (score-skill.py has this built-in)
+- `scripts/run-eval.sh` — Run eval suite (`--runtime` auto-enabled if claude CLI available)
+- `scripts/progress.py` — Convergence charts + strategy analysis (`--emit-meta`)
+- `hooks/session-injector.js` — SessionStart hook: surfaces untriaged failures
+- `references/improvement-protocol.md` — Full 9-phase loop spec
+- `references/metrics-catalog.md` — Scoring rubrics + custom metrics
+- `templates/eval-suite-template.json` — Eval skeleton for new skills

--- a/skills/schliff/tests/fixtures/self-skill-baseline/eval-suite.json
+++ b/skills/schliff/tests/fixtures/self-skill-baseline/eval-suite.json
@@ -1,0 +1,996 @@
+{
+  "skill_name": "schliff",
+  "version": "5.1.0",
+  "created_by": "schliff",
+  "triggers": [
+    {
+      "id": "pos-1",
+      "prompt": "I have a deploy skill in .claude/skills/deploy/ and it barely ever triggers when I say 'push to staging'. Can you improve it?",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Direct skill improvement request with specific trigger problem"
+    },
+    {
+      "id": "pos-2",
+      "prompt": "grind my code-review skill to production quality, run like 30 iterations overnight",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Casual 'grind' phrasing with iteration count"
+    },
+    {
+      "id": "pos-3",
+      "prompt": "Can you optimize the trigger accuracy of my deploy skill? It's only hitting about 60% right now.",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Explicit metric (trigger accuracy) with current baseline"
+    },
+    {
+      "id": "pos-4",
+      "prompt": "make this skill better — it works but the outputs are way too verbose and it wastes tokens",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Exact trigger phrase from SKILL.md description, token efficiency focus"
+    },
+    {
+      "id": "pos-5",
+      "prompt": "iterate on this skill until the edge coverage is above 90%",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Goal-oriented iteration with explicit metric target"
+    },
+    {
+      "id": "pos-6",
+      "prompt": "benchmark my skill at skills/commit-msg/SKILL.md — I want to see current scores across all dimensions",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Benchmark subcommand request with path"
+    },
+    {
+      "id": "pos-7",
+      "prompt": "audit the skill I just wrote, check for anti-patterns and missing sections",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Audit keyword with structural analysis request"
+    },
+    {
+      "id": "pos-8",
+      "prompt": "harden my testing skill against malformed inputs and weird edge cases",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Harden keyword targeting edge coverage"
+    },
+    {
+      "id": "pos-9",
+      "prompt": "I finished a first draft with skill-creator. Now I want schliff to take over and grind it for a couple hours.",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Explicit handoff from skill-creator to schliff"
+    },
+    {
+      "id": "pos-10",
+      "prompt": "here's my SKILL.md — can you tell me what's wrong with it and how to fix it?\n\n---\nname: my-deploy\ndescription: deploys stuff\n---\n# Deploy\nJust deploy.",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "User pastes SKILL.md content directly for analysis"
+    },
+    {
+      "id": "pos-11",
+      "prompt": "review my skill and show me a report of gaps + suggestions, don't change anything yet",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Analysis-only request, maps to /schliff:analyze"
+    },
+    {
+      "id": "pos-12",
+      "prompt": "run the eval suite for my skill and show me which tests fail",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Maps to /schliff:eval subcommand"
+    },
+    {
+      "id": "pos-13",
+      "prompt": "my skill at .claude/skills/lint/SKILL.md has conflicting instructions — the description says one thing but the examples do another. fix it.",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Consistency/quality problem in existing skill"
+    },
+    {
+      "id": "pos-14",
+      "prompt": "improv my skill pls, its not working good for edge cases",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Typos and casual language — should still trigger"
+    },
+    {
+      "id": "pos-15",
+      "prompt": "I want to improve the composability of my database skill — it conflicts with the migration skill when both are active",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Composability dimension with cross-skill conflict"
+    },
+    {
+      "id": "pos-16",
+      "prompt": "The skill I made yesterday scores 45/100. I need it at 80+ before shipping. Run autonomous improvement.",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Numeric goal with autonomous loop request"
+    },
+    {
+      "id": "pos-17",
+      "prompt": "generate a schliff report for the last improvement session on my deploy skill",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Maps to /schliff:report subcommand"
+    },
+    {
+      "id": "neg-1",
+      "prompt": "I want to create a brand new skill from scratch that helps me write commit messages. I have some ideas but no code yet.",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Creating new skills = skill-creator's job, not schliff"
+    },
+    {
+      "id": "neg-2",
+      "prompt": "Can you review this Python function and suggest performance improvements? It's in src/utils/parser.py",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Code review, not skill improvement — similar vocabulary but wrong domain"
+    },
+    {
+      "id": "neg-3",
+      "prompt": "Help me set up pre-commit hooks for my repository with eslint and prettier",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Developer tooling setup, not skill improvement"
+    },
+    {
+      "id": "neg-4",
+      "prompt": "Write unit tests for my authentication module in tests/auth.test.ts",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Writing application tests, not skill eval tests"
+    },
+    {
+      "id": "neg-5",
+      "prompt": "Debug why my API endpoint returns 500 when I send a POST request with an empty body",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Application debugging, not skill debugging"
+    },
+    {
+      "id": "neg-6",
+      "prompt": "deploy my app to vercel and set up the environment variables",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Deployment task, not skill improvement — 'deploy' is a red herring"
+    },
+    {
+      "id": "neg-7",
+      "prompt": "refactor this class to use dependency injection instead of singletons",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Code refactoring, not skill refactoring"
+    },
+    {
+      "id": "neg-8",
+      "prompt": "I need a new Claude skill that handles database migrations. Design the SKILL.md for me.",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Designing a new skill from scratch — skill-creator territory"
+    },
+    {
+      "id": "neg-9",
+      "prompt": "optimize my Dockerfile to reduce image size, it's currently 2.3GB",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "'Optimize' keyword but targets infrastructure, not a skill"
+    },
+    {
+      "id": "neg-10",
+      "prompt": "improve the performance of my SQL query, it's taking 12 seconds on the users table",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "'Improve' keyword but targets SQL performance, not a skill"
+    },
+    {
+      "id": "neg-11",
+      "prompt": "benchmark my REST API with wrk and show me the throughput numbers",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "'Benchmark' keyword but targets an API, not a skill"
+    },
+    {
+      "id": "neg-12",
+      "prompt": "Can you help me write a README for my open source project?",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Documentation writing, nothing to do with skills"
+    },
+    {
+      "id": "edge-1",
+      "prompt": "This SKILL.md seems off, the formatting is weird and I think some of the instructions are contradicting each other",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "References SKILL.md + describes quality issues — should analyze"
+    },
+    {
+      "id": "edge-2",
+      "prompt": "I want to benchmark how well my deploy script performs compared to the old version",
+      "should_trigger": false,
+      "category": "edge",
+      "notes": "Benchmarking a script (not a skill) — keyword overlap"
+    },
+    {
+      "id": "edge-3",
+      "prompt": "can you make my workflow better? I have a skill but also some bash scripts that are slow",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "Ambiguous — mentions skill AND scripts, but skill improvement is primary"
+    },
+    {
+      "id": "edge-4",
+      "prompt": "audit this code for security vulnerabilities and check if there are any injection risks",
+      "should_trigger": false,
+      "category": "edge",
+      "notes": "'Audit' keyword but targets code security, not skill quality"
+    },
+    {
+      "id": "edge-5",
+      "prompt": "I pasted my skill description into a markdown file, can you improve the writing quality?",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "Improving skill description content — borderline with copyediting but skill-relevant"
+    },
+    {
+      "id": "edge-6",
+      "prompt": "iterate on my prompt template until it generates better summaries",
+      "should_trigger": false,
+      "category": "edge",
+      "notes": "'Iterate' + 'prompt template' — prompt engineering, not Claude skill improvement"
+    },
+    {
+      "id": "edge-7",
+      "prompt": "my skill needs work but I'm not sure what exactly is wrong. just look at it.",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "Vague request referencing a skill — should trigger analysis mode"
+    },
+    {
+      "id": "pos-18",
+      "prompt": "Verbessere meinen Deploy-Skill, die Trigger-Genauigkeit liegt bei 50%",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Non-English (German) improvement request"
+    },
+    {
+      "id": "pos-19",
+      "prompt": "My deploy skill has a SKILL.md plus 10 reference files in references/. The main file is fine but the references are outdated. Can you improve the whole skill?",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "Multi-file skill improvement request"
+    },
+    {
+      "id": "neg-13",
+      "prompt": "Compare the performance of my Python web scraper on v1 vs v2 of the target site",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "Performance comparison of application code, not skill improvement"
+    },
+    {
+      "id": "edge-8",
+      "prompt": "/schliff",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "Bare slash command with zero context — should trigger and prompt for target"
+    },
+    {
+      "id": "edge-9",
+      "prompt": "My eval suite is showing 12 out of 20 tests failing and the trigger pass rate dropped after I edited the description yesterday. What happened?",
+      "should_trigger": true,
+      "category": "edge",
+      "notes": "Eval-suite + trigger-pass-rate context implies Schliff analysis"
+    },
+    {
+      "id": "pos-mesh",
+      "prompt": "check if my skills are conflicting with each other",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "mesh/conflict detection request"
+    },
+    {
+      "id": "pos-triage",
+      "prompt": "cluster my logged failures and generate fixes for the top issues",
+      "should_trigger": true,
+      "category": "positive",
+      "notes": "failure triage request"
+    },
+    {
+      "id": "neg-mesh-false",
+      "prompt": "optimize my database queries for better performance",
+      "should_trigger": false,
+      "category": "negative",
+      "notes": "performance optimization, not skill mesh analysis"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "tc-1",
+      "prompt": "Analyze my skill at .claude/skills/deploy/SKILL.md and tell me what's wrong with it",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "contains",
+          "value": "structure",
+          "description": "Report includes structure dimension"
+        },
+        {
+          "type": "contains",
+          "value": "trigger",
+          "description": "Report includes trigger analysis"
+        },
+        {
+          "type": "contains",
+          "value": "score-skill.py",
+          "description": "SKILL.md references the scoring script"
+        },
+        {
+          "type": "excludes",
+          "value": "TODO",
+          "description": "No placeholder text in output"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I cannot",
+          "description": "Runtime: does not refuse the task"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I don't know",
+          "description": "Runtime: does not claim ignorance"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm sorry",
+          "description": "Runtime: does not apologize instead of acting"
+        },
+        {
+          "type": "response_excludes",
+          "value": "not possible",
+          "description": "Runtime: does not claim impossibility"
+        },
+        {
+          "type": "response_excludes",
+          "value": "outside my",
+          "description": "Runtime: does not claim out of scope"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm unable",
+          "description": "Runtime: does not claim inability"
+        },
+        {
+          "type": "response_excludes",
+          "value": "Traceback",
+          "description": "Runtime: no Python stack trace in output"
+        }
+      ]
+    },
+    {
+      "id": "tc-2",
+      "prompt": "Run one improvement iteration on my skill — focus on trigger accuracy",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "contains",
+          "value": "description",
+          "description": "Mentions modifying the description"
+        },
+        {
+          "type": "contains",
+          "value": "commit",
+          "description": "Makes a git commit"
+        },
+        {
+          "type": "pattern",
+          "value": "(keep|discard|revert)",
+          "description": "Makes a keep/discard/revert decision"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I cannot",
+          "description": "Runtime: does not refuse the task"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I don't know",
+          "description": "Runtime: does not claim ignorance"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm sorry",
+          "description": "Runtime: does not apologize instead of acting"
+        },
+        {
+          "type": "response_excludes",
+          "value": "not possible",
+          "description": "Runtime: does not claim impossibility"
+        },
+        {
+          "type": "response_excludes",
+          "value": "outside my",
+          "description": "Runtime: does not claim out of scope"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm unable",
+          "description": "Runtime: does not claim inability"
+        },
+        {
+          "type": "response_excludes",
+          "value": "Traceback",
+          "description": "Runtime: no Python stack trace in output"
+        }
+      ]
+    },
+    {
+      "id": "tc-3",
+      "prompt": "Benchmark my skill at skills/testing/SKILL.md and show me scores for all six dimensions",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "contains",
+          "value": "structure",
+          "description": "Reports structure score"
+        },
+        {
+          "type": "contains",
+          "value": "trigger",
+          "description": "Reports trigger accuracy score"
+        },
+        {
+          "type": "contains",
+          "value": "token",
+          "description": "Reports token efficiency"
+        },
+        {
+          "type": "pattern",
+          "value": "\\d+",
+          "description": "Contains numeric scores"
+        },
+        {
+          "type": "contains",
+          "value": "composability",
+          "description": "SKILL.md covers composability dimension"
+        },
+        {
+          "type": "response_excludes",
+          "value": "error",
+          "description": "Runtime: no error messages in output"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I cannot",
+          "description": "Runtime: does not refuse the task"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I don't know",
+          "description": "Runtime: does not claim ignorance"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm sorry",
+          "description": "Runtime: does not apologize instead of acting"
+        },
+        {
+          "type": "response_excludes",
+          "value": "not possible",
+          "description": "Runtime: does not claim impossibility"
+        },
+        {
+          "type": "response_excludes",
+          "value": "outside my",
+          "description": "Runtime: does not claim out of scope"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm unable",
+          "description": "Runtime: does not claim inability"
+        }
+      ]
+    },
+    {
+      "id": "tc-4",
+      "prompt": "Run the eval suite for my deploy skill and tell me which tests pass and which fail",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "contains",
+          "value": "run-eval.sh",
+          "description": "SKILL.md references the eval runner"
+        },
+        {
+          "type": "contains",
+          "value": "assertion",
+          "description": "SKILL.md mentions assertions"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I cannot",
+          "description": "Runtime: does not refuse the task"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I don't know",
+          "description": "Runtime: does not claim ignorance"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm sorry",
+          "description": "Runtime: does not apologize instead of acting"
+        },
+        {
+          "type": "response_excludes",
+          "value": "not possible",
+          "description": "Runtime: does not claim impossibility"
+        },
+        {
+          "type": "response_excludes",
+          "value": "outside my",
+          "description": "Runtime: does not claim out of scope"
+        },
+        {
+          "type": "response_excludes",
+          "value": "I'm unable",
+          "description": "Runtime: does not claim inability"
+        },
+        {
+          "type": "response_excludes",
+          "value": "Traceback",
+          "description": "Runtime: no Python stack trace in output"
+        }
+      ]
+    },
+    {
+      "id": "tc-5",
+      "prompt": "Generate an improvement report for the last 10 experiments on my skill",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "exp[- ]?\\d+",
+          "description": "References experiment numbers"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(keep|discard|revert)",
+          "description": "Shows experiment outcomes"
+        },
+        {
+          "type": "contains",
+          "value": "baseline",
+          "description": "References the baseline measurement"
+        },
+        {
+          "type": "pattern",
+          "value": "\\d+%|\\d+/\\d+",
+          "description": "Includes metric values"
+        }
+      ]
+    },
+    {
+      "id": "tc-6",
+      "prompt": "Set up schliff on my skill: goal is 90% eval pass rate, verify with bash scripts/run-eval.sh, run 20 iterations",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "contains",
+          "value": "baseline",
+          "description": "Establishes baseline before iterating"
+        },
+        {
+          "type": "pattern",
+          "value": "exp[- ]?0|#0",
+          "description": "Records experiment zero"
+        },
+        {
+          "type": "pattern",
+          "value": "90%|90 ?%",
+          "description": "Acknowledges the 90% target"
+        },
+        {
+          "type": "contains",
+          "value": "iteration",
+          "description": "Mentions iterations"
+        }
+      ]
+    },
+    {
+      "id": "tc-7",
+      "prompt": "My skill has a SKILL.md with no frontmatter, no examples, and no trigger phrases. Analyze it and tell me what to fix first.",
+      "input_files": [],
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)frontmatter",
+          "description": "Flags missing frontmatter"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(example|trigger)",
+          "description": "Flags missing examples or triggers"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(priority|first|critical|start)",
+          "description": "Provides prioritized recommendations"
+        }
+      ]
+    },
+    {
+      "id": "tc-8",
+      "prompt": "My skill is stuck after 5 discards. Use parallel experimentation with worktree branches and keep the highest candidate.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "worktree", "description": "SKILL.md covers worktree parallel experimentation"},
+        {"type": "contains", "value": "branches", "description": "SKILL.md mentions branches for parallel runs"},
+        {"type": "contains", "value": "candidates", "description": "SKILL.md uses candidate terminology"},
+        {"type": "contains", "value": "highest", "description": "SKILL.md selects highest improvement"},
+        {"type": "contains", "value": "sequential", "description": "SKILL.md mentions sequential fallback"},
+        {"type": "contains", "value": "stuck", "description": "SKILL.md handles stuck state"},
+        {"type": "contains", "value": "separate", "description": "SKILL.md uses separate branches"},
+        {"type": "contains", "value": "Fallback", "description": "SKILL.md falls back to sequential when unavailable"}
+      ]
+    },
+    {
+      "id": "tc-9",
+      "prompt": "Use cross-session learning from history to prioritize strategies that succeeded before.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "session", "description": "SKILL.md covers cross-session learning"},
+        {"type": "contains", "value": "history", "description": "SKILL.md reads history for learning"},
+        {"type": "contains", "value": "results.jsonl", "description": "SKILL.md references results.jsonl file"},
+        {"type": "contains", "value": "success", "description": "SKILL.md tracks success rates"},
+        {"type": "contains", "value": "strategy", "description": "SKILL.md prioritizes strategies"},
+        {"type": "contains", "value": "parse", "description": "SKILL.md parses history data"},
+        {"type": "contains", "value": "record", "description": "SKILL.md records metrics per run"},
+        {"type": "contains", "value": "prioritize", "description": "SKILL.md prioritizes high-ROI strategies"},
+        {"type": "contains", "value": "rates", "description": "SKILL.md computes success rates"}
+      ]
+    },
+    {
+      "id": "tc-10",
+      "prompt": "Run discovery mode to analyze all dimensions and find the weakest scorer target.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "discovery", "description": "SKILL.md has discovery mode"},
+        {"type": "contains", "value": "dimension", "description": "SKILL.md analyzes dimensions"},
+        {"type": "contains", "value": "analyze", "description": "SKILL.md supports analysis"},
+        {"type": "contains", "value": "scorer", "description": "SKILL.md runs dimension scorers"},
+        {"type": "contains", "value": "script", "description": "SKILL.md references scoring scripts"},
+        {"type": "contains", "value": "target", "description": "SKILL.md identifies improvement targets"},
+        {"type": "contains", "value": "goal", "description": "SKILL.md suggests goals after analysis"},
+        {"type": "contains", "value": "mode", "description": "SKILL.md has discovery and auto modes"},
+        {"type": "contains", "value": "scorers", "description": "SKILL.md runs all 7 dimension scorers"},
+        {"type": "contains", "value": "high-ROI", "description": "SKILL.md prioritizes high-ROI strategies"}
+      ]
+    },
+    {
+      "id": "tc-11",
+      "prompt": "Define a custom metric using a bash command with json output and verify it.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "custom", "description": "SKILL.md supports custom metrics"},
+        {"type": "contains", "value": "metric", "description": "SKILL.md defines metric interface"},
+        {"type": "contains", "value": "json", "description": "SKILL.md supports JSON output"},
+        {"type": "contains", "value": "command", "description": "SKILL.md uses verify commands"},
+        {"type": "contains", "value": "verify", "description": "SKILL.md has verify interface"},
+        {"type": "contains", "value": "output", "description": "SKILL.md processes command output"},
+        {"type": "contains", "value": "execute", "description": "SKILL.md executes verify commands"},
+        {"type": "contains", "value": "bash", "description": "SKILL.md supports bash commands"}
+      ]
+    },
+    {
+      "id": "tc-12",
+      "prompt": "Harden my skill against malformed input, empty files, and missing context.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "edge", "description": "SKILL.md covers edge cases"},
+        {"type": "contains", "value": "malformed", "description": "SKILL.md tests malformed input"},
+        {"type": "contains", "value": "empty", "description": "SKILL.md handles empty files"},
+        {"type": "contains", "value": "input", "description": "SKILL.md tests input handling"},
+        {"type": "contains", "value": "file", "description": "SKILL.md processes skill files"},
+        {"type": "contains", "value": "missing", "description": "SKILL.md handles missing context"},
+        {"type": "contains", "value": "context", "description": "SKILL.md re-reads context before changes"},
+        {"type": "contains", "value": "case", "description": "SKILL.md defines edge case handling"},
+        {"type": "contains", "value": "none", "description": "SKILL.md handles none/missing eval suites"}
+      ]
+    },
+    {
+      "id": "tc-13",
+      "prompt": "Show the improvement loop scoring changes over time and check for regression.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "loop", "description": "SKILL.md runs improvement loop"},
+        {"type": "contains", "value": "scoring", "description": "SKILL.md tracks scoring progress"},
+        {"type": "contains", "value": "changes", "description": "SKILL.md tracks atomic changes"},
+        {"type": "contains", "value": "time", "description": "SKILL.md tracks time budgets"},
+        {"type": "contains", "value": "point", "description": "SKILL.md tracks point deltas"},
+        {"type": "contains", "value": "check", "description": "SKILL.md checks for regressions"},
+        {"type": "contains", "value": "current", "description": "SKILL.md shows current state"},
+        {"type": "contains", "value": "improve", "description": "SKILL.md drives improvements"},
+        {"type": "contains", "value": "once", "description": "SKILL.md runs verify once before loop"},
+        {"type": "contains", "value": "between", "description": "SKILL.md evolves eval suites between sessions"},
+        {"type": "contains", "value": "number", "description": "SKILL.md uses number for metric tracking"}
+      ]
+    },
+    {
+      "id": "tc-14",
+      "prompt": "Handle a multi-file skill with deep reference files in a directory, extract and move content.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "reference", "description": "SKILL.md handles reference files"},
+        {"type": "contains", "value": "extract", "description": "SKILL.md extracts content to references"},
+        {"type": "contains", "value": "content", "description": "SKILL.md manages skill content"},
+        {"type": "contains", "value": "directory", "description": "SKILL.md mentions directory structure"},
+        {"type": "contains", "value": "deep", "description": "SKILL.md handles deep content"},
+        {"type": "contains", "value": "move", "description": "SKILL.md moves sections to references"},
+        {"type": "contains", "value": "adjacent", "description": "SKILL.md checks adjacent skills"},
+        {"type": "contains", "value": "handoff", "description": "SKILL.md defines handoff points"},
+        {"type": "contains", "value": "references", "description": "SKILL.md manages reference file trees"}
+      ]
+    },
+    {
+      "id": "tc-15",
+      "prompt": "Run the test suite assertions on my deploy skill and show pass rate without manual steps.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "test", "description": "SKILL.md supports test suites"},
+        {"type": "contains", "value": "suite", "description": "SKILL.md uses eval suites"},
+        {"type": "contains", "value": "assertion", "description": "SKILL.md checks assertions"},
+        {"type": "contains", "value": "deploy", "description": "SKILL.md handles deploy skills"},
+        {"type": "contains", "value": "default", "description": "SKILL.md has default settings"},
+        {"type": "contains", "value": "user", "description": "SKILL.md interacts with user"},
+        {"type": "contains", "value": "pass", "description": "SKILL.md reports pass rate"},
+        {"type": "contains", "value": "without", "description": "SKILL.md works without manual input"},
+        {"type": "contains", "value": "assertions", "description": "SKILL.md validates assertions"},
+        {"type": "contains", "value": "path", "description": "SKILL.md requires skill path as input"}
+      ]
+    },
+    {
+      "id": "tc-16",
+      "prompt": "Generate an eval suite from seed examples with concrete pairs and initial coverage.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "seed", "description": "SKILL.md uses examples as seeds"},
+        {"type": "contains", "value": "examples", "description": "SKILL.md includes examples"},
+        {"type": "contains", "value": "concrete", "description": "SKILL.md suggests concrete pairs"},
+        {"type": "contains", "value": "pairs", "description": "SKILL.md creates before/after pairs"},
+        {"type": "contains", "value": "initial", "description": "SKILL.md establishes initial baseline"},
+        {"type": "contains", "value": "descriptive", "description": "SKILL.md requires descriptive commits"},
+        {"type": "contains", "value": "write", "description": "SKILL.md writes commit messages"},
+        {"type": "contains", "value": "says", "description": "SKILL.md handles when user says something vague"},
+        {"type": "contains", "value": "before", "description": "SKILL.md reads files before each change"}
+      ]
+    },
+    {
+      "id": "tc-17",
+      "prompt": "Show cost tracking and running time, then write a handoff for the next Claude session.",
+      "input_files": [],
+      "assertions": [
+        {"type": "contains", "value": "schliff", "description": "SKILL.md is the Schliff skill"},
+        {"type": "contains", "value": "running", "description": "SKILL.md tracks running experiments"},
+        {"type": "contains", "value": "claude", "description": "SKILL.md mentions Claude Code"},
+        {"type": "contains", "value": "grep", "description": "SKILL.md uses grep for output parsing"},
+        {"type": "contains", "value": "work", "description": "SKILL.md describes workflow"},
+        {"type": "contains", "value": "unavailable", "description": "SKILL.md handles unavailable resources"},
+        {"type": "contains", "value": "correct", "description": "SKILL.md ensures correct output"},
+        {"type": "contains", "value": "exists", "description": "SKILL.md checks if resources exist"},
+        {"type": "contains", "value": "return", "description": "SKILL.md returns structured error on failure"},
+        {"type": "contains", "value": "prevent", "description": "SKILL.md prevents contradictions and drift"},
+        {"type": "contains", "value": "next", "description": "SKILL.md supports handoff to next session"}
+      ]
+    }
+  ],
+  "edge_cases": [
+    {
+      "id": "ec-1",
+      "prompt": "Improve my skill",
+      "category": "minimal_input",
+      "expected_behavior": "Ask for the skill path before proceeding",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "\\?|path|which|where",
+          "description": "Asks for clarification about which skill"
+        }
+      ]
+    },
+    {
+      "id": "ec-2",
+      "prompt": "Analyze the skill at /nonexistent/path/SKILL.md",
+      "category": "invalid_path",
+      "expected_behavior": "Report that the file was not found gracefully",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(not found|doesn't exist|cannot find|no such)",
+          "description": "Reports missing file gracefully"
+        }
+      ]
+    },
+    {
+      "id": "ec-3",
+      "prompt": "Run 1000 iterations on my skill overnight",
+      "category": "scale_extreme",
+      "expected_behavior": "Proceed but mention diminishing returns or plateau detection",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(plateau|diminish|stuck|interrupt|stop)",
+          "description": "Mentions stopping conditions"
+        }
+      ]
+    },
+    {
+      "id": "ec-4",
+      "prompt": "Improve my skill at .claude/skills/broken/SKILL.md",
+      "category": "malformed_skill",
+      "input_context": "SKILL.md contains: '---\\nname:\\n---\\n# \\n\\n'",
+      "expected_behavior": "Detect malformed/empty SKILL.md fields and report issues before iterating",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(empty|missing|incomplete|malformed|invalid)",
+          "description": "Detects the malformed content"
+        },
+        {
+          "type": "pattern",
+          "value": "(?i)(name|description|frontmatter)",
+          "description": "Points out specific missing fields"
+        }
+      ]
+    },
+    {
+      "id": "ec-5",
+      "prompt": "Analyze my skill at .claude/skills/données/COMPÉTENCE.md",
+      "category": "unicode_path",
+      "expected_behavior": "Handle Unicode characters in file path without crashing",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(read|found|analyz|not found|error)",
+          "description": "Attempts to read the file rather than crashing on Unicode path"
+        }
+      ]
+    },
+    {
+      "id": "ec-6",
+      "prompt": "Run schliff on my skill but the scripts/ directory is missing — there's no analyze-skill.sh or score-skill.py",
+      "category": "missing_scripts",
+      "expected_behavior": "Detect missing scripts and either generate them or provide manual fallback",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(missing|not found|unavailable|create|generate|fallback)",
+          "description": "Acknowledges missing scripts"
+        },
+        {
+          "type": "excludes",
+          "value": "Traceback",
+          "description": "No Python stack trace in output"
+        }
+      ]
+    },
+    {
+      "id": "ec-7",
+      "prompt": "Improve my skill — goal: make it trigger 100% of the time AND reduce token usage by 80% AND add 50 edge cases",
+      "category": "conflicting_goals",
+      "expected_behavior": "Identify conflicting goals (more coverage vs fewer tokens) and ask to prioritize",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(conflict|trade.?off|priorit|pick|focus|which)",
+          "description": "Flags the tension between competing goals"
+        }
+      ]
+    },
+    {
+      "id": "ec-8",
+      "prompt": "Analyze my skill at .claude/skills/giant/SKILL.md",
+      "category": "huge_file",
+      "input_context": "SKILL.md is 15,000 lines with deeply nested reference files totalling 50,000 tokens",
+      "expected_behavior": "Handle large files without truncation errors; suggest extracting content to references/",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(large|long|extract|reference|split|reduce)",
+          "description": "Suggests reducing file size or extracting references"
+        },
+        {
+          "type": "excludes",
+          "value": "truncated",
+          "description": "Does not silently truncate content"
+        }
+      ]
+    },
+    {
+      "id": "ec-9",
+      "prompt": "",
+      "category": "empty_input",
+      "expected_behavior": "Prompt the user for a goal and skill path instead of doing nothing",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(what|which|how|help|skill|goal|\\?)",
+          "description": "Asks what the user wants to do"
+        }
+      ]
+    },
+    {
+      "id": "ec-10",
+      "prompt": "Improve my skill. Goal: make metric go up. Verify: exit 0",
+      "category": "trivial_verify",
+      "expected_behavior": "Detect that the verify command always succeeds and warn about meaningless metric",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(always|trivial|meaningless|no.?op|useless|exit 0)",
+          "description": "Warns about the always-passing verify command"
+        }
+      ]
+    },
+    {
+      "id": "ec-11",
+      "prompt": "Run schliff with verify: rm -rf / and improve my skill",
+      "category": "dangerous_verify",
+      "expected_behavior": "Refuse to execute a destructive verify command",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(dangerous|destructive|refuse|cannot|won't|will not|unsafe)",
+          "description": "Refuses the dangerous command"
+        }
+      ]
+    },
+    {
+      "id": "ec-12",
+      "prompt": "Analyze the skill at this path — it's actually a binary PNG file accidentally named SKILL.md",
+      "category": "binary_file",
+      "expected_behavior": "Detect non-text content, report error gracefully, suggest renaming",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(binary|not.*text|cannot.*parse|invalid|encoding)",
+          "description": "Detects non-text file"
+        }
+      ]
+    },
+    {
+      "id": "ec-13",
+      "prompt": "Improve this skill:\n---\nname: x\ndescription: bad yaml: unescaped: colons: everywhere\n---\n# Stuff",
+      "category": "malformed_yaml",
+      "expected_behavior": "Handle corrupted YAML frontmatter gracefully, suggest fixes",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(yaml|frontmatter|parse|format|fix)",
+          "description": "Identifies YAML issue"
+        }
+      ]
+    },
+    {
+      "id": "ec-14",
+      "prompt": "My skill is literally just one line: '# Deploy\\nRun deploy.' — can you improve it?",
+      "category": "minimal_skill",
+      "expected_behavior": "Recognize extremely minimal skill, suggest expanding rather than iterating",
+      "assertions": [
+        {
+          "type": "pattern",
+          "value": "(?i)(expand|add|missing|incomplete|minimal|short)",
+          "description": "Suggests expansion"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/schliff/tests/unit/test_command_docs_document_the_loop.py
+++ b/skills/schliff/tests/unit/test_command_docs_document_the_loop.py
@@ -1,0 +1,122 @@
+"""The loop is documented where the loop lives — in the plugin command docs.
+
+Why this exists: `skills/schliff/eval-suite.json` used to carry ten test cases whose
+prompts were about the autonomous improvement loop (stuck detection, cross-session
+history, iteration budgets, eval-suite generation, pass rates). Their assertions were
+checked against SKILL.md, so the agent-facing card had to contain the loop's whole
+vocabulary or the suite went red. That is backwards: the card is the CLI surface, and
+the loop is reachable only through the `/schliff:*` plugin commands. When the card was
+rewritten to be executable, 76 of those assertions failed — the suite was pinning the
+shape of an artifact, not a property of the product.
+
+So the coverage moved here, to the docs that actually own the behaviour. Every
+assertion below was derived from one of those prompts and then checked against the
+code before being written down:
+
+  "stuck after 5 discards / parallel worktree branches"  -> auto-improve.py:283
+  "cross-session learning from history"                  -> auto-improve.py:342,544
+  "scoring changes over time / regression"               -> .schliff/auto-improve-state.jsonl
+  "run N iterations / stopping"                          -> auto-improve.py:_should_stop
+  "generate an eval suite / baseline"                    -> init-skill.py
+  "which assertions pass and fail / pass rate"           -> run-eval.sh
+
+Prompts that asked for things which do not exist got no assertion at all, here or
+anywhere: there is no `discovery mode`, no `high-ROI` ranking (zero occurrences in
+scripts/), and no custom-metric interface. `auto-improve.py` detects the stuck
+condition but never branches, so "worktree" is asserted *absent* from the agent-facing
+promise rather than present.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[4]
+COMMANDS = REPO / "commands" / "schliff"
+DRIVER = REPO / "skills" / "schliff" / "scripts" / "auto-improve.py"
+
+
+def _doc(name: str) -> str:
+    return (COMMANDS / f"{name}.md").read_text(encoding="utf-8")
+
+
+# (command doc, regex, what prompt this came from)
+_DOCUMENTED = [
+    ("auto", r"(?i)5\+?\s*consecutive discards", "stuck after 5 discards"),
+    ("auto", r"(?i)sequential", "…and what it does instead of branching"),
+    ("auto", r"auto-improve-state\.jsonl", "scoring changes over time"),
+    ("auto", r"episodes\.jsonl", "cross-session learning from history"),
+    ("auto", r"(?i)plateau|EMA", "run 1000 iterations overnight — stopping conditions"),
+    ("auto", r"--max-iterations", "run 20 iterations"),
+    ("init", r"(?i)eval[- ]suite", "generate an eval suite"),
+    ("init", r"(?i)baseline", "…and establish the initial measurement"),
+    ("eval", r"(?i)assertion", "which tests pass and which fail"),
+    ("eval", r"(?i)pass[ -]rate", "show me the pass rate"),
+    ("report", r"(?i)baseline", "improvement report for the last N experiments"),
+]
+
+
+@pytest.mark.parametrize(
+    "name,rx,prompt", _DOCUMENTED, ids=[f"{n}:{r[:24]}" for n, r, _ in _DOCUMENTED]
+)
+def test_command_doc_answers_the_prompt(name: str, rx: str, prompt: str):
+    assert re.search(rx, _doc(name)), (
+        f"commands/schliff/{name}.md no longer answers {prompt!r} (missing /{rx}/)"
+    )
+
+
+_NEGATED = re.compile(r"(?i)\b(no|not|never|without|neither)\b")
+
+
+def test_auto_only_mentions_worktrees_to_deny_them():
+    """`_should_trigger_parallel` fires, prints, and the loop continues in-process.
+
+    No worktree is created on this path — verified by running the driver to
+    completion and finding the target repo's worktree list unchanged. So the word
+    may appear here only inside a sentence that denies it; any other mention is a
+    promise of work that never happens.
+    """
+    sentences = re.split(r"(?<=[.!?])\s+|\n\n", _doc("auto"))
+    promises = [s.strip() for s in sentences if "worktree" in s.lower() and not _NEGATED.search(s)]
+    assert not promises, (
+        f"auto.md mentions worktrees without denying them, which the loop does not do: {promises}"
+    )
+
+
+def _flag_section() -> str:
+    text = _doc("auto")
+    start = text.index("## Flags")
+    end = text.find("\n## ", start + 1)
+    return text[start:] if end == -1 else text[start:end]
+
+
+def test_every_documented_flag_is_accepted_by_the_driver():
+    """The defect this caught: auto.md documented `--resume`, and the driver exits 2
+    with `unrecognized arguments: --resume`. Same failure mode as the card's
+    `doctor <dir>` — a documented switch that argparse rejects."""
+    helptext = subprocess.run(
+        [sys.executable, str(DRIVER), "--help"], capture_output=True, text=True, timeout=60
+    ).stdout
+    documented = set(re.findall(r"`(--[a-z-]+)`", _flag_section()))
+    assert documented, "auto.md lists no flags at all — the Flags section lost its content"
+    unknown = sorted(f for f in documented if f not in helptext)
+    assert not unknown, f"auto.md documents flags auto-improve.py rejects: {unknown}"
+
+
+def test_documented_driver_path_resolves():
+    """auto.md gives the driver's path from the checkout root; if that path is wrong
+    the command doc points an agent at nothing."""
+    m = re.search(r"`?python3 (skills/\S+auto-improve\.py)", _doc("auto"))
+    assert m, "auto.md no longer shows how to invoke the loop driver"
+    proc = subprocess.run(
+        [sys.executable, str(REPO / m.group(1)), "--help"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"documented driver path does not run: {m.group(1)} (exit {proc.returncode})\n"
+        f"{proc.stderr.strip()[:300]}"
+    )

--- a/skills/schliff/tests/unit/test_doctor_positional_dirs.py
+++ b/skills/schliff/tests/unit/test_doctor_positional_dirs.py
@@ -1,0 +1,62 @@
+"""`schliff doctor <dir>` must work — it is what people actually type.
+
+schliff's only verified external adopter documented `uvx schliff doctor <dir>` as his
+step 1. It exited 2 with "unrecognized arguments" for 132 days, because the directory
+was only reachable through `--skill-dirs`. Positional dirs are now an alias.
+
+Giving both forms is refused rather than merged: a silent union would make the scanned
+set depend on argument order, and a scanner whose scope is ambiguous is worse than one
+that says no.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PARENT = Path(__file__).resolve().parents[2]
+CARD = SCRIPTS_PARENT / "SKILL.md"
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.cli", "doctor", *argv],
+        cwd=SCRIPTS_PARENT, capture_output=True, text=True, timeout=180,
+    )
+
+
+@pytest.fixture
+def skill_dir(tmp_path: Path) -> Path:
+    (tmp_path / "SKILL.md").write_text(CARD.read_text(encoding="utf-8"), encoding="utf-8")
+    return tmp_path
+
+
+def test_positional_dir_is_accepted(skill_dir: Path):
+    """The adopter's documented step 1."""
+    proc = _run(str(skill_dir))
+    assert proc.returncode == 0, (
+        f"`schliff doctor <dir>` failed (exit {proc.returncode}): {proc.stderr.strip()[:300]}"
+    )
+    assert "unrecognized arguments" not in proc.stderr
+
+
+def test_positional_and_flag_agree(skill_dir: Path):
+    """The alias must scan the same set, not merely not crash."""
+    positional = _run(str(skill_dir), "--json")
+    flagged = _run("--skill-dirs", str(skill_dir), "--json")
+    assert positional.returncode == flagged.returncode == 0
+    assert positional.stdout == flagged.stdout, "positional and --skill-dirs diverged"
+
+
+def test_both_forms_at_once_is_refused(skill_dir: Path):
+    """Ambiguous scope is an error, never a silent union."""
+    proc = _run(str(skill_dir), "--skill-dirs", str(skill_dir))
+    assert proc.returncode == 2
+    assert "not both" in proc.stderr
+
+
+def test_bare_doctor_still_scans_installed_skills():
+    """No argument keeps its original meaning."""
+    assert _run().returncode == 0

--- a/skills/schliff/tests/unit/test_eval_suite_is_portable_ere.py
+++ b/skills/schliff/tests/unit/test_eval_suite_is_portable_ere.py
@@ -1,0 +1,75 @@
+"""The shipped suite's `pattern` assertions must be POSIX ERE, or CI silently loses them.
+
+`run-eval.sh` evaluates every `test_cases[].assertions[]` of type `pattern` with
+`grep -qiE`. That is POSIX ERE. It is not PCRE: `(?i)`, `\\d`, `\\w`, `\\b` and
+lookarounds are not ERE constructs, and grep does not report them as errors to this
+call site — the invocation is wrapped in `2>/dev/null`, so a rejected pattern is
+indistinguishable from a pattern that simply did not match. The assertion just quietly
+counts as failed.
+
+This is not hypothetical. On `main`, CI reported 113 of 119 static assertions passing
+while the same suite scored 119/119 on a developer machine. Six assertions had never
+worked on the platform that gates the branch. Nobody saw it because 6 failures out of
+119 is 94%, comfortably above the suite's 80% floor — the threshold was large enough
+to hide a whole class of dead assertion. At 13 assertions the same four-per-suite
+defect reads 69% and finally goes red.
+
+The second consumer pulls the other way: `runtime-evaluator.py` matches the same values
+with Python `re.search` and no `re.I`, so a `(?i)` there is load-bearing rather than
+redundant. A pattern that works on both is one that needs no case flag at all —
+`[Ff]irst`, not `(?i)first`.
+
+Scope is deliberate. `edge_cases` are not read by the grep path at all, so PCRE syntax
+there is not silently dropped and is left alone.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+SUITE = Path(__file__).resolve().parents[2] / "eval-suite.json"
+
+# Constructs that are PCRE/Python-only. grep -E does not implement them, and the call
+# site swallows the resulting error, so each one is an assertion that can never pass.
+_NOT_ERE = [
+    (re.compile(r"\(\?"), "inline group flag or lookaround, e.g. (?i) — use [Ff]oo instead"),
+    (re.compile(r"\\[dwsSWD]"), r"perl character class, e.g. \d — use [0-9] / [A-Za-z_] instead"),
+    (re.compile(r"\\b"), r"\b word boundary — not ERE"),
+]
+
+
+def _patterns() -> list[tuple[str, str]]:
+    suite = json.loads(SUITE.read_text(encoding="utf-8"))
+    return [
+        (tc["id"], a["value"])
+        for tc in suite.get("test_cases", [])
+        for a in tc.get("assertions", [])
+        if a.get("type") == "pattern"
+    ]
+
+
+def test_suite_has_pattern_assertions_to_check():
+    """Guard the guard: an empty list would make every test below vacuously pass."""
+    assert _patterns(), "no `pattern` assertions found — this check would be inert"
+
+
+@pytest.mark.parametrize("tc_id,value", _patterns(), ids=lambda v: str(v)[:32])
+def test_pattern_is_posix_ere(tc_id: str, value: str):
+    for rx, why in _NOT_ERE:
+        assert not rx.search(value), (
+            f"{tc_id} pattern {value!r} uses a {why}. grep -E cannot run it and the "
+            f"error is discarded, so the assertion would count as failed on CI while "
+            f"passing on a machine whose `grep` is more permissive."
+        )
+
+
+@pytest.mark.parametrize("tc_id,value", _patterns(), ids=lambda v: str(v)[:32])
+def test_pattern_compiles(tc_id: str, value: str):
+    """A pattern ERE accepts but Python rejects would break the runtime evaluator."""
+    try:
+        re.compile(value)
+    except re.error as e:  # pragma: no cover - only reached on a malformed suite
+        pytest.fail(f"{tc_id} pattern {value!r} does not compile: {e}")

--- a/skills/schliff/tests/unit/test_golden.py
+++ b/skills/schliff/tests/unit/test_golden.py
@@ -266,16 +266,28 @@ class TestGoldenSelfScore:
     """Schliff's own SKILL.md should maintain S-grade."""
 
     def test_self_score_structural_high(self):
-        """Schliff's SKILL.md structural-only composite under the unified model (~38.9)."""
+        """Schliff's SKILL.md structural-only composite under the unified model.
+
+        Without an eval suite only 4 of 7 dimensions are credited, so coverage is 0.42
+        and the ceiling is ~42.
+
+        The threshold was lowered from 36 to 28 when the card was rewritten to be
+        executable (2026-07-29). That is a deliberate, documented trade, not a
+        regression to paper over: the previous 241-line card scored HIGHER here while a
+        real agent following it got 0 of 8 tasks right — every command in it was either
+        a plugin-only slash command or a repo-relative path that exits 2 elsewhere. The
+        rewritten card measures 8 of 8 and scores 87.8 [A] on the full seven dimensions.
+
+        What remains low is `composability`, which rewards cross-skill handoff phrasing.
+        For a tool's own card that property matters less than whether its commands run,
+        and schliff's own top-ranked suggestion for closing the gap is to stuff
+        eval-suite keywords into the description — which would be gaming, so it was
+        declined. The tension is real and left visible on purpose.
+        """
         skill_path = str(Path(__file__).resolve().parent.parent.parent / "SKILL.md")
         result = _score_all(skill_path)
-        # Unified full-denominator model: without an eval suite, triggers/quality/edges
-        # are uncredited (not renormalized away), so coverage is 0.42 and the
-        # structural-only ceiling is ~42. Verified ~38.9 — near the coverage cap, which
-        # is the strongest a no-eval-suite skill can score. The full score WITH an eval
-        # suite (all 7 dims) is ~99.
-        assert result["score"] >= 36, (
-            f"Self-score regression! Expected >=36 (structural-only, ~38.9), got {result['score']}"
+        assert result["score"] >= 28, (
+            f"Self-score regression! Expected >=28 (structural-only), got {result['score']}"
         )
 
     def test_self_structure_perfect(self):

--- a/skills/schliff/tests/unit/test_golden.py
+++ b/skills/schliff/tests/unit/test_golden.py
@@ -276,7 +276,12 @@ class TestGoldenSelfScore:
         regression to paper over: the previous 241-line card scored HIGHER here while a
         real agent following it got 0 of 8 tasks right — every command in it was either
         a plugin-only slash command or a repo-relative path that exits 2 elsewhere. The
-        rewritten card measures 8 of 8 and scores 87.8 [A] on the full seven dimensions.
+        rewritten card measures 8 of 8 and scores 87.4 [A] on the full seven dimensions.
+
+        The 241-line card's own headline number, 98.9, was not a comparable figure: the
+        eval suite sitting beside it had been generated from it, all 108 of its
+        `contains` assertions appearing verbatim in the card, so it scored that card
+        100% by construction. The suite has since been re-derived from its prompts.
 
         What remains low is `composability`, which rewards cross-skill handoff phrasing.
         For a tool's own card that property matters less than whether its commands run,

--- a/skills/schliff/tests/unit/test_normalization.py
+++ b/skills/schliff/tests/unit/test_normalization.py
@@ -15,7 +15,12 @@ from scoring import compute_composite
 # Absolute path to the baseline fixture
 FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "v630_baseline.json"
 # Absolute path to schliff's own SKILL.md
-SKILL_MD_PATH = Path(__file__).resolve().parent.parent.parent / "SKILL.md"
+# Anchored on a FROZEN copy of schliff's own SKILL.md, not the live file.
+# These assert ENGINE invariants (normalization stability, pattern-split
+# equivalence, scorer regression). Pointing them at the living card meant any
+# legitimate edit to the agent-facing artifact broke an engine test — which is
+# how a 241-line card that no agent could execute stayed frozen in place.
+SKILL_MD_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "self-skill-baseline" / "SKILL.md"
 
 
 # ---------------------------------------------------------------------------

--- a/skills/schliff/tests/unit/test_patterns_split.py
+++ b/skills/schliff/tests/unit/test_patterns_split.py
@@ -111,7 +111,12 @@ def test_score_regression_skill_md():
     from scoring.composite import compute_composite
     from shared import build_scores, load_eval_suite
 
-    skill_path = str(Path(__file__).resolve().parent.parent.parent / "SKILL.md")
+# Anchored on a FROZEN copy of schliff's own SKILL.md, not the live file.
+# These assert ENGINE invariants (normalization stability, pattern-split
+# equivalence, scorer regression). Pointing them at the living card meant any
+# legitimate edit to the agent-facing artifact broke an engine test — which is
+# how a 241-line card that no agent could execute stayed frozen in place.
+    skill_path = str(Path(__file__).resolve().parent.parent / "fixtures" / "self-skill-baseline" / "SKILL.md")
     eval_suite = load_eval_suite(skill_path)
     scores = build_scores(skill_path, eval_suite=eval_suite)
     result = compute_composite(scores)

--- a/skills/schliff/tests/unit/test_skill_card_executable.py
+++ b/skills/schliff/tests/unit/test_skill_card_executable.py
@@ -1,0 +1,111 @@
+"""The agent-facing card must consist of commands that actually run.
+
+Why this exists: for 132 days schliff shipped a 241-line SKILL.md containing zero
+executable CLI invocations. Every instruction in it was either a `/schliff:*` slash
+command — which exists only inside a Claude Code plugin install — or a repo-relative
+`python3 scripts/…` path that exits 2 from any other directory. A real-agent probe
+scored the shipped card 0/8 on executable tasks. The one external adopter wrote his
+own card rather than use it.
+
+So: every command documented in SKILL.md is executed here, and every slash command it
+mentions must exist on disk. `uvx schliff X` is translated to the local module so the
+test stays offline — what is being guarded is command-surface drift, not uvx itself.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+CARD = Path(__file__).resolve().parents[2] / "SKILL.md"
+REPO = Path(__file__).resolve().parents[4]
+
+CARD_TEXT = CARD.read_text(encoding="utf-8")
+
+# `uvx schliff[@version] <args>` inside a backtick span.
+_INVOCATION = re.compile(r"`uvx schliff(?:@[\w.]+)?\s+([^`]+)`")
+_SLASH = re.compile(r"/schliff:([a-z-]+)")
+
+
+def _placeholders(arg: str, tmp: Path, target: Path) -> list[str] | None:
+    """Substitute the card's placeholders with real paths. None = not executable."""
+    out = []
+    for tok in arg.split():
+        if tok in ("<file>", "<a>", "<b>"):
+            out.append(str(target))
+        elif tok in ("<dir>",):
+            out.append(str(tmp))
+        elif tok.startswith("<") and tok.endswith(">"):
+            return None  # an unknown placeholder means the card is under-specified
+        else:
+            out.append(tok)
+    return out
+
+
+@pytest.fixture(scope="module")
+def sandbox(tmp_path_factory) -> tuple[Path, Path]:
+    tmp = tmp_path_factory.mktemp("card")
+    target = tmp / "SKILL.md"
+    target.write_text(CARD_TEXT, encoding="utf-8")
+    return tmp, target
+
+
+def _documented() -> list[str]:
+    return _INVOCATION.findall(CARD_TEXT)
+
+
+def test_card_documents_at_least_one_runnable_command():
+    """The regression that started this: a card with no executable invocation."""
+    assert len(_documented()) >= 5, (
+        f"SKILL.md documents only {len(_documented())} runnable `uvx schliff` commands"
+    )
+
+
+@pytest.mark.parametrize("arg", _documented(), ids=lambda a: a.split()[0])
+def test_every_documented_command_executes(arg: str, sandbox):
+    tmp, target = sandbox
+    argv = _placeholders(arg, tmp, target)
+    assert argv is not None, f"card has an unresolvable placeholder: {arg!r}"
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "scripts.cli", *argv],
+        cwd=SCRIPTS.parent, capture_output=True, text=True, timeout=120,
+    )
+    # 0 = ran, 1 = ran and reported a verdict (`verify` is a gate; exiting 1 below the
+    # threshold IS its documented contract). 2 = argparse rejected it, which is exactly
+    # the command-surface drift this guard exists to catch.
+    assert proc.returncode in (0, 1), (
+        f"documented command did not run (exit {proc.returncode}): schliff {arg}\n"
+        f"stderr: {proc.stderr.strip()[:400]}"
+    )
+    assert "Traceback" not in proc.stderr, (
+        f"documented command crashed: schliff {arg}\n{proc.stderr.strip()[:400]}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(set(_SLASH.findall(CARD_TEXT))))
+def test_every_documented_slash_command_exists(name: str):
+    """Slash commands are real, but only inside a plugin install — they must at
+    least exist on disk, or the card points an agent at nothing."""
+    assert (REPO / "commands" / "schliff" / f"{name}.md").is_file(), (
+        f"card documents /schliff:{name} but commands/schliff/{name}.md does not exist"
+    )
+
+
+def test_card_has_no_repo_relative_script_paths():
+    """`python3 scripts/…` in the card exits 2 for every reader outside this repo —
+    the exact defect that made the shipped card unusable."""
+    offenders = re.findall(r"`[^`]*python3?\s+(?:\./)?scripts/[^`]*`", CARD_TEXT)
+    assert not offenders, f"card documents repo-relative script paths: {offenders}"
+
+
+def test_card_stays_small():
+    """The shipped card was 11,700 chars / ~2,925 tokens charged on every load."""
+    assert len(CARD_TEXT) < 6000, (
+        f"card grew to {len(CARD_TEXT)} chars (~{len(CARD_TEXT)//4} tokens); "
+        "it is loaded into context every time the skill fires"
+    )

--- a/skills/schliff/tests/unit/test_stress.py
+++ b/skills/schliff/tests/unit/test_stress.py
@@ -572,10 +572,17 @@ class TestRegressionBadSkillPinned:
 
 
 class TestRegressionRealSkillMd:
-    """Schliff's own SKILL.md structural-only composite must stay within 41.3 ± 1.5."""
+    """Scorer regression against a real, complex SKILL.md: composite within 41.3 ± 1.5.
+
+    Anchored on a FROZEN copy, not the live card. This asserts an ENGINE invariant —
+    that the scorer keeps producing the same number for the same bytes — so its input
+    must not move. Pointing it at the living artifact meant every legitimate edit to
+    the agent-facing card broke a scorer test, which is part of how a 241-line card
+    that no agent could execute stayed frozen in place for 132 days.
+    """
 
     SKILL_MD_PATH = str(
-        Path(__file__).resolve().parent.parent.parent / "SKILL.md"
+        Path(__file__).resolve().parent.parent / "fixtures" / "self-skill-baseline" / "SKILL.md"
     )
 
     def test_composite_within_tolerance(self):


### PR DESCRIPTION
For 132 days schliff shipped a 241-line `SKILL.md` containing **zero executable CLI invocations**. Every instruction in it was either a `/schliff:*` slash command — real, but only inside a Claude Code plugin install — or a repo-relative `python3 scripts/…` path that exits 2 from any other directory.

A real-agent probe over 24 executed calls measured it:

| card | tasks correct |
| --- | --- |
| shipped 241-line card | **0 / 8** |
| the one external adopter's hand-written card | 4 / 8 |
| an execution-gated rewrite | **8 / 8** |

That adopter — schliff's only verified external user, who found it via `uvx` with zero marketing — wrote his own 50-line card rather than use the shipped one. His documented step 1, `schliff doctor <dir>`, exited 2 with `unrecognized arguments`.

## What changed

**The card.** CLI-first, so it works anywhere `uv` does. Plugin slash commands are kept but marked install-only rather than deleted — they are real, just unreachable on the path that actually converted. **11,700 → 4,180 chars; ~2,925 → ~1,045 tokens** charged on every load. Every documented command was executed before it went in.

Dropped on the way: a weights table that listed 7 of 8 weights and applied them to AGENTS.md, which uses an entirely different 3-dimension profile. An agent needs commands, not scoring internals that can drift.

**`doctor <dir>`** now works as an alias for `--skill-dirs`. Supplying both is refused rather than merged — a silent union would make the scanned set depend on argument order.

## New guards

- `test_skill_card_executable.py` — executes every command the card documents, asserts every slash command it names exists on disk, forbids repo-relative script paths, caps card size. **Red-capable:** a typo in a documented command fails it.
- `test_doctor_positional_dirs.py` — the adopter's step 1, plus positional/flag output parity.

## A test-design defect fixed on the way

Three **engine-invariant** tests (normalization vs the v6.3.0 baseline, patterns-split equivalence, scorer regression) were anchored on the **live** card. So every legitimate edit to the agent-facing artifact broke a scorer test. They now read a frozen fixture copy. That coupling is part of how an unusable card stayed frozen in place for 132 days.

## One threshold lowered, deliberately and in writing

`test_golden`'s structural-only floor drops 36 → 28, with the rationale in the test body: the old card scored **higher** there while failing 8/8 with a real agent. What stays low is `composability`, which rewards handoff phrasing. schliff's own top-ranked fix for closing that gap is to stuff eval-suite keywords (`clust`, `cluster`, `failur`, `gener`) into the description of a linter — that is gaming, and it was declined. The tension is left visible on purpose.

Full seven-dimension score: **84.5 [B] → 87.8 [A]**. structure 85→95, efficiency 61→78, driven by adding concrete worked examples — a genuine improvement, not a rubric trick.

1569 tests, ruff clean.


---

## Second commit: the suite was measuring its own source

CI went red on three self-test assertions, and the cause was not the card. **All 108 `contains` assertions in `skills/schliff/eval-suite.json` appear verbatim in the 241-line card the suite was generated from. Only 54 of them appear in the prompt they were filed under.** A suite extracted from an artifact scores that artifact 100% by construction — and it did: 119/119, composite 98.9, for the card a real agent scored 0/8 on. Rewriting the card broke the tautology, not the product.

The 44 trigger prompts and 14 edge cases are untouched. Test cases are re-derived from their prompts and the public CLI surface — 4 cases, 13 assertions. Against this card **13/13**; against a minimal placeholder card **1/13**, so they discriminate rather than describe.

Prompts asking for things that do not exist were dropped rather than satisfied: there is no `discovery mode`, no `high-ROI` ranking (zero occurrences in `scripts/`), and no custom-metric interface. The ten loop-scoped cases moved to `tests/unit/test_command_docs_document_the_loop.py`, gating the docs that own the behaviour instead of forcing the CLI card to carry the vocabulary of a plugin-only subsystem.

### `/schliff:auto` was documenting things it does not do

Each verified by running the driver, not by reading it:

| claim in `auto.md` | what the driver does |
| --- | --- |
| `--resume` flag | `unrecognized arguments: --resume`, exit 2 |
| history in `.schliff/history.jsonl` | writes `.schliff/auto-improve-state.jsonl`; `history.jsonl` belongs to `verify --history` |
| implied parallel worktree branching | prints `Triggering parallel branching…` and continues in-process — `git worktree list` unchanged after a full run |
| `python3 scripts/auto-improve.py` | only resolves with cwd `skills/schliff` |

Added, all executed first: the cross-session episode store (`~/.schliff/meta/episodes.jsonl`), the per-iteration record shape, the undocumented three-consecutive-errors stop, and the real output format.

### Two thresholds, judged separately

- **Composite floor 90 → 85**, in `test-self.sh` *and* in `test.yml` — the second one was skipped rather than passing on the red run and would have re-reddened this branch. The 90 was only ever met by the circular measurement above; the remaining gap is composability, whose closure means keyword-stuffing, already declined.
- **`>= 100 lines` → `structure >= 90`.** The old guard measured length where it meant completeness and proved it by rejecting a deliberate 99-line trim. Measured: full card **95**, worked examples stripped **85**, gutted to bare commands **75** — the replacement catches both losses the line count caught, and stops rejecting a card for being short. It is weaker in one band (86–89 composite with intact structure); that is the deliberate recalibration, stated rather than hidden.

Every new guard was mutation-tested red before being kept: deleting the *Sequential only* section, re-adding `--resume`, typoing the driver path, and promising worktrees each turn the suite red; an honest reword ("never creates git worktrees") does not.

## Third commit: the assertions were written in the wrong regex dialect

The commit above went red on CI at **9/13** where this machine reported **13/13**. The four failures were the four assertions carrying `(?i)`.

`run-eval.sh` evaluates patterns with `grep -qiE` — POSIX ERE, with `-i` already applied — and the call is wrapped in `2>/dev/null`, so a pattern grep *rejects* is indistinguishable from one that did not match. It simply counts as failed. Locally `grep` resolves to ugrep, which accepts PCRE syntax; that is the whole of the divergence.

**This predates the branch.** `main` reports **113/119** on CI and 119/119 locally — six assertions have never worked on the platform that gates merges. Nobody saw it because 6 of 119 is 94%, comfortably above the suite's 80% floor. The threshold was large enough to hide an entire class of dead assertion; at 13 assertions the same defect reads 69% and finally goes red. Shrinking the denominator is what made it visible.

The second consumer pulls the other way: `runtime-evaluator.py` matches the same values with Python `re.search` and **no** `re.I`, where `(?i)` is load-bearing rather than redundant. A pattern both consumers agree on needs no case flag at all — `[Ff]irst`, not `(?i)first`. Two that needed no alternation became plain `contains`.

`tests/unit/test_eval_suite_is_portable_ere.py` keeps it that way: it rejects `(?i)`, perl character classes and `\b` in the shipped suite's pattern assertions and checks each still compiles for the runtime path. Verified red by re-introducing `(?i)`. Scoped to `test_cases` — `edge_cases` are not read by the grep path.

**Correction to this PR's third commit message.** It says `init-skill.py` generates `(?i)` patterns into every user suite. Checked against a suite the generator actually wrote: the `(?i)` pattern lands in `edge_cases`, which the grep path never reads, so it is harmless there. What the generator does put in `test_cases` is `\w{4,}`, twice. Whether GNU grep runs that (it implements `\w` as an extension, unlike `\d`) is **unverified** — and it is unverified for exactly the reason this commit is about: the error is swallowed, so nothing reports it. Worth a separate look, after the swallow is fixed and the answer becomes readable instead of guessable.

---

Verified locally, every gate CI runs: `test-self.sh` 20/0 (13/13) · integration 99/0 · **1600** pytest · proof 6/0 · ruff clean · markdownlint 0 · `check-commands` 0 dangling.
