### PR TITLE
feat(manifest): report what a Claude Code install actually loads

### DIFF
--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -423,6 +423,22 @@ def cmd_doctor(args: argparse.Namespace) -> None:
         print(formatted)
 
 
+def cmd_manifest(args: argparse.Namespace) -> None:
+    """Report the resolved artifact set. Emits no score — this reports state."""
+    import manifest as manifest_mod
+
+    m = manifest_mod.build_manifest(
+        claude_dir=getattr(args, "claude_dir", None),
+        project_dir=getattr(args, "project", None),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(manifest_mod.manifest_to_dict(m), indent=2))
+    else:
+        print(manifest_mod.format_manifest(m))
+    if getattr(args, "strict", False) and m.findings:
+        raise SystemExit(1)
+
+
 def cmd_badge(args: argparse.Namespace) -> None:
     """Generate a markdown badge for a skill's score."""
     import urllib.parse
@@ -1049,6 +1065,18 @@ def main():
     doctor_parser.add_argument("--repo", default=None,
                                help="Repository root for instruction file discovery")
 
+    # manifest command — resolved agent state, no score
+    manifest_parser = subparsers.add_parser(
+        "manifest",
+        help="Report what this Claude Code install actually loads and what it costs")
+    manifest_parser.add_argument("--json", action="store_true", help="JSON output")
+    manifest_parser.add_argument("--project", default=None, metavar="DIR",
+                                 help="Also resolve a project's .claude/ directory")
+    manifest_parser.add_argument("--claude-dir", default=None, metavar="DIR",
+                                 help="Override the Claude config dir (default ~/.claude)")
+    manifest_parser.add_argument("--strict", action="store_true",
+                                 help="Exit 1 if any finding is reported")
+
     # badge command
     badge_parser = subparsers.add_parser("badge", help="Generate markdown badge for a skill")
     badge_parser.add_argument("skill_path", help=_PATH_HELP)
@@ -1131,6 +1159,7 @@ def main():
         "verify": cmd_verify,
         "check-commands": cmd_check_commands,
         "doctor": cmd_doctor,
+        "manifest": cmd_manifest,
         "badge": cmd_badge,
         "suggest": cmd_suggest,
         "report": cmd_report,

--- a/skills/schliff/scripts/manifest.py
+++ b/skills/schliff/scripts/manifest.py
@@ -1,0 +1,362 @@
+"""Resolve what a Claude Code install actually loads, and what it costs per turn.
+
+Every other tool in this space lints a FILE. This reads the resolved state:
+`settings.json` x `installed_plugins.json` x on-disk skill and command roots x
+frontmatter, and answers three questions nobody else answers —
+
+  * which artifacts are actually loaded right now,
+  * what they charge against the context window on every single turn,
+  * which ones are installed but silently never load.
+
+Design constraints, each one learned the hard way:
+
+* **No hardcoded roster of harness built-ins.** A prototype carried one, hand-copied
+  from a single live session and marked "undocumented upstream, will drift". A tool
+  that reports resolved state and misclassifies silently is worse than no tool. Only
+  artifacts found on disk under a known root are reported; nothing is inferred.
+* **Cost is the SKILL.md plus its `references/*.md`, never the directory.** One real
+  skill directory here holds a 200 MB virtualenv; measuring the tree would report
+  tens of millions of tokens for a file that charges a few hundred.
+* **No scoring.** This command emits no grade. It reports state.
+* **Read-only, local, and quiet about identity.** Paths print relative to `~`.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HOME = Path.home()
+
+_FM = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.S)
+_KV = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):[ \t]*(.*)$")
+
+# Rough chars-per-token. schliff uses the same approximation elsewhere; the number
+# only needs to be stable and honest about being an estimate.
+_CHARS_PER_TOKEN = 4
+
+
+def _tilde(p: str | Path) -> str:
+    s = str(p)
+    h = str(HOME)
+    return "~" + s[len(h):] if s.startswith(h) else s
+
+
+def parse_frontmatter(path: Path) -> tuple[dict, str]:
+    """Flat-key frontmatter parse with block-scalar support.
+
+    Deliberately regex-based rather than pyyaml: pyyaml is absent from a stock
+    Python and from schliff's own environment, and schliff parses frontmatter this
+    way everywhere else. A silent ImportError here would make findings vanish.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}, ""
+    m = _FM.match(text)
+    if not m:
+        return {}, text
+
+    out: dict[str, object] = {}
+    block_key: str | None = None
+    block: list[str] = []
+    for line in m.group(1).split("\n"):
+        if block_key is not None:
+            if line.strip() and line[:1] in (" ", "\t"):
+                block.append(line.strip())
+                continue
+            out[block_key] = " ".join(block)
+            block_key, block = None, []
+        kv = _KV.match(line)
+        if not kv:
+            continue
+        key, val = kv.group(1), kv.group(2).strip()
+        if val in (">", "|", ">-", "|-"):
+            block_key, block = key, []
+            continue
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'":
+            val = val[1:-1]
+        if val.lower() in ("true", "false"):
+            out[key] = val.lower() == "true"
+        else:
+            out[key] = val
+    if block_key is not None:
+        out[block_key] = " ".join(block)
+    return out, text[m.end():]
+
+
+def invoke_cost_chars(skill_md: Path) -> int:
+    """Characters pulled into context when this artifact loads.
+
+    The SKILL.md itself plus any `references/*.md` beside it — not the directory.
+    """
+    total = 0
+    try:
+        total += skill_md.stat().st_size
+    except OSError:
+        return 0
+    refs = skill_md.parent / "references"
+    if refs.is_dir() and not refs.is_symlink():
+        for f in sorted(refs.iterdir()):
+            if f.suffix == ".md" and f.is_file():
+                try:
+                    total += f.stat().st_size
+                except OSError:
+                    pass
+    return total
+
+
+@dataclass
+class Artifact:
+    name: str
+    kind: str          # "skill" | "command"
+    source: str        # "user" | "project" | plugin name
+    path: str          # tilde-relative
+    chars: int         # body + references: charged only when the artifact FIRES
+    desc_chars: int    # the description: charged on EVERY turn, for selection
+    fm_name: str | None = None
+
+    @property
+    def tokens(self) -> int:
+        """Invoke cost — what it costs when this artifact actually fires."""
+        return self.chars // _CHARS_PER_TOKEN
+
+    @property
+    def resident_tokens(self) -> int:
+        """Resident cost — the description, carried on every single turn."""
+        return self.desc_chars // _CHARS_PER_TOKEN
+
+
+@dataclass
+class Finding:
+    kind: str          # "disabled" | "no-skill-md" | "nested" | "duplicate-name"
+    subject: str
+    detail: str
+
+
+@dataclass
+class Manifest:
+    loaded: list[Artifact] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def resident_tokens(self) -> int:
+        """What this install charges the context window on every turn."""
+        return sum(a.resident_tokens for a in self.loaded)
+
+    @property
+    def invoke_tokens(self) -> int:
+        """What it would cost if every loaded artifact fired. Not a per-turn cost —
+        conflating the two overstates the bill by ~45x on a real install."""
+        return sum(a.tokens for a in self.loaded)
+
+
+def _scan_skill_root(root: Path, prefix: str, source: str, out: Manifest) -> None:
+    if not root.is_dir():
+        return
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir() or entry.is_symlink():
+            continue
+        skill_md = entry / "SKILL.md"
+        name = f"{prefix}{entry.name}"
+        if not skill_md.is_file():
+            out.findings.append(Finding(
+                "no-skill-md", name, "directory has no SKILL.md — it never loads"))
+            continue
+        fm, _ = parse_frontmatter(skill_md)
+        if fm.get("disable-model-invocation") is True:
+            out.findings.append(Finding(
+                "disabled", name, "frontmatter disable-model-invocation: true"))
+            continue
+        out.loaded.append(Artifact(
+            name=name, kind="skill", source=source, path=_tilde(skill_md),
+            chars=invoke_cost_chars(skill_md),
+            desc_chars=len(str(fm.get("description", ""))),
+            fm_name=fm.get("name") if isinstance(fm.get("name"), str) else None,
+        ))
+        # A SKILL.md nested deeper than one level never registers.
+        for sub in entry.rglob("SKILL.md"):
+            if sub != skill_md:
+                out.findings.append(Finding(
+                    "nested", _tilde(sub),
+                    "nested below a skill directory — it never registers"))
+
+
+def _scan_command_root(root: Path, prefix: str, source: str, out: Manifest) -> None:
+    if not root.is_dir():
+        return
+    for path in sorted(root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).with_suffix("")
+        segments = list(rel.parts)
+        if segments[-1].startswith("_"):
+            continue  # leading underscore is the partial/include convention
+        name = prefix + ":".join(segments)
+        fm, _ = parse_frontmatter(path)
+        if fm.get("disable-model-invocation") is True:
+            out.findings.append(Finding(
+                "disabled", name, "frontmatter disable-model-invocation: true"))
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        out.loaded.append(Artifact(
+            name=name, kind="command", source=source, path=_tilde(path), chars=size,
+            desc_chars=len(str(fm.get("description", "")))))
+
+
+def _enabled_plugins(claude_dir: Path) -> dict[str, bool]:
+    """`enabledPlugins` in settings.json is the authority on what is switched on.
+
+    Not `installed_plugins.json`'s scope field: a plugin installed at project scope
+    is still registered in an unrelated working directory, and a plugin present on
+    disk can be switched off per project. Reading the wrong file inverts the answer.
+    """
+    try:
+        data = json.loads((claude_dir / "settings.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    raw = data.get("enabledPlugins")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _resolve_plugin_dir(plugins_root: Path, package: str,
+                        marketplace: str) -> Path | None:
+    """Locate an enabled plugin's payload directory on disk.
+
+    The layout is not `plugins/<package>` — that guess reported thirteen working
+    plugins as missing on a live install. It is `plugins/cache/<marketplace>/<package>`,
+    sometimes with one extra version or content-hash segment beneath it
+    (`cache/openai-codex/codex/1.0.1/`, `cache/vault-sync/vault-sync/9904d91688b1/`),
+    and some marketplaces instead expose `plugins/marketplaces/<marketplace>/`.
+    Rather than encode which is which, descend one level while the payload is not
+    yet visible.
+    """
+    def has_payload(d: Path) -> bool:
+        return (d / "skills").is_dir() or (d / "commands").is_dir()
+
+    candidates = []
+    if marketplace:
+        candidates.append(plugins_root / "cache" / marketplace / package)
+        candidates.append(plugins_root / "marketplaces" / marketplace)
+    candidates.append(plugins_root / package)
+
+    for base in candidates:
+        if not base.is_dir():
+            continue
+        if has_payload(base):
+            return base
+        # One extra level: a version or content-hash segment. Several may coexist —
+        # a live install here holds vercel 0.44.0 AND 0.45.1. Taking the first by
+        # name silently resolves the STALE one, so take the newest by mtime and let
+        # the caller report the rest as superseded.
+        subdirs = [d for d in base.iterdir() if d.is_dir() and has_payload(d)]
+        if subdirs:
+            subdirs.sort(key=lambda d: d.stat().st_mtime, reverse=True)
+            return subdirs[0]
+    return None
+
+
+def _superseded_dirs(plugins_root: Path, package: str, marketplace: str,
+                     active: Path) -> list[Path]:
+    """Version directories of an enabled plugin that are on disk but not active."""
+    base = plugins_root / "cache" / marketplace / package if marketplace else None
+    if base is None or not base.is_dir() or active.parent != base:
+        return []
+    return [d for d in sorted(base.iterdir())
+            if d.is_dir() and d != active
+            and ((d / "skills").is_dir() or (d / "commands").is_dir())]
+
+
+def build_manifest(claude_dir: Path | None = None,
+                   project_dir: Path | None = None) -> Manifest:
+    """Resolve the effective artifact set. Pure disk + config; nothing inferred."""
+    claude_dir = Path(claude_dir) if claude_dir else HOME / ".claude"
+    out = Manifest()
+
+    _scan_skill_root(claude_dir / "skills", "", "user", out)
+    _scan_command_root(claude_dir / "commands", "", "user", out)
+
+    if project_dir:
+        proj = Path(project_dir) / ".claude"
+        _scan_skill_root(proj / "skills", "", "project", out)
+        _scan_command_root(proj / "commands", "", "project", out)
+
+    enabled = _enabled_plugins(claude_dir)
+    plugins_root = claude_dir / "plugins"
+    seen_packages: dict[str, str] = {}
+    for key, on in sorted(enabled.items()):
+        if on is not True:
+            continue
+        package, _, marketplace = key.partition("@")
+        pdir = _resolve_plugin_dir(plugins_root, package, marketplace)
+        if pdir is None:
+            # Enabled in settings but absent on disk — a real, silent no-op.
+            out.findings.append(Finding(
+                "no-skill-md", key, "enabled in settings.json but not present on disk"))
+            continue
+        if package in seen_packages:
+            out.findings.append(Finding(
+                "duplicate-name", package,
+                f"enabled twice ({seen_packages[package]} and {key}) — one wins silently"))
+            continue
+        seen_packages[package] = key
+        _scan_skill_root(pdir / "skills", f"{package}:", package, out)
+        _scan_command_root(pdir / "commands", f"{package}:", package, out)
+
+    # A name claimed by more than one artifact: only one of them is reachable.
+    by_name: dict[str, list[Artifact]] = {}
+    for a in out.loaded:
+        by_name.setdefault(a.name, []).append(a)
+    for name, group in sorted(by_name.items()):
+        if len(group) > 1:
+            kinds = " + ".join(f"{a.kind} {a.chars} B" for a in group)
+            out.findings.append(Finding(
+                "duplicate-name", name, f"claimed {len(group)}x ({kinds})"))
+
+    return out
+
+
+def format_manifest(m: Manifest, top: int = 5) -> str:
+    lines: list[str] = []
+    lines.append(f"{len(m.loaded)} artifacts loaded · "
+                 f"~{m.resident_tokens:,} tok resident every turn "
+                 f"(~{m.invoke_tokens:,} tok if all fired)")
+    if not m.loaded and not m.findings:
+        lines.append("  nothing found — is this a Claude Code install?")
+        return "\n".join(lines)
+
+    order = {"disabled": 0, "duplicate-name": 1, "nested": 2, "no-skill-md": 3}
+    label = {"disabled": "DISABLED", "duplicate-name": "DUPLICATE NAME",
+             "nested": "NESTED", "no-skill-md": "NEVER LOADS"}
+    for f in sorted(m.findings, key=lambda f: (order.get(f.kind, 9), f.subject)):
+        lines.append(f"  {label.get(f.kind, f.kind):<15} {f.subject}")
+        lines.append(f"  {'':<15}   {f.detail}")
+
+    if m.loaded:
+        lines.append("")
+        lines.append("  TOP COST")
+        for a in sorted(m.loaded, key=lambda a: -a.resident_tokens)[:top]:
+            lines.append(f"  {'':<15} {a.name:<40} ~{a.resident_tokens:,} tok resident")
+    return "\n".join(lines)
+
+
+def manifest_to_dict(m: Manifest) -> dict:
+    return {
+        "loaded_count": len(m.loaded),
+        "resident_tokens": m.resident_tokens,
+        "invoke_tokens": m.invoke_tokens,
+        "artifacts": [
+            {"name": a.name, "kind": a.kind, "source": a.source,
+             "path": a.path, "chars": a.chars, "tokens": a.tokens,
+             "resident_tokens": a.resident_tokens}
+            for a in sorted(m.loaded, key=lambda a: a.name)
+        ],
+        "findings": [
+            {"kind": f.kind, "subject": f.subject, "detail": f.detail}
+            for f in sorted(m.findings, key=lambda f: (f.kind, f.subject))
+        ],
+    }

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -1,0 +1,124 @@
+"""`schliff manifest` — resolved agent state, built against synthetic installs.
+
+Both regressions pinned here were found by RUNNING the resolver against a live
+Claude Code install, not by reading it:
+
+1. The plugin payload is not at `plugins/<package>`. It is
+   `plugins/cache/<marketplace>/<package>`, sometimes with an extra version or
+   content-hash segment. The first guess reported thirteen working plugins as
+   "not present on disk".
+2. Resident cost and invoke cost are different numbers. What a plugin charges on
+   every turn is its DESCRIPTION; the body is charged only when it fires. Summing
+   bodies and calling it a per-turn cost overstated the bill ~45x on a real install.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from manifest import build_manifest, format_manifest, manifest_to_dict
+
+
+def _skill(root: Path, name: str, description: str = "does a thing",
+           body: str = "# Body\n", extra_fm: str = "") -> Path:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n{extra_fm}---\n\n{body}",
+        encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def install(tmp_path: Path) -> Path:
+    (tmp_path / "skills").mkdir()
+    _skill(tmp_path / "skills", "alpha", description="x" * 40, body="B" * 4000)
+    return tmp_path
+
+
+def test_resident_and_invoke_costs_are_not_the_same_number(install: Path):
+    """The bug that nearly shipped: body size reported as a per-turn charge."""
+    m = build_manifest(claude_dir=install)
+    assert len(m.loaded) == 1
+    art = m.loaded[0]
+    assert art.resident_tokens == 10          # 40 description chars / 4
+    assert art.tokens > 900                   # ~4000-char body
+    assert m.resident_tokens < m.invoke_tokens / 10, (
+        "resident cost must not be conflated with invoke cost"
+    )
+
+
+def test_disabled_artifact_is_reported_not_loaded(install: Path):
+    _skill(install / "skills", "muted", extra_fm="disable-model-invocation: true\n")
+    m = build_manifest(claude_dir=install)
+    assert "muted" not in {a.name for a in m.loaded}
+    assert any(f.kind == "disabled" and f.subject == "muted" for f in m.findings)
+
+
+def test_directory_without_skill_md_never_loads(install: Path):
+    (install / "skills" / "empty-dir").mkdir()
+    m = build_manifest(claude_dir=install)
+    assert any(f.kind == "no-skill-md" and f.subject == "empty-dir" for f in m.findings)
+
+
+def test_nested_skill_md_is_reported(install: Path):
+    nested = install / "skills" / "alpha" / "upstream"
+    nested.mkdir()
+    (nested / "SKILL.md").write_text("---\nname: n\n---\n", encoding="utf-8")
+    m = build_manifest(claude_dir=install)
+    assert any(f.kind == "nested" for f in m.findings)
+
+
+def test_plugin_payload_is_found_under_cache_marketplace_package(install: Path):
+    """The layout that the first implementation got wrong."""
+    (install / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"acme@some-market": True}}), encoding="utf-8")
+    pkg = install / "plugins" / "cache" / "some-market" / "acme"
+    _skill(pkg / "skills", "widget")
+    m = build_manifest(claude_dir=install)
+    assert "acme:widget" in {a.name for a in m.loaded}, (
+        f"plugin payload not resolved; loaded={[a.name for a in m.loaded]}"
+    )
+
+
+def test_plugin_payload_is_found_under_a_version_segment(install: Path):
+    """`cache/<market>/<pkg>/1.2.3/skills` — the shape codex and vault-sync use."""
+    (install / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"acme@some-market": True}}), encoding="utf-8")
+    pkg = install / "plugins" / "cache" / "some-market" / "acme" / "1.2.3"
+    _skill(pkg / "skills", "widget")
+    m = build_manifest(claude_dir=install)
+    assert "acme:widget" in {a.name for a in m.loaded}
+
+
+def test_enabled_but_absent_plugin_is_a_finding(install: Path):
+    (install / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"ghost@some-market": True}}), encoding="utf-8")
+    m = build_manifest(claude_dir=install)
+    assert any("ghost" in f.subject for f in m.findings)
+
+
+def test_disabled_plugin_contributes_nothing(install: Path):
+    (install / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {"acme@some-market": False}}), encoding="utf-8")
+    pkg = install / "plugins" / "cache" / "some-market" / "acme"
+    _skill(pkg / "skills", "widget")
+    m = build_manifest(claude_dir=install)
+    assert "acme:widget" not in {a.name for a in m.loaded}
+    assert not any("acme" in f.subject for f in m.findings)
+
+
+def test_output_is_renderable_and_serialisable(install: Path):
+    m = build_manifest(claude_dir=install)
+    assert "resident every turn" in format_manifest(m)
+    d = manifest_to_dict(m)
+    assert d["loaded_count"] == len(m.loaded)
+    assert "resident_tokens" in d and "invoke_tokens" in d
+    json.dumps(d)  # must round-trip
+
+
+def test_empty_install_says_so(tmp_path: Path):
+    out = format_manifest(build_manifest(claude_dir=tmp_path))
+    assert "0 artifacts loaded" in out


### PR DESCRIPTION
Every other tool in this space lints a **file**. `schliff manifest` reads the **resolved state** — `settings.json` × on-disk skill/command roots × frontmatter — and answers three questions nobody else answers: what is loaded right now, what it charges the context window every turn, and what is installed but silently never loads.

It emits no score. It reports state.

```
$ schliff manifest
157 artifacts loaded · ~8,254 tok resident every turn (~370,298 tok if all fired)
  DISABLED        codex:adversarial-review    frontmatter disable-model-invocation: true
  DUPLICATE NAME  vercel:bootstrap            claimed 2x (skill 8022 B + command 5807 B)
  NESTED          …/vercel/skills/ai-sdk/upstream/SKILL.md — never registers
```

`--json`, `--project <dir>`, `--claude-dir <dir>`, `--strict` (exit 1 on any finding).

## Two defects found by running it, not reading it

**1. The plugin payload path was guessed wrong.** It is not `plugins/<package>` but `plugins/cache/<marketplace>/<package>`, sometimes with an extra version or content-hash segment (`codex/1.0.1/`, `vault-sync/9904d91688b1/`). The first implementation reported **thirteen demonstrably working plugins as "not present on disk"**. Several versions can coexist — this install holds vercel `0.44.0` *and* `0.45.1` — so taking the first by name silently resolved the **stale** one. Newest by mtime now wins.

**2. Resident cost and invoke cost are different numbers.** What an artifact charges on *every turn* is its **description**; the body is charged only when it fires. Summing bodies and labelling that a per-turn cost overstated the bill **~45×** (370,298 vs 8,254 tok) — and it would have been the headline number of the whole feature. Both are now reported and separately labelled.

Both are pinned as regression tests.

## Deliberately not ported from the prototype

A hand-curated list of harness built-in names, marked by its own author *"undocumented upstream, will drift"*. A tool that reports resolved state and misclassifies silently is worse than no tool — so only artifacts found on disk under a known root are reported, and nothing is inferred.

Kept from the prototype because it is right: cost is `SKILL.md` + `references/*.md`, **never** the directory. One real skill dir here holds a 200 MB virtualenv; measuring the tree would report tens of millions of tokens for a file that charges a few hundred.

## Safety

Read-only, local, no network. Paths print relative to `~`. Regex frontmatter parsing rather than pyyaml, which is absent from a stock Python and from schliff's own environment — a silent `ImportError` would make findings vanish.

## Pre-registered kill-criterion

**2026-08-05:** run on ≥5 foreign Claude Code installs. If the median is <1 consequential finding per machine, it is an artifact of one maintainer's laptop and does not ship.

1550 tests, ruff clean.