### PR TITLE
fix(eval): report assertions the evaluator cannot run instead of blaming the skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **An assertion the evaluator could not run counted as one the skill failed.**
+  `run-eval.sh` evaluated patterns with `grep -qiE … 2>/dev/null` inside an `if`, and
+  grep's exit status carries three outcomes rather than two: 0 matched, 1 did not match,
+  **2 could not compile the pattern**. `timeout` adds 124. All of them collapsed into
+  `passed: false` with the reason discarded.
+
+  What that cost, measured: six assertions in the previous suite were dead on CI for
+  months (`main` reported 113/119 there against 119/119 on a developer machine, whose
+  `grep` was a more permissive implementation), and the reason was unobtainable — which
+  is how a **wrong** diagnosis about the generator ended up published in a commit
+  message. The swallow does not only produce dead tests, it makes confident wrong
+  statements about them the only available move.
+
+  Unrunnable assertions are now reported as such: `pass_rate` gains an `errored` count,
+  the affected `binary_results` entry carries an `error` explaining which construct grep
+  refused, and a warning goes to stderr. They are **excluded from the pass-rate
+  denominator** and **not written to `.schliff/failures.jsonl`** — an assertion that
+  cannot execute is evidence about the suite, not about the skill, and `/schliff:triage`
+  clusters that file into proposed SKILL.md fixes.
+
+  Note the ReDoS guard above the call never covered this: it rejects *expensive*
+  patterns, not invalid ones — `validate_regex_complexity("[")` returns ok.
+
+  **Output contract:** `pass_rate.errored` is new; `binary_results[].error` appears only
+  on unrunnable assertions. Both additive.
+
+- **Two gates so the fix cannot rot.** Excluding errored assertions shrinks the
+  denominator, so a decaying suite could report a *rising* pass rate — one runnable
+  assertion out of thirteen reads 100%. `test-self.sh` therefore asserts `errored == 0`
+  on schliff's own suite (verified red by injecting `(` — the pass rate stayed at a
+  reassuring 100% while only the new assertion moved). And `test-integration.sh` now runs
+  a suite `init-skill.py` generated instead of only checking that its JSON parses, which
+  turns the generator's contract from shape into property.
+
 - **`/schliff:auto` documented a flag that does not exist and a state file it does not
   write.** `commands/schliff/auto.md` listed `--resume`, which `auto-improve.py` rejects
   with `unrecognized arguments` and exit 2 — the same defect class as the `doctor <dir>`

--- a/docs/specs/2026-07-29-eval-reports-unrunnable-assertions.md
+++ b/docs/specs/2026-07-29-eval-reports-unrunnable-assertions.md
@@ -1,0 +1,105 @@
+# Report unrunnable assertions instead of counting them as failures
+
+- **Status:** accepted, implementing
+- **Date:** 2026-07-29
+- **Follows:** #156 (`73b53e3`) — the re-derived eval suite and the static ERE gate
+
+## Goal
+
+`run-eval.sh` cannot currently distinguish an assertion the skill **failed** from an
+assertion `grep` **refused to run**. Both become `passed: false`, silently. Make the
+second case visible, attribute it to the suite rather than to the skill, and gate
+against it where schliff owns the artifact.
+
+## Context: three symptoms, one cause
+
+`scripts/run-eval.sh:265` evaluates every `pattern` assertion as:
+
+```bash
+if echo "$SKILL_CONTENT" | $_GREP_TIMEOUT grep -qiE -- "$assertion_value" 2>/dev/null; then
+```
+
+`grep` exits 0 on match, 1 on no match, **2 on a pattern it cannot compile**; `timeout`
+exits 124. The `if` collapses everything non-zero into one branch and `2>/dev/null`
+discards the reason. Measured consequences, all from 2026-07-29:
+
+| symptom | measurement |
+| --- | --- |
+| 6 assertions dead on CI for months | `main` reported 113/119 on CI, 119/119 locally |
+| a whole PR red for an invisible reason | 13/13 locally, 9/13 on CI |
+| **a wrong published diagnosis** | claimed `init-skill.py` emits `(?i)` into user suites; it emits `(?i)` into `edge_cases`, which the grep path never reads, and `\w{4,}` into `test_cases` |
+
+The third is the one that decided this work. The swallow does not only produce dead
+tests, it produces **confident wrong statements about dead tests**, because guessing is
+the only option left.
+
+The ReDoS guard above the call does not cover this: `validate_regex_complexity("[")`
+returns `(True, "ok")`. It rejects expensive patterns, not invalid ones.
+
+## Decisions
+
+**D1 — An unrunnable assertion is `errored`, not `failed`.** It keeps `passed: false`
+and gains an `error` field, but leaves the pass-rate denominator and is **not** written
+to `.schliff/failures.jsonl`.
+
+*Why:* the pass rate answers "how much of what the suite asks does the skill deliver?"
+An assertion that cannot execute asks nothing. Counting it blames the skill for a defect
+in the suite — and that mis-attribution has a real consumer today: failed assertions are
+appended to `failures.jsonl` (`run-eval.sh:423-433`), which `/schliff:triage` clusters
+and turns into proposed SKILL.md fixes. A broken regex would generate advice about a
+file that is not the problem.
+
+**D2 — Blocking only where schliff owns the suite.** `test-self.sh` asserts
+`errored == 0`. For a user's own suite the count is reported, not enforced.
+
+*Why:* D1 shrinks the denominator, so a suite could rot toward unrunnability while its
+pass rate *improves* — 1 runnable assertion out of 13 reads 100%. That is precisely the
+"a gate that pins output constant cannot detect loss" failure this project has already
+paid for. Enforcing it in schliff's own CI closes it where we can fix it; enforcing it
+for users would break someone's CI over a typo in their suite while their skill is fine,
+and would break `run-eval.sh`'s exit contract (`:514` — exit 0 means *pass rate
+improved*, not *evaluation succeeded*).
+
+**D3 — Timeouts (`124`) are treated as `errored` too.** A pattern that did not finish
+did not answer the question either.
+
+**D4 — `contains` / `excludes` get the same exit-code handling.** They use `grep -qiF`,
+where a compile error is not reachable and rc 2 means I/O trouble. Uniform handling is
+cheaper to read than a justified special case, and an I/O failure should not read as
+"the skill lacks this string".
+
+**D5 — The generator is not touched yet.** `init-skill.py` writes `\w{4,}` into
+`test_cases`. It runs clean on both locally available greps (ugrep, BSD, rc=0) and `\w`
+is a documented GNU extension — unlike `\d`, which GNU does not implement. So it is
+probably fine, and *probably* is the word this spec exists to eliminate. Decide after
+the first measurement, not before.
+
+**D6 — The measurement path is a new integration step.** `test-integration.sh` already
+generates real suites (17.1, 17.6) and checks that the **JSON is well-formed**. It never
+runs one. Step 17.7 executes a generated suite and asserts `errored == 0` — turning the
+generator's contract from *shape* into *property*, and answering D5 on the next CI run.
+
+It asserts immediately rather than merely reporting: a red run here is the finding we
+want, and a number nobody asserts is a number nobody reads.
+
+## Non-goals
+
+- No release. The one verified external adopter drives `uvx schliff score` / `verify`;
+  `run-eval.sh` is not on that path. Rides `[Unreleased]`.
+- `parallel_runner.py`'s cwd-derived repo root stays open. It is unreachable from every
+  shipping entry point (`/schliff:auto` no-ops it, the CLI does not expose it), so it is
+  a deletion candidate, not a hardening candidate.
+- The ERE gate's strictness about `\w` is not revisited here — see D5.
+
+## Output contract change
+
+`pass_rate` gains `errored`; `binary_results[]` entries may carry `error`. Both are
+additive. The only consumer outside `run-eval.sh` itself is `test-integration.sh:179`,
+which reads `type`.
+
+## Verification
+
+- Red-test: put `[` in a suite → `errored: 1`, `test-self.sh` red, the assertion absent
+  from `failures.jsonl`, and the pass rate computed over the remaining 12.
+- Full local gate set, all seven CI steps.
+- After merge, read 17.7's output on CI for the D5 answer.

--- a/skills/schliff/scripts/run-eval.sh
+++ b/skills/schliff/scripts/run-eval.sh
@@ -195,6 +195,7 @@ RUNTIME_ONLY_TYPES="response_contains|response_matches|response_excludes"
 BINARY_RESULTS="[]"
 ASSERTIONS_PASSED=0
 ASSERTIONS_TOTAL=0
+ASSERTIONS_ERRORED=0
 
 if jq -e '.test_cases' "$EVAL_SUITE" > /dev/null 2>&1; then
     echo "  Running binary assertions..." >&2
@@ -236,35 +237,56 @@ if jq -e '.test_cases' "$EVAL_SUITE" > /dev/null 2>&1; then
 
             ASSERTIONS_TOTAL=$((ASSERTIONS_TOTAL + 1))
 
-            # Evaluate assertion against skill content (static check)
+            # Evaluate assertion against skill content (static check).
+            #
+            # grep's exit status carries three outcomes, not two: 0 matched, 1 did not
+            # match, 2 could not compile the pattern at all. `timeout` adds 124. This
+            # used to collapse all of them into "failed", with the reason sent to
+            # /dev/null — which is how six assertions stayed dead on CI for months while
+            # reading as though the skill had failed them. An assertion that cannot run
+            # is a defect in the suite, so it is reported separately and kept out of the
+            # pass rate. See docs/specs/2026-07-29-eval-reports-unrunnable-assertions.md.
             assertion_passed="false"
+            assertion_error=""
+            rc=0
 
             case "$assertion_type" in
                 contains)
-                    if echo "$SKILL_CONTENT" | grep -qiF -- "$assertion_value" 2>/dev/null; then
-                        assertion_passed="true"
-                    fi
+                    echo "$SKILL_CONTENT" | grep -qiF -- "$assertion_value" 2>/dev/null || rc=$?
+                    case $rc in
+                        0) assertion_passed="true" ;;
+                        1) ;;
+                        *) assertion_error="fixed-string match failed to run (exit $rc)" ;;
+                    esac
                     ;;
                 excludes)
-                    if ! echo "$SKILL_CONTENT" | grep -qiF -- "$assertion_value" 2>/dev/null; then
-                        assertion_passed="true"
-                    fi
+                    echo "$SKILL_CONTENT" | grep -qiF -- "$assertion_value" 2>/dev/null || rc=$?
+                    case $rc in
+                        0) ;;
+                        1) assertion_passed="true" ;;
+                        *) assertion_error="fixed-string match failed to run (exit $rc)" ;;
+                    esac
                     ;;
                 pattern)
-                    # Validate regex complexity before execution (ReDoS prevention)
+                    # Validate regex complexity before execution (ReDoS prevention).
+                    # Note this guard rejects *expensive* patterns, not invalid ones:
+                    # validate_regex_complexity("[") returns ok. Syntax is grep's verdict.
                     if ! PYTHONPATH="$SCRIPT_DIR:${PYTHONPATH:-}" python3 -c "
 from shared import validate_regex_complexity
 import sys
 ok, reason = validate_regex_complexity(sys.argv[1])
 if not ok: sys.exit(1)
 " "$assertion_value" 2>/dev/null; then
-                        echo "  Warning: skipping unsafe regex in $tc_id" >&2
-                        assertion_passed="false"
+                        assertion_error="rejected by the complexity guard (possible ReDoS)"
                     else
                         # Regex passed complexity check — execute with timeout guard
-                        if echo "$SKILL_CONTENT" | $_GREP_TIMEOUT grep -qiE -- "$assertion_value" 2>/dev/null; then
-                            assertion_passed="true"
-                        fi
+                        echo "$SKILL_CONTENT" | $_GREP_TIMEOUT grep -qiE -- "$assertion_value" 2>/dev/null || rc=$?
+                        case $rc in
+                            0) assertion_passed="true" ;;
+                            1) ;;
+                            124) assertion_error="pattern timed out after 2s" ;;
+                            *) assertion_error="grep rejected this pattern (exit $rc) — POSIX ERE only, no (?i), \\d, \\b or lookarounds" ;;
+                        esac
                     fi
                     ;;
                 *)
@@ -278,10 +300,18 @@ if not ok: sys.exit(1)
                 ASSERTIONS_PASSED=$((ASSERTIONS_PASSED + 1))
             fi
 
-            # Append result as JSONL line (using jq for correct JSON escaping)
+            if [[ -n "$assertion_error" ]]; then
+                echo "  Warning: $tc_id assertion could not be run — $assertion_error" >&2
+            fi
+
+            # Append result as JSONL line (using jq for correct JSON escaping).
+            # `error` is present only when the assertion could not be run at all;
+            # its absence is what marks a result as a real pass/fail verdict.
             jq -n -c --arg tc "$tc_id" --arg type "$assertion_type" \
                 --arg desc "$assertion_desc" --argjson passed "$assertion_passed" \
-                '{"test_case":$tc,"type":$type,"description":$desc,"passed":$passed}' >> "$RESULTS_LINES"
+                --arg err "$assertion_error" \
+                '{"test_case":$tc,"type":$type,"description":$desc,"passed":$passed}
+                 + (if $err == "" then {} else {"error":$err} end)' >> "$RESULTS_LINES"
         done < "$ASSERTIONS_FILE"
 
         # Build the JSON array from collected JSONL results
@@ -296,7 +326,10 @@ if not ok: sys.exit(1)
 
     BINARY_RESULTS=$(cat "$BINARY_OUTPUT")
     ASSERTIONS_PASSED=$(echo "$BINARY_RESULTS" | jq '[.[] | select(.passed == true)] | length')
-    ASSERTIONS_TOTAL=$(echo "$BINARY_RESULTS" | jq 'length')
+    # Assertions that could not be run are not evidence about the skill, so they are
+    # counted separately and excluded from the pass-rate denominator.
+    ASSERTIONS_ERRORED=$(echo "$BINARY_RESULTS" | jq '[.[] | select(has("error"))] | length')
+    ASSERTIONS_TOTAL=$(echo "$BINARY_RESULTS" | jq '[.[] | select(has("error") | not)] | length')
 
     rm -f "$BINARY_OUTPUT"
 fi
@@ -367,6 +400,7 @@ RESULT_JSON=$(jq -n \
     --argjson pass_rate "$PASS_RATE" \
     --argjson assertions_passed "$ASSERTIONS_PASSED" \
     --argjson assertions_total "$ASSERTIONS_TOTAL" \
+    --argjson assertions_errored "$ASSERTIONS_ERRORED" \
     --argjson composite_score "$COMPOSITE_SCORE" \
     --argjson dimension_scores "$DIMENSION_SCORES" \
     --argjson binary_results "$BINARY_RESULTS" \
@@ -379,6 +413,7 @@ RESULT_JSON=$(jq -n \
         "pass_rate": {
             "passed": $assertions_passed,
             "total": $assertions_total,
+            "errored": $assertions_errored,
             "percentage": $pass_rate
         },
         "dimension_scores": $dimension_scores,
@@ -424,7 +459,10 @@ fi
 FAILURES_DIR="${SKILL_DIR}/.schliff"
 FAILURES_FILE="$FAILURES_DIR/failures.jsonl"
 if [[ "$BINARY_RESULTS" != "[]" ]]; then
-    FAILED_ASSERTIONS=$(echo "$BINARY_RESULTS" | jq -c '[.[] | select(.passed == false)]')
+    # Only real verdicts are failures. An assertion that could not be run says nothing
+    # about the skill, and /schliff:triage clusters this file into proposed SKILL.md
+    # fixes — feeding it a broken regex would generate advice about the wrong file.
+    FAILED_ASSERTIONS=$(echo "$BINARY_RESULTS" | jq -c '[.[] | select(.passed == false and (has("error") | not))]')
     FAILED_COUNT=$(echo "$FAILED_ASSERTIONS" | jq 'length')
     if [[ $FAILED_COUNT -gt 0 ]]; then
         mkdir -p "$FAILURES_DIR"

--- a/skills/schliff/scripts/test-integration.sh
+++ b/skills/schliff/scripts/test-integration.sh
@@ -838,11 +838,20 @@ REOF
 REGEX_RESULT=$(bash "$SCRIPT_DIR/run-eval.sh" "$SKILL_DIR/SKILL.md" "$REGEX_EVAL" --no-runtime-auto 2>/dev/null || true)
 REGEX_PASSED_CT=$(echo "$REGEX_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['pass_rate']['passed'])" 2>/dev/null)
 REGEX_TOTAL_CT=$(echo "$REGEX_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['pass_rate']['total'])" 2>/dev/null)
-# Bad regex should fail (grep -qiE returns non-zero), frontmatter should pass
-if [[ "$REGEX_PASSED_CT" == "1" ]] && [[ "$REGEX_TOTAL_CT" == "2" ]]; then
-    pass "Invalid regex → assertion fails gracefully (1/2 passed)"
+REGEX_ERRORED_CT=$(echo "$REGEX_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['pass_rate'].get('errored','missing'))" 2>/dev/null)
+REGEX_HAS_REASON=$(echo "$REGEX_RESULT" | python3 -c "
+import sys,json
+print(any('error' in r for r in json.load(sys.stdin)['binary_results']))" 2>/dev/null)
+# The runner must not crash, and the sibling assertion must still be evaluated — that was
+# always this test's point. What changed: a pattern grep cannot compile is reported as
+# unrunnable rather than counted as a failure of the skill, so it leaves the denominator.
+# 1 runnable assertion, it passes, 1 errored, and the reason is recorded rather than lost.
+if [[ "$REGEX_PASSED_CT" == "1" ]] && [[ "$REGEX_TOTAL_CT" == "1" ]] \
+   && [[ "$REGEX_ERRORED_CT" == "1" ]] && [[ "$REGEX_HAS_REASON" == "True" ]]; then
+    pass "Invalid regex → reported unrunnable with a reason, not counted as a failure"
 else
-    fail "Invalid regex" "passed=$REGEX_PASSED_CT total=$REGEX_TOTAL_CT, expected 1/2"
+    fail "Invalid regex" \
+        "passed=$REGEX_PASSED_CT total=$REGEX_TOTAL_CT errored=$REGEX_ERRORED_CT reason=$REGEX_HAS_REASON, expected 1/1/1/True"
 fi
 
 # Test: unknown assertion type → passed (skipped)
@@ -1405,6 +1414,23 @@ if [[ -f "$_INIT_WRITE/eval-suite.json" ]]; then
     fi
 else
     fail "init-skill.py write" "eval-suite.json was not created"
+fi
+
+# 17.6b A generated suite must be RUNNABLE, not merely well-formed JSON.
+# 17.6 above checks the shape. Nothing checked the property, so a suite schliff wrote
+# could carry patterns the evaluator cannot execute and nobody would learn of it — the
+# assertions would just read as failures. Uses the suite 17.6 just generated.
+if [[ -f "$_INIT_WRITE/eval-suite.json" ]]; then
+    _GEN_EVAL=$(bash "$SCRIPT_DIR/run-eval.sh" "$_INIT_WRITE/SKILL.md" \
+        "$_INIT_WRITE/eval-suite.json" --no-runtime-auto 2>/dev/null || true)
+    _GEN_ERRORED=$(echo "$_GEN_EVAL" | python3 -c \
+        "import sys,json; print(json.load(sys.stdin)['pass_rate'].get('errored','?'))" 2>/dev/null)
+    if [[ "$_GEN_ERRORED" == "0" ]]; then
+        pass "init-skill.py: generated suite is runnable (0 unrunnable assertions)"
+    else
+        fail "init-skill.py generated suite" \
+            "$_GEN_ERRORED assertions in a schliff-generated suite cannot be run"
+    fi
 fi
 
 # 17.7 generate-report.py with synthetic JSONL

--- a/skills/schliff/scripts/test-self.sh
+++ b/skills/schliff/scripts/test-self.sh
@@ -95,6 +95,13 @@ PASS_TOTAL=$(echo "$EVAL_RESULT" | python3 -c "import sys,json; d=json.load(sys.
 python3 -c "import sys; exit(0 if int(sys.argv[1]) >= 80 else 1)" "${PASS_PCT:-0}" 2>/dev/null && \
     pass "Pass rate ${PASS_PCT}% ($PASS_TOTAL static assertions)" || fail "Pass rate ${PASS_PCT}% ($PASS_TOTAL) below 80%"
 
+# Assertions that cannot be run leave the pass-rate denominator, so the rate above can
+# rise while the suite decays — one runnable assertion out of thirteen reads 100%. This
+# is the counterweight: on our own suite, every assertion must actually execute.
+ERRORED=$(echo "$EVAL_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['pass_rate'].get('errored', 0))" 2>/dev/null)
+[[ "${ERRORED:-0}" == "0" ]] && pass "All assertions runnable (0 errored)" || \
+    fail "$ERRORED assertions could not be run — the pass rate above is measured over a shrunken suite"
+
 # Composite from eval should match standalone scorer
 EVAL_COMP=$(echo "$EVAL_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['composite_score'])" 2>/dev/null)
 python3 -c "import sys; exit(0 if abs(float(sys.argv[1]) - float(sys.argv[2])) < 1 else 1)" "$EVAL_COMP" "$COMPOSITE" 2>/dev/null && \


### PR DESCRIPTION
`run-eval.sh` evaluated every `pattern` assertion as `grep -qiE … 2>/dev/null` inside an `if`. grep's exit status carries **three** outcomes, not two: `0` matched, `1` did not match, **`2` could not compile the pattern**. `timeout` adds `124`. All of them collapsed into `passed: false`, reason discarded.

## What the swallow cost

| symptom | measurement |
| --- | --- |
| assertions dead on CI for months | `main` reported **113/119** on CI against 119/119 locally, where `grep` resolves to a more permissive implementation |
| a PR red for an invisible reason | 13/13 locally, 9/13 on CI (#156) |
| **a wrong claim published in a commit message** | asserted `init-skill.py` emits `(?i)` into user suites; it emits `(?i)` into `edge_cases`, which the grep path never reads |

The third one decided this work. The swallow does not only produce dead tests — it makes a confident wrong guess the only available move, because nothing reports.

The ReDoS guard above the call never covered it: it rejects *expensive* patterns, not invalid ones. `validate_regex_complexity("[")` returns `ok`.

## What changed

An unrunnable assertion is reported as such: `pass_rate` gains `errored`, the `binary_results` entry carries an `error` naming the construct grep refused, and a warning goes to stderr.

It is **excluded from the pass-rate denominator** and **not written to `.schliff/failures.jsonl`**. An assertion that cannot execute is evidence about the suite, not about the skill — and `/schliff:triage` clusters that file into proposed SKILL.md fixes, so feeding it a broken regex would generate advice about the wrong file.

```
pass_rate: {passed: 13, total: 14, errored: 1, percentage: 92}
  {type: pattern, passed: false,
   error: "grep rejected this pattern (exit 2) — POSIX ERE only, no (?i), \\d, \\b or lookarounds"}
failures.jsonl: contains the real failure only
```

## Two gates, because the fix creates its own risk

Excluding errored assertions shrinks the denominator, so a decaying suite could report a **rising** pass rate — one runnable assertion out of thirteen reads 100%. That is the "a gate that pins output constant cannot detect loss" failure this repo has already paid for.

- `test-self.sh` asserts `errored == 0` on schliff's own suite.
- `test-integration.sh` now **runs** a suite `init-skill.py` generated, rather than only checking that its JSON parses — turning the generator's contract from *shape* into *property*. Nothing had ever checked that a suite schliff writes is executable.

## A pre-existing test pinned the old conflation

`test-integration.sh`'s "Invalid regex" case expected the bad pattern **in** the denominator at `1/2`; its comment read *"Bad regex should fail (grep -qiE returns non-zero)"*. Its purpose — do not crash, still evaluate the sibling assertion — is unchanged and still met. The expectation moved to the new contract and now asserts four properties instead of two: 1 passed, 1 runnable, 1 errored, reason recorded.

## Output contract

`pass_rate.errored` is new; `binary_results[].error` appears only on unrunnable assertions. Both additive — the only consumer outside `run-eval.sh` is `test-integration.sh`, which reads `type`. The JSONL log keeps its `"N/M"` string form, so `progress.py` is unaffected.

## Deliberately not here

- **No release.** The one verified external adopter drives `uvx schliff score` / `verify`; `run-eval.sh` is not on that path. Rides `[Unreleased]`.
- **The generator is not touched.** `init-skill.py` writes `\w{4,}` into `test_cases`. It runs clean on both locally available greps and `\w` is a documented GNU extension — unlike `\d`. The new integration step reports the CI answer; decide then, not on a guess. Local result: `0 unrunnable`.
- **`parallel_runner.py`'s cwd-derived repo root.** Unreachable from every shipping entry point, so a deletion candidate rather than a hardening one.

Spec: `docs/specs/2026-07-29-eval-reports-unrunnable-assertions.md`

## Verification

Every gate CI runs, locally: `test-self.sh` 21/0 · integration **100/0** · 1600 pytest · proof 6/0 · ruff clean · markdownlint 0/66 · `check-commands` 0 dangling.

Each new guard was mutation-tested red first. The sharpest one: injecting `(` into schliff's own suite left the pass rate reading a reassuring **100% (13/13)** while only the new assertion moved — which is the entire argument for having it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)