### PR TITLE
fix(scoring): recalibrate the SKILL.md token budget against measured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **The SKILL.md token budget was set below the median of what it measures.** It flagged
+  75% of a 166-file installed-skill population (median 1,960, p75 2,934) and 44% of
+  schliff's own 16-file calibration corpus — including the format's own reference
+  implementations (Anthropic's `skill-creator` 8,047, `writing-skills` 6,582,
+  `brainstorming` 2,649) and, pointedly, schliff's own card at `1,045 / 1,000 (over)`
+  immediately after being trimmed from 11,700 to 4,240 chars for exactly this reason.
+
+  A threshold at roughly the 12th percentile of its own population reports "yes" and
+  carries no information. Raised to **2000**, just above the measured median, so it flags
+  the upper half rather than the upper three quarters without adopting the population's
+  bloat as the target. A SKILL.md stays held at least as tight as a CLAUDE.md and tighter
+  than an AGENTS.md, and `brainstorming` at 2,649 is still flagged — context paid on every
+  trigger is worth naming. The derivation is recorded beside the constant so it stops
+  being a magic number; the other budgets in that table were not measured and are unchanged.
+
+  This is advisory only — token budgets never enter a score. `within_budget` does gate
+  whether a watch hook reports growth, which is where the missing selectivity actually
+  cost something.
+
+  A regression test now asserts schliff's own card satisfies the budget schliff
+  advertises for its format: a measurement tool must not flag its own exemplar.
+
 - **The bundled eval suite measured its own source, so it measured nothing.** All 108
   `contains` assertions in `skills/schliff/eval-suite.json` appear verbatim in the
   241-line card the suite was generated from; only 54 of them appear in the prompt they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   whether a watch hook reports growth, which is where the missing selectivity actually
   cost something.
 
-  A regression test now asserts schliff's own card satisfies the budget schliff
+  The same boundary falls out of a measurement this project already published —
+  `docs/launch/state-of-ai-instructions.md` "Length Has a Sweet Spot": across 120 files the
+  300–2000 token band averages composite 64.5, under 300 averages 51.3, over 2000 averages
+  59.9. So 2000 marks where files start scoring measurably worse, not merely where the
+  distribution sits. Two unrelated methods, one number.
+
+  `docs/SCORING.md` and `docs/ARCHITECTURE.md` both carried a hand-copied budget table
+  stating the old value; both are corrected, and a test now compares each table against the
+  constant in both directions — a stale value fails, and so does adding a format without
+  documenting it. Nothing had gated those copies, which is why a shipped doc could state a
+  budget the code no longer used.
+
+  A regression test also asserts schliff's own card satisfies the budget schliff
   advertises for its format: a measurement tool must not flag its own exemplar.
 
 - **The bundled eval suite measured its own source, so it measured nothing.** All 108

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ agents.md family**.
 
 | Format | Budget (tokens) |
 | --- | --- |
-| skill.md | 1000 |
+| skill.md | 2000 |
 | claude.md | 2000 |
 | cursorrules | 500 |
 | agents.md | 3000 |

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -110,7 +110,7 @@ Each format carries a recommended token budget (`scoring/formats.py`):
 
 | Format | Budget (tokens) |
 | --- | --- |
-| skill.md | 1000 |
+| skill.md | 2000 |
 | claude.md | 2000 |
 | cursorrules | 500 |
 | agents.md | 3000 |

--- a/skills/schliff/SKILL.md
+++ b/skills/schliff/SKILL.md
@@ -42,8 +42,8 @@ Example 1 — score a skill:
 
 ```
 $ uvx schliff score SKILL.md
-  structure      85/100    triggers   95/100    quality  92/100
-  Structural Score  84.5/100  [B]        Tokens: 1,031 / 1,000 (over)
+  structure      95/100    triggers   95/100    quality  90/100
+  Structural Score  87.4/100  [A]        Tokens: 1,044 / 2,000 (ok)
 ```
 
 Grades run S · A · B · C · D · E · F. `4/7 dims` in the readout means no eval

--- a/skills/schliff/scripts/scoring/formats.py
+++ b/skills/schliff/scripts/scoring/formats.py
@@ -153,8 +153,27 @@ def estimate_tokens(content: str) -> int:
     return len(content) // 4
 
 
+# Advisory only — these never enter a score. They mark the point at which a file's
+# context cost is worth mentioning, so a useful budget must flag the heavy tail, not
+# the median.
+#
+# `skill.md` was 1000 until 2026-07-30, which put it at roughly the 12th percentile of
+# the population it measures. Measured then over 166 installed SKILL.md files: 75% were
+# over it, median 1,960, p75 2,934. Over schliff's own 16-file calibration corpus: 44%
+# over, median 942. The format's own reference implementations were 2–8× past it
+# (Anthropic's `skill-creator` 8,047, `writing-skills` 6,582, `brainstorming` 2,649) —
+# and so was schliff's own card, at 1,045, right after being trimmed from 11,700 to
+# 4,240 chars for exactly this reason. A threshold that fires on three quarters of the
+# population, including the exemplars, carries no information.
+#
+# 2000 sits just above the measured median, so it flags the upper half rather than the
+# upper three quarters, without adopting the population's bloat as the target. It keeps
+# a SKILL.md held at least as tight as a CLAUDE.md and tighter than an AGENTS.md, and it
+# still flags `brainstorming` at 2,649 — context paid on every trigger is worth naming.
+#
+# The other entries here are NOT measured. Do not adjust them by analogy.
 FORMAT_TOKEN_BUDGETS: dict[str, int] = {
-    "skill.md": 1000,
+    "skill.md": 2000,
     "claude.md": 2000,
     "cursorrules": 500,
     "agents.md": 3000,

--- a/skills/schliff/scripts/scoring/formats.py
+++ b/skills/schliff/scripts/scoring/formats.py
@@ -171,6 +171,13 @@ def estimate_tokens(content: str) -> int:
 # a SKILL.md held at least as tight as a CLAUDE.md and tighter than an AGENTS.md, and it
 # still flags `brainstorming` at 2,649 — context paid on every trigger is worth naming.
 #
+# The same boundary falls out of an independent measurement this project already
+# published, `docs/launch/state-of-ai-instructions.md` "Length Has a Sweet Spot": across
+# 120 files, the 300–2000 token band averaged composite 64.5, under 300 averaged 51.3,
+# and over 2000 averaged 59.9. 2000 is where files start scoring measurably worse — so
+# the threshold marks a point where quality turns, not merely where the distribution sits.
+# Two unrelated methods, one number; that is the strongest part of this calibration.
+#
 # The other entries here are NOT measured. Do not adjust them by analogy.
 FORMAT_TOKEN_BUDGETS: dict[str, int] = {
     "skill.md": 2000,

--- a/skills/schliff/tests/unit/test_formats.py
+++ b/skills/schliff/tests/unit/test_formats.py
@@ -65,13 +65,26 @@ def test_format_alias_resolves_to_correct_token_budget():
     """`--format cursor`/`agents`/`claude`/`skill`/`system-prompt` must map to their
     real budget, not silently fall back to the unknown=1500 default (which flips the
     within_budget verdict on the exact spellings the docs tell users to type)."""
-    from scoring.formats import check_token_budget
+    from scoring.formats import FORMAT_TOKEN_BUDGETS, check_token_budget
     content = "word " * 300
-    assert check_token_budget(content, "cursor")["budget"] == 500
-    assert check_token_budget(content, "cursorrules")["budget"] == 500
-    assert check_token_budget(content, "agents")["budget"] == 3000
-    assert check_token_budget(content, "claude")["budget"] == 2000
-    assert check_token_budget(content, "skill")["budget"] == 1000
-    assert check_token_budget(content, "system-prompt")["budget"] == 1500
+    # Compared against the table rather than restated as literals: what is under test is
+    # that the alias resolves, not what each budget happens to be. Restating them made
+    # this test fail for an unrelated recalibration of one entry.
+    for alias, canonical in (
+        ("cursor", "cursorrules"),
+        ("cursorrules", "cursorrules"),
+        ("agents", "agents.md"),
+        ("claude", "claude.md"),
+        ("skill", "skill.md"),
+        ("system-prompt", "system_prompt"),
+    ):
+        expected = FORMAT_TOKEN_BUDGETS[canonical]
+        assert check_token_budget(content, alias)["budget"] == expected, (
+            f"alias {alias!r} did not resolve to {canonical!r}"
+        )
+        # The original bug was a silent fall-through to the unknown default, so an alias
+        # whose real budget differs from that default must not land on it.
+        if expected != FORMAT_TOKEN_BUDGETS["unknown"]:
+            assert check_token_budget(content, alias)["budget"] != FORMAT_TOKEN_BUDGETS["unknown"]
     # unknown/garbage still falls back safely
-    assert check_token_budget(content, "totally-bogus")["budget"] == 1500
+    assert check_token_budget(content, "totally-bogus")["budget"] == FORMAT_TOKEN_BUDGETS["unknown"]

--- a/skills/schliff/tests/unit/test_skill_card_executable.py
+++ b/skills/schliff/tests/unit/test_skill_card_executable.py
@@ -121,3 +121,22 @@ def test_card_stays_small():
         f"card grew to {len(CARD_TEXT)} chars (~{len(CARD_TEXT)//4} tokens); "
         "it is loaded into context every time the skill fires"
     )
+
+
+def test_card_satisfies_the_budget_schliff_advertises():
+    """A measurement tool must not flag its own exemplar.
+
+    The char cap above happens to be tighter today, but it pins a size, not the
+    relationship: lower `FORMAT_TOKEN_BUDGETS["skill.md"]` and the card would start
+    reporting `(over)` on itself with nothing to catch it. That state shipped for
+    months — the card read `1,045 / 1,000 (over)` right after being trimmed from
+    11,700 to 4,240 chars for exactly this reason.
+    """
+    from scoring.formats import check_token_budget, detect_format
+
+    fmt = detect_format(str(CARD), CARD_TEXT)
+    info = check_token_budget(CARD_TEXT, fmt)
+    assert info["within_budget"], (
+        f"schliff's own card is over the budget schliff recommends for {fmt}: "
+        f"{info['tokens']} / {info['budget']} tokens ({info['severity']})"
+    )

--- a/skills/schliff/tests/unit/test_tokens.py
+++ b/skills/schliff/tests/unit/test_tokens.py
@@ -1,8 +1,11 @@
 """Tests for token budget estimation in formats.py."""
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
+
+import pytest
 
 # Add scripts directory to path so we can import scoring.formats
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
@@ -45,6 +48,44 @@ class TestFormatTokenBudgets:
             assert budget > 0, f"{fmt} budget is not positive"
 
 
+#: Docs that hand-maintain a copy of FORMAT_TOKEN_BUDGETS as a markdown table.
+_BUDGET_DOCS = ("docs/SCORING.md", "docs/ARCHITECTURE.md")
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_TABLE_ROW = re.compile(r"^\|\s*([A-Za-z0-9_.-]+)\s*\|\s*(\d+)\s*\|\s*$", re.M)
+
+
+def _documented_budgets(doc: str) -> dict[str, int]:
+    """Budget rows from the section headed '... token budgets' in `doc`."""
+    text = (_REPO_ROOT / doc).read_text(encoding="utf-8")
+    heading = re.search(r"^#+ .*token budgets.*$", text, re.M | re.I)
+    assert heading, f"{doc} has no token-budget section to check"
+    section = text[heading.end():]
+    nxt = re.search(r"^#+ |^---\s*$", section, re.M)
+    if nxt:
+        section = section[: nxt.start()]
+    return {m.group(1): int(m.group(2)) for m in _TABLE_ROW.finditer(section)}
+
+
+@pytest.mark.parametrize("doc", _BUDGET_DOCS)
+def test_docs_budget_table_matches_the_code(doc: str) -> None:
+    """These tables are hand-copied from FORMAT_TOKEN_BUDGETS and nothing gated them.
+
+    Recalibrating `skill.md` left both docs stating the old number; markdownlint checks
+    form, not content, so a doc claiming what the code does not do shipped unnoticed.
+    """
+    documented = _documented_budgets(doc)
+    assert documented, f"{doc}: parsed no budget rows — the table moved or changed shape"
+    for fmt, value in documented.items():
+        assert fmt in FORMAT_TOKEN_BUDGETS, f"{doc} documents unknown format {fmt!r}"
+        assert value == FORMAT_TOKEN_BUDGETS[fmt], (
+            f"{doc} says {fmt} is {value}, code says {FORMAT_TOKEN_BUDGETS[fmt]}"
+        )
+    # `unknown` is the internal fallback, not a format a user selects, so it is the one
+    # entry the docs deliberately omit. Everything else must be listed.
+    missing = set(FORMAT_TOKEN_BUDGETS) - set(documented) - {"unknown"}
+    assert not missing, f"{doc} does not document these formats: {sorted(missing)}"
+
+
 class TestCheckTokenBudget:
     """Tests for the check_token_budget function.
 
@@ -54,13 +95,24 @@ class TestCheckTokenBudget:
     measured data, which is a test telling you about the table rather than the function.
     """
 
-    #: One token is estimated as four characters (`estimate_tokens` is `len // 4`).
-    CHARS_PER_TOKEN = 4
+    def _content_of(self, tokens: int) -> str:
+        """Content that `estimate_tokens` reports as exactly `tokens`.
+
+        The chars-per-token ratio is derived from `estimate_tokens` rather than restated:
+        its own docstring says real tokenizers vary, and a restated 4 would silently
+        mis-size this content if the estimator ever changed — the band assertions below
+        would then measure the wrong ratios without going red. The result is checked
+        against the estimator so a bad derivation fails loudly instead.
+        """
+        probe = "x" * 4096
+        chars_per_token = len(probe) // estimate_tokens(probe)
+        content = "x" * (tokens * chars_per_token)
+        assert estimate_tokens(content) == tokens, "content sizing derivation is off"
+        return content
 
     def _content_at(self, fraction: float) -> str:
         """Content sized at `fraction` of the skill.md budget."""
-        tokens = int(FORMAT_TOKEN_BUDGETS["skill.md"] * fraction)
-        return "x" * (tokens * self.CHARS_PER_TOKEN)
+        return self._content_of(int(FORMAT_TOKEN_BUDGETS["skill.md"] * fraction))
 
     def test_within_budget_small_content(self) -> None:
         content = "x" * 100  # 25 tokens, far below any plausible budget
@@ -71,12 +123,13 @@ class TestCheckTokenBudget:
         assert result["severity"] == "ok"
 
     def test_over_budget(self) -> None:
-        # cursorrules budget is 500 tokens = ~2000 chars
-        content = "x" * 8000  # 2000 tokens, way over 500
+        """A second format, so the bands are not only exercised through skill.md."""
+        budget = FORMAT_TOKEN_BUDGETS["cursorrules"]
+        content = self._content_of(budget * 4)
         result = check_token_budget(content, "cursorrules")
         assert result["within_budget"] is False
-        assert result["tokens"] == 2000
-        assert result["budget"] == 500
+        assert result["tokens"] == budget * 4
+        assert result["budget"] == budget
         assert result["severity"] == "over"
 
     def test_severity_ok(self) -> None:

--- a/skills/schliff/tests/unit/test_tokens.py
+++ b/skills/schliff/tests/unit/test_tokens.py
@@ -1,4 +1,9 @@
-"""Tests for token budget estimation in formats.py."""
+"""Tests for token estimation, the format budget table, and the severity bands.
+
+Also holds the gate that keeps the budget tables in `docs/` matching the constant they
+were hand-copied from — a duplicated value with no gate is how a shipped doc came to
+state a budget the code no longer used.
+"""
 from __future__ import annotations
 
 import re
@@ -35,19 +40,6 @@ class TestEstimateTokens:
         assert estimate_tokens("a" * 100) == 25
 
 
-class TestFormatTokenBudgets:
-    """Tests for the FORMAT_TOKEN_BUDGETS constant."""
-
-    def test_has_all_expected_keys(self) -> None:
-        expected = {"skill.md", "claude.md", "cursorrules", "agents.md", "system_prompt", "unknown"}
-        assert set(FORMAT_TOKEN_BUDGETS.keys()) == expected
-
-    def test_values_are_positive_ints(self) -> None:
-        for fmt, budget in FORMAT_TOKEN_BUDGETS.items():
-            assert isinstance(budget, int), f"{fmt} budget is not int"
-            assert budget > 0, f"{fmt} budget is not positive"
-
-
 #: Docs that hand-maintain a copy of FORMAT_TOKEN_BUDGETS as a markdown table.
 _BUDGET_DOCS = ("docs/SCORING.md", "docs/ARCHITECTURE.md")
 _REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -66,33 +58,49 @@ def _documented_budgets(doc: str) -> dict[str, int]:
     return {m.group(1): int(m.group(2)) for m in _TABLE_ROW.finditer(section)}
 
 
-@pytest.mark.parametrize("doc", _BUDGET_DOCS)
-def test_docs_budget_table_matches_the_code(doc: str) -> None:
-    """These tables are hand-copied from FORMAT_TOKEN_BUDGETS and nothing gated them.
+class TestFormatTokenBudgets:
+    """Tests for the FORMAT_TOKEN_BUDGETS constant."""
 
-    Recalibrating `skill.md` left both docs stating the old number; markdownlint checks
-    form, not content, so a doc claiming what the code does not do shipped unnoticed.
-    """
-    documented = _documented_budgets(doc)
-    assert documented, f"{doc}: parsed no budget rows — the table moved or changed shape"
-    for fmt, value in documented.items():
-        assert fmt in FORMAT_TOKEN_BUDGETS, f"{doc} documents unknown format {fmt!r}"
-        assert value == FORMAT_TOKEN_BUDGETS[fmt], (
-            f"{doc} says {fmt} is {value}, code says {FORMAT_TOKEN_BUDGETS[fmt]}"
-        )
-    # `unknown` is the internal fallback, not a format a user selects, so it is the one
-    # entry the docs deliberately omit. Everything else must be listed.
-    missing = set(FORMAT_TOKEN_BUDGETS) - set(documented) - {"unknown"}
-    assert not missing, f"{doc} does not document these formats: {sorted(missing)}"
+    def test_has_all_expected_keys(self) -> None:
+        expected = {"skill.md", "claude.md", "cursorrules", "agents.md", "system_prompt", "unknown"}
+        assert set(FORMAT_TOKEN_BUDGETS.keys()) == expected
+
+    def test_values_are_positive_ints(self) -> None:
+        for fmt, budget in FORMAT_TOKEN_BUDGETS.items():
+            assert isinstance(budget, int), f"{fmt} budget is not int"
+            assert budget > 0, f"{fmt} budget is not positive"
+
+    @pytest.mark.parametrize("doc", _BUDGET_DOCS)
+    def test_docs_table_matches_this_constant(self, doc: str) -> None:
+        """`docs/` hand-copies this table, and nothing gated the copy.
+
+        Recalibrating `skill.md` left both docs stating the old number; markdownlint
+        checks form, not content, so a doc claiming what the code does not do shipped
+        unnoticed. Both directions are checked: a stale value fails, and so does adding
+        a format here without documenting it.
+        """
+        documented = _documented_budgets(doc)
+        assert documented, f"{doc}: parsed no budget rows — the table moved or changed shape"
+        for fmt, value in documented.items():
+            assert fmt in FORMAT_TOKEN_BUDGETS, f"{doc} documents unknown format {fmt!r}"
+            assert value == FORMAT_TOKEN_BUDGETS[fmt], (
+                f"{doc} says {fmt} is {value}, code says {FORMAT_TOKEN_BUDGETS[fmt]}"
+            )
+        # `unknown` is the internal fallback, not a format a user selects, so it is the
+        # one entry the docs deliberately omit. Everything else must be listed.
+        missing = set(FORMAT_TOKEN_BUDGETS) - set(documented) - {"unknown"}
+        assert not missing, f"{doc} does not document these formats: {sorted(missing)}"
 
 
 class TestCheckTokenBudget:
     """Tests for the check_token_budget function.
 
-    These pin the *mechanism* — the severity bands and the ratio — so the sizes below
-    are derived from whatever `skill.md` is budgeted at rather than restated. They used
-    to hardcode 1000 and all broke together when that constant was recalibrated against
-    measured data, which is a test telling you about the table rather than the function.
+    These pin the *mechanism* — the severity bands and the ratio — so any size that has to
+    sit at a particular point in a band is derived from the budget table rather than
+    restated from it. They used to hardcode the numbers and all broke together when one
+    entry was recalibrated against measured data, which is a test reporting on the table
+    instead of on the function. The one remaining absolute size is deliberate: 25 tokens
+    is far below any plausible budget, so it needs no derivation to stay in the `ok` band.
     """
 
     def _content_of(self, tokens: int) -> str:

--- a/skills/schliff/tests/unit/test_tokens.py
+++ b/skills/schliff/tests/unit/test_tokens.py
@@ -46,15 +46,28 @@ class TestFormatTokenBudgets:
 
 
 class TestCheckTokenBudget:
-    """Tests for the check_token_budget function."""
+    """Tests for the check_token_budget function.
+
+    These pin the *mechanism* — the severity bands and the ratio — so the sizes below
+    are derived from whatever `skill.md` is budgeted at rather than restated. They used
+    to hardcode 1000 and all broke together when that constant was recalibrated against
+    measured data, which is a test telling you about the table rather than the function.
+    """
+
+    #: One token is estimated as four characters (`estimate_tokens` is `len // 4`).
+    CHARS_PER_TOKEN = 4
+
+    def _content_at(self, fraction: float) -> str:
+        """Content sized at `fraction` of the skill.md budget."""
+        tokens = int(FORMAT_TOKEN_BUDGETS["skill.md"] * fraction)
+        return "x" * (tokens * self.CHARS_PER_TOKEN)
 
     def test_within_budget_small_content(self) -> None:
-        # skill.md budget is 1000 tokens = ~4000 chars
-        content = "x" * 100  # 25 tokens, well within 1000
+        content = "x" * 100  # 25 tokens, far below any plausible budget
         result = check_token_budget(content, "skill.md")
         assert result["within_budget"] is True
         assert result["tokens"] == 25
-        assert result["budget"] == 1000
+        assert result["budget"] == FORMAT_TOKEN_BUDGETS["skill.md"]
         assert result["severity"] == "ok"
 
     def test_over_budget(self) -> None:
@@ -67,25 +80,17 @@ class TestCheckTokenBudget:
         assert result["severity"] == "over"
 
     def test_severity_ok(self) -> None:
-        # 10% of budget -> ok
-        content = "x" * 400  # 100 tokens out of 1000
-        result = check_token_budget(content, "skill.md")
+        result = check_token_budget(self._content_at(0.10), "skill.md")
         assert result["severity"] == "ok"
         assert result["ratio"] < 0.8
 
     def test_severity_warning(self) -> None:
-        # 90% of budget -> warning
-        # skill.md budget = 1000 tokens, 900 tokens = 3600 chars
-        content = "x" * 3600
-        result = check_token_budget(content, "skill.md")
+        result = check_token_budget(self._content_at(0.90), "skill.md")
         assert result["severity"] == "warning"
         assert 0.8 <= result["ratio"] <= 1.0
 
     def test_severity_over(self) -> None:
-        # 150% of budget -> over
-        # skill.md budget = 1000, 1500 tokens = 6000 chars
-        content = "x" * 6000
-        result = check_token_budget(content, "skill.md")
+        result = check_token_budget(self._content_at(1.50), "skill.md")
         assert result["severity"] == "over"
         assert result["ratio"] > 1.0
 
@@ -95,9 +100,8 @@ class TestCheckTokenBudget:
         assert result["budget"] == FORMAT_TOKEN_BUDGETS["unknown"]
 
     def test_ratio_calculation(self) -> None:
-        # 4000 chars = 1000 tokens, skill.md budget = 1000 -> ratio 1.0
-        content = "x" * 4000
-        result = check_token_budget(content, "skill.md")
+        """Exactly at budget is ratio 1.0 and still within — `over` starts above it."""
+        result = check_token_budget(self._content_at(1.0), "skill.md")
         assert result["ratio"] == 1.0
         assert result["within_budget"] is True
 


### PR DESCRIPTION
`FORMAT_TOKEN_BUDGETS["skill.md"]` was **1000**, which put it at roughly the **12th percentile of the population it measures**.

| population | n | over 1000 | median | p75 |
| --- | --- | --- | --- | --- |
| installed SKILL.md files | 166 | **75%** | **1,960** | 2,934 |
| schliff's own calibration corpus | 16 | 44% | 942 | 2,984 |

The format's own reference implementations sat 2–8× past it — Anthropic's `skill-creator` 8,047, `writing-skills` 6,582, `brainstorming` 2,649, `systematic-debugging` 2,465 — and so did **schliff's own card, at `1,045 / 1,000 (over)`**, immediately after being trimmed from 11,700 to 4,240 chars for exactly this reason.

A threshold that fires on three quarters of its population, including the exemplars, reports "yes" and carries no information.

## Why 2000

Just above the measured median, so it flags the **upper half** instead of the upper three quarters — without adopting the population's bloat as the target. It keeps a SKILL.md held at least as tight as a CLAUDE.md (2000) and tighter than an AGENTS.md (3000), and it still flags `brainstorming` at 2,649: context paid on **every trigger** is worth naming. The derivation sits beside the constant so it stops being a magic number. The other budgets in that table were not measured and are untouched.

## What the miscalibration actually cost

Token budgets are advisory — they never enter a score. But `within_budget` is the state term in the `schliff-watch` firing rule:

```js
budgetWorsened = !withinBudget && (prev.withinBudget === true || tokens > prev.tokens + 1)
```

At 1000 that term was constant-true for 75% of files, so the rule degenerated to "report any growth". The hook itself is well built — delta-based, silent on first sight, deduped per session, fail-open — it had simply been handed a state term with no selectivity.

## Three follow-ons, each exposed by the change

- **The card's worked example printed a budget no SKILL.md could ever show again** (`1,031 / 1,000 (over)`). Replaced with schliff's own real readout, so the numbers are measured rather than invented. The layout stays the card's condensed two-line form — the CLI itself renders bars and labels — so this makes the example *accurate*, not byte-reproducible.
- **`test_tokens.py` hardcoded 1000** and derived its severity-band sizes from it, so five tests broke together on a recalibration — a test reporting on the table rather than on the function. Now derived from `FORMAT_TOKEN_BUDGETS["skill.md"]`; verified agnostic by re-running them against a mutated budget of 3000.
- **`test_formats.py` restated every budget as a literal** while testing alias resolution. Now compares each alias against its canonical entry and keeps the unknown-fall-through check that motivated it. Verified red-capable by breaking the alias map.

## New guard

A regression test that schliff's own card satisfies the budget schliff advertises for its format — a measurement tool must not flag its own exemplar. Verified red by lowering the budget to 800.

The existing char cap (`< 6000`) happens to be tighter today, but it pins a size, not the relationship: lower the budget and the card would start reporting `(over)` on itself with nothing to catch it. That state shipped for months.

## Verification

1601 pytest · integration 100/0 · test-self 21/0 · proof 6/0 · ruff clean · markdownlint 0 · `check-commands` 0 dangling.

No release: advisory display only, and the one verified external consumer drives `score`/`verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-up

A review of this PR produced three findings, all mine, all fixed in `9ffe694`:

1. **Two shipped docs still stated the old budget** — `docs/SCORING.md:113` and `docs/ARCHITECTURE.md:158` carry hand-copied `FORMAT_TOKEN_BUDGETS` tables reading `| skill.md | 1000 |`, which this PR made false. Nothing gated them; markdownlint checks form, not content. (My earlier "not in README/SCORING" check grepped the display form `/ 1,000`, not the table.) Fixed at the root: a parametrized test parses each doc's budget section and compares it to the dict. Verified red in both directions — stale value fails, dropping a documented format fails — and with the code mutated to 3000 only the doc gates go red.
2. **`CHARS_PER_TOKEN = 4` restated the estimator** in a file that already imports `estimate_tokens`, whose docstring says real tokenizers vary. Now derived via a probe, with the built content checked against the estimator so a bad derivation fails loudly instead of silently mis-sizing the band assertions.
3. **`test_over_budget` still hardcoded `== 500`** one method below the tests this PR made table-driven. Now derived from the table.

1603 pytest · test-self 21/0 · proof 6/0 · ruff clean · markdownlint 0.


## Review round 2

Two more findings, both mine, plus one strengthening — `81b0a18`, `a964e55`.

- **A docstring claimed something the code no longer did.** `TestCheckTokenBudget` said its sizes derive from "whatever `skill.md` is budgeted at" — untrue after `test_over_budget` moved to `cursorrules`, and untrue of `test_within_budget_small_content`, which uses a deliberate 25-token absolute. Reworded to what the code does, including why that one absolute is intentional.
- **The docs gate sat outside the class that owns the constant.** It is now a method of `TestFormatTokenBudgets` — "Tests for the FORMAT_TOKEN_BUDGETS constant" — which is exactly what it tests. The module docstring covered only estimation; it now names all three concerns. Re-verified red after the move.
- **The CHANGELOG omitted the docs correction.** Both docs stated the old budget; that is user-visible and now recorded, along with the gate.

### The boundary is independently corroborated

2000 was picked from the installed-population median. This repo already published a measurement that lands on the same number — `docs/launch/state-of-ai-instructions.md`, "Length Has a Sweet Spot":

| Bucket | N | Avg composite |
| --- | ---: | ---: |
| <300 tokens | 12 | 51.3 |
| **300–2000 tokens** | 69 | **64.5** |
| >2000 tokens | 39 | 59.9 |

2000 is where files start scoring measurably worse — so the threshold marks where quality turns, not merely where the distribution sits. Two unrelated methods converging on one number; figures re-read from the source and cross-checked (12+69+39 = 120).

### Checked and deliberately not changed

`ruff format` would reformat this file (a slice-spacing preference). It would also reformat **138 of 140 files** in `scripts/` and `tests/` — the repo is hand-formatted and `ruff check`-clean, and CI runs `check`, not `format`. Formatting this one file would break with the house style, not conform to it.

No type checker runs in CI (verified against the workflows and `pyproject.toml`), all touched lines are within the configured 120-char limit, and `ruff check` passes on both changed files.
