### PR TITLE
security: bound five quadratic scoring regexes and gate the class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and `GET /api/badge?repo=`, from the CLI at the 1 MB cap, and — the worst blast
   radius — from the GitHub Action on a fork PR's AGENTS.md, i.e. in other people's CI.
 
-  Fixed by bounding each quantifier, with every bound **calibrated against the longest
-  run it actually consumes across 380 real instruction files** rather than guessed: 58
-  for `[\w/]+`, 118 for `[\w/.-]+`, 1,151 for a backtick span, 19 for `[\w-]+` in a
-  trigger prompt. A first guessed bound of 120 would have sat one character above a
-  real 118-character token and truncated a real 1,151-character span; the failure mode
-  of a guessed bound is a silent score change, which is why they are measured.
+  Fixed by bounding **only the quantifier the measurement blames**, with every bound
+  **calibrated against the longest run it actually consumes across 380 real instruction
+  files** rather than guessed: 58 for `[\w/]+`, 118 for `[\w/.-]+`, 1,151 for a backtick
+  span, 19 for `[\w-]+` in a trigger prompt. A first guessed bound of 120 would have sat
+  one character above a real 118-character token and truncated a real 1,151-character
+  span; the failure mode of a guessed bound is a silent score change.
+
+  Whitespace runs are deliberately left unbounded. Self-review of the first commit
+  caught it bounding `rm\s+` to `rm\s{1,8}` "for consistency" with the flag runs that
+  were the real quadratic source — which cost **five detections that 8.8.2 caught**
+  (`rm` plus 9 or more spaces or tabs, then `-rf /`), for no gain: that run is prefixed
+  by the literal `rm`, which limits how many start positions it is reachable from, so it
+  never contributed to the blowup. The pattern is linear without the whitespace bound
+  (1.92–2.04× per doubling, measured on a whitespace-run payload). This is the #149
+  defect class reproduced internally — narrowing a matcher without enumerating its
+  evasion classes, then checking only that the corpus verdict did not move, which a
+  corpus cannot show for an evasion it does not contain. Gated by
+  `TestDangerousCmdWhitespaceIsNotBounded`, which walks whitespace-run length 1…100 for
+  spaces and tabs on both sides of the flag cluster; re-introducing the mistake turns 11
+  assertions red.
 
   `clarity` needed a second, independent fix: bounding its regexes alone only took the
   worst case from 162.6 s to 11.9 s, because the match-independent context build and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+
+- **Five scoring regexes were quadratic on untrusted input; the worst cost 162 seconds
+  of CPU for one unauthenticated request.** A trust-boundary audit of the whole repo
+  found the same defect in five places, and it is not the textbook ReDoS shape — no
+  nested quantifier, no overlapping alternation, just **an unbounded run followed by a
+  required literal**. `[\w/]+` before a required `\.` consumes to the end of the input,
+  fails on the dot, and gives back one character at a time, once per start position.
+
+  The measured worst case sat *inside* the public playground's 32 KB input cap, whose
+  own comment claimed that cap bounded "any residual O(n^2) hot path to well under a
+  second": 162.6 s at 25,883 bytes against 46 ms for a benign payload of the same
+  length, growing 4.01× per doubling. Reachable unauthenticated via `POST /api/score`
+  and `GET /api/badge?repo=`, from the CLI at the 1 MB cap, and — the worst blast
+  radius — from the GitHub Action on a fork PR's AGENTS.md, i.e. in other people's CI.
+
+  Fixed by bounding each quantifier, with every bound **calibrated against the longest
+  run it actually consumes across 380 real instruction files** rather than guessed: 58
+  for `[\w/]+`, 118 for `[\w/.-]+`, 1,151 for a backtick span, 19 for `[\w-]+` in a
+  trigger prompt. A first guessed bound of 120 would have sat one character above a
+  real 118-character token and truncated a real 1,151-character span; the failure mode
+  of a guessed bound is a silent score change, which is why they are measured.
+
+  `clarity` needed a second, independent fix: bounding its regexes alone only took the
+  worst case from 162.6 s to 11.9 s, because the match-independent context build and
+  search sat *inside* the per-match loop, turning O(n²) into O(m·n²). Hoisting them out
+  is output-identical by construction. Bound plus hoist: **58.9 ms**.
+
+  Two-sided acceptance, because a one-sided "is it fast now" check is how a narrowing
+  ships as a silent detection loss: **0 of 250 real files change their clarity result**,
+  the published hero score and every case-study number reproduce byte-identically
+  against a clean `main` worktree with identical commands, and every malicious shape is
+  still detected with the same finding counts. `rm -rf /` still matches and the Docker
+  layer-cleanup false positive stays fixed.
+
+  Patterns: `_RE_SPECIFIC_REF`, `_RE_CONCRETE_CMD`, `_RE_SEC_DANGEROUS_CMD` (three
+  consecutive unbounded flag runs before a required `/`), `_RE_LENGTH_EXTENDED` (the
+  *second* branch — the first fails fast on digits, which is why an early probe against
+  one branch showed nothing), and `_RE_SKILL_AS_OBJECT`.
+
+- **Two gates so a sixth one cannot land.** `test_patterns_scale_linearly.py` times
+  every compiled pattern against 25 pathological filler alphabets at doubling lengths
+  and fails on super-linear growth — it found `_RE_SKILL_AS_OBJECT`, which was not on
+  the audit's fix list, on its first run. It confirms an offender at two consecutive
+  doublings with more repetitions before failing, because the healthy margin is
+  1.3–2.4× against a 3.0× threshold and a single sample under load did flake once
+  during development; verified red-capable (4.20×, 4.02× confirmed) and green four
+  times over under four busy cores. `test_patterns_are_bounded.py` is its deterministic
+  companion: it pins each bounded spelling and pins each bound above the corpus maximum
+  it was calibrated from, so tightening one below the real data fails too.
+
+  A repo-wide *static* rule was prototyped and rejected on measurement: "any unbounded
+  quantifier on a character class" flagged 45 of 102 patterns, and the refinement "…with
+  no required literal prefix" still flagged 11, including one certain false positive. A
+  gate whose allowlist is longer than its findings is the thing it exists to prevent.
+
+- **`clarity`'s function docstring contradicted its own module docstring**, claiming a
+  zero default weight and a `--clarity` opt-in. Both were stale — clarity runs in the
+  default scorer set for every format — and that contradiction is exactly what made two
+  quadratic sub-checks in that function look unreachable.
+
+  Spec: `docs/specs/2026-07-30-redos-audit-fixes.md`.
+
 ### Changed
 
 - **The SKILL.md token budget was set below the median of what it measures.** It flagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,16 +59,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   *second* branch — the first fails fast on digits, which is why an early probe against
   one branch showed nothing), and `_RE_SKILL_AS_OBJECT`.
 
-- **Two gates so a sixth one cannot land.** `test_patterns_scale_linearly.py` times
-  every compiled pattern against 25 pathological filler alphabets at doubling lengths
-  and fails on super-linear growth — it found `_RE_SKILL_AS_OBJECT`, which was not on
-  the audit's fix list, on its first run. It confirms an offender at two consecutive
-  doublings with more repetitions before failing, because the healthy margin is
-  1.3–2.4× against a 3.0× threshold and a single sample under load did flake once
-  during development; verified red-capable (4.20×, 4.02× confirmed) and green four
-  times over under four busy cores. `test_patterns_are_bounded.py` is its deterministic
+- **Two gates against a recurrence.** `test_patterns_scale_linearly.py` times all 224
+  compiled patterns across 30 modules against 25 pathological filler alphabets at
+  doubling lengths and fails on super-linear growth — it found `_RE_SKILL_AS_OBJECT`,
+  which was not on the audit's fix list, on its first run. It confirms an offender at two
+  consecutive doublings with more repetitions before failing, because the healthy margin
+  is 1.3–2.4× against a 3.0× threshold and a single sample under load did flake once
+  during development; verified red-capable (4.20×, 4.02× confirmed) and green four times
+  over under four busy cores. `test_patterns_are_bounded.py` is its deterministic
   companion: it pins each bounded spelling and pins each bound above the corpus maximum
   it was calibrated from, so tightening one below the real data fails too.
+
+  **What these gates do not cover, stated rather than implied:** the empirical one reaches
+  exactly as far as its filler alphabet. Its first draft also covered only 11 modules and
+  138 patterns while the harness that found the defects covered 25 and 224 — a gate
+  narrower than the harness it replaces is not a regression guard, so the module list was
+  widened (0 additional findings, so the coverage was free) and a count assertion now
+  fails if it ever shrinks. The remaining blind spot is real and documented in the test:
+  `manifest._FM` is quadratic on a frontmatter-shaped input and none of the generic
+  fillers trip it. A shape nobody thought of stays invisible.
 
   A repo-wide *static* rule was prototyped and rejected on measurement: "any unbounded
   quantifier on a character class" flagged 45 of 102 patterns, and the refinement "…with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Security
 
 - **Five scoring regexes were quadratic on untrusted input; the worst cost 162 seconds
-  of CPU for one unauthenticated request.** A trust-boundary audit of the whole repo
-  found the same defect in five places, and it is not the textbook ReDoS shape — no
-  nested quantifier, no overlapping alternation, just **an unbounded run followed by a
-  required literal**. `[\w/]+` before a required `\.` consumes to the end of the input,
+  of CPU for one unauthenticated request.** A trust-boundary audit of the whole repo found
+  the same defect in four of them; the new empirical gate found the fifth,
+  `_RE_SKILL_AS_OBJECT`, on its first run. It is not the textbook ReDoS shape — no nested
+  quantifier, no overlapping alternation, just **an unbounded run followed by a required
+  literal**. `[\w/]+` before a required `\.` consumes to the end of the input,
   fails on the dot, and gives back one character at a time, once per start position.
 
   The measured worst case sat *inside* the public playground's 32 KB input cap, whose
@@ -80,9 +81,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   fillers trip it. A shape nobody thought of stays invisible.
 
   A repo-wide *static* rule was prototyped and rejected on measurement: "any unbounded
-  quantifier on a character class" flagged 45 of 102 patterns, and the refinement "…with
-  no required literal prefix" still flagged 11, including one certain false positive. A
-  gate whose allowlist is longer than its findings is the thing it exists to prevent.
+  quantifier on a character class" flagged 47 of the 102 patterns in `scoring/patterns/*`,
+  and the refinement "…with no required literal prefix" still flagged 11, including one
+  certain false positive. A gate whose allowlist is longer than its findings is the thing
+  it exists to prevent.
 
 - **`clarity`'s function docstring contradicted its own module docstring**, claiming a
   zero default weight and a `--clarity` opt-in. Both were stale — clarity runs in the

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -1,0 +1,189 @@
+# Bounded quantifiers: closing the ReDoS class found by the 2026-07-30 audit
+
+Status: implementing
+Date: 2026-07-30
+Baseline: `main` @ `ab41827`
+
+## Goal
+
+Close every reachable super-linear regex path found by the whole-repo security audit,
+without moving a single score, and add a gate so a fifth one cannot land.
+
+## Context
+
+A trust-boundary audit of `ab41827` produced seven findings. Four of them are the
+same defect, and it is not the textbook one: **an unbounded quantifier followed by
+a required literal**. No nesting, no overlapping alternation — which is why static
+shape-triage flagged 105 of 169 compiled patterns and isolated neither of the two
+that mattered. An empirical fuzz (warm each pattern, time `.search()` against ~25
+pathological filler alphabets at doubling lengths, keep ratio ≥ 3.0) narrowed 169
+patterns to 32 candidates and then to the reachable ones in a single run.
+
+`[\w/]+` before a required `\.` backtracks one character per start position, so it
+is O(n²) on its own. The same shape appears as `[a-z]*[a-z]*[a-z]*` before `/`, as
+`\d+` before a required word, and as `\s*` allowed to span the `\n` record
+separator.
+
+The headline number: **162.6 s of CPU for one unauthenticated `POST /api/score`**
+at 25,883 bytes — inside `MAX_SKILL_CHARS` = 32 KB, whose own comment claims the cap
+bounds "any residual O(n^2) hot path to well under a second".
+
+### Why this is not a repeat report
+
+v8.6.3 bounded a tail slice in `clarity.py` for exactly this reason, and the module
+docstring has asserted the invariant ever since:
+
+> Runs in the DEFAULT scorer set for every instruction-file format … It therefore
+> executes on untrusted content up to the 1MB read cap, so its regex/loops must stay
+> linear (see the bounded tail slice below).
+
+That fix covered sub-check #1. Sub-checks #2 and #4, in the same function, were left
+unbounded. **A per-sub-check fix does not generalise itself.**
+
+## Requirements
+
+1. Every reachable super-linear path measured in the audit becomes linear
+   (ratio ≤ 2.5 per doubling).
+2. **Zero score movement** on real data — proven, not asserted.
+3. **Recall preserved** — every malicious shape that was detected before is still
+   detected. Two-sided acceptance, because a one-sided "corpus byte-identical" gate
+   is what let the #149 regression through.
+4. A regression gate that fails CI on a new unbounded quantifier.
+5. No change to the `grep` matcher in `run-eval.sh` (dialect-regression risk).
+
+## Technical decisions
+
+### D1 — Bound the quantifier; calibrate the bound from the corpus
+
+Bounds are measured, not guessed. Longest real run per quantifier over 380 real
+instruction files (installed skills, plugin payloads, `benchmarks/`, `docs/`, the
+project's own files):
+
+| quantifier | longest real run | bound chosen | headroom |
+| --- | --- | --- | --- |
+| `[\w/]+` (`_RE_SPECIFIC_REF`) | 58 | 256 | 4.4× |
+| `[\w/.-]+` (`_RE_CONCRETE_CMD`) | 118 | 256 | 2.2× |
+| `` [^`]+ `` (backtick span) | 1151 | 2000 | 1.7× |
+| `\w+` after a dot | 50 | 64 | 1.3× |
+| `[a-z]*` (`rm` flags) | 2 | 12 | 6× |
+| `\d+` (digit run) | 27 | 12 → see D5 | — |
+
+A first guess of 120 would have sat one character above a real 118-char token and
+would have **truncated** a real 1151-char backtick span. That is the whole argument
+for calibrating: the failure mode of a guessed bound is a silent score change.
+
+### D2 — The bound alone is NOT sufficient for `clarity` check #2
+
+Measured on the 162 s payload:
+
+| variant | time | findings |
+| --- | --- | --- |
+| today (unbounded, per-match) | 159,939 ms | 200 |
+| bound only | 11,906 ms | 200 |
+| bound + hoist | **58.9 ms** | 200 |
+
+The residual O(m·n) is the match-independent work sitting inside
+`for match in matches`: the `context` join, the `_RE_BACKTICK_REF` test, and the
+`_RE_SPECIFIC_REF` search do not depend on `match`, so they run once per vague
+reference instead of once per line. Hoisting them is output-identical by
+construction, and verified so on 250 real files (0 differing vague-reference lists).
+
+Rejected: slicing `context` / `rest` to a fixed window. It is a second behaviour
+change on top of a fix that already measures score-neutral, and D1+D2 make it
+unnecessary.
+
+### D3 — `manifest.py`: read the head, drop the unused body
+
+`_FM = r"^---\s*\n(.*?)\n---\s*\n"` is O(n²) because `\s*` may consume newlines:
+every `\s*` length restarts the lazy `(.*?)` scan. `^---[ \t]*\r?\n…` is 32,823×
+faster at 64 KB with a byte-identical verdict **and** `group(1)` on every real shape
+including CRLF and unterminated frontmatter.
+
+Independently, `manifest.py:54` reads with a raw `read_text()` — no
+`MAX_SKILL_SIZE`, unlike every other reader in the engine. Both call sites do
+`fm, _ = parse_frontmatter(...)`: **the returned body is never used.** So the fix is
+not a size cap on a full read — it is to read a bounded head and drop the body from
+the signature. That removes the unbounded read, the quadratic trigger, and a dead
+return value at once.
+
+### D4 — F3 is a reachability correction, not a gate change
+
+`shared.py:215-219`: the `system_prompt` branch of `build_scores` is an early return
+that iterates every scorer and never consults `include_security`. Proven at the
+shipping CLI — `score sp.txt --json` on a `.txt` with a role line emits
+`security: 100`; the same content as `SKILL.md` emits none.
+
+So the standing claim "the security dimension is reachable from no shipping entry
+point" holds for the skill.md family and is **false for `system_prompt`**.
+
+We do **not** start honouring `include_security` there: for `system_prompt`,
+`security` is a documented CORE headline dimension (weight 0.15, `docs/ARCHITECTURE.md`),
+so computing it is correct and suppressing it would move composites. What was wrong
+is that the behaviour was accidental and undocumented. Therefore:
+
+- pin it with a test, so it is a contract rather than an artefact;
+- treat `security.py` and `output_contract.py` as **live** code on that path — their
+  two quadratics get bounded under D1, not deferred as dead weight.
+
+### D5 — `_RE_LENGTH_EXTENDED` needs both branches bounded
+
+First measurement only exercised the leading `max(imum)?…` branch and showed no
+blowup. The culprit is the second branch, `\d+\s*(words?|…)`. Bounding both:
+11,657 ms → 18.3 ms at 16 KB (636×), linear, 0 verdict differences over the corpus,
+and all four real phrasings still matched. Recorded because the incomplete first
+measurement is exactly the trap this project keeps hitting: a probe against a
+fragment is not a probe.
+
+The digit bound is 12, below the measured 27-char run. That run is a digit sequence
+somewhere in prose, not a length constraint; the corpus verdict check (0
+differences) is the authority here, not the raw maximum.
+
+### D6 — Two gates, static and empirical
+
+- `test_patterns_are_bounded.py` — deterministic, gates: no compiled pattern in
+  `scoring/patterns/*` carries an unbounded quantifier before a required literal.
+  Allowlist entries each carry a reason; no blank skips.
+- `test_patterns_scale_linearly.py` — empirical: every compiled pattern against the
+  filler alphabets at doubling lengths, ratio < 3.0. Generous threshold so a loaded
+  CI runner does not flake, while still catching the 4.0× class.
+
+The static test alone is insufficient — the first heuristic written for this audit
+flagged 105 of 169 patterns and isolated neither real one. The empirical test alone
+is timing-based. Both, or the gate is theatre.
+
+### D7 — `run-eval.sh`: make the missing guard visible, do not touch the matcher
+
+`_GREP_TIMEOUT` is set only `if command -v timeout || gtimeout`. Both are absent on
+a stock macOS, so the 2 s guard is inert and its `124)` branch is dead code there.
+
+Measured refutation of the underlying worry: the sink does not backtrack. GNU grep,
+BSD grep 2.6.0 and ugrep 7.5.0 are all DFA-based and stayed flat (0.044–0.050 s) on
+patterns `validate_regex_complexity` accepts (`a*a*a*…b`, `a{1,10}{1,10}b`,
+`(\w+\s?)*$`). The guard is defense-in-depth, not load-bearing.
+
+So: one stderr note when no timeout binary exists, and a comment recording why the
+matcher stays. A portable Python fallback is rejected — swapping ERE for Python `re`
+is what left six assertions dead on CI for months.
+
+### D8 — F6 declined, with the measurement
+
+`playground/public/index.html:1476-1490` auto-scores a `#content=` deeplink 300 ms
+after load. Its entire severity was derived from F1: after D1+D2 the scoring cost is
+linear (58.9 ms for the former 162 s payload), and the endpoint is unauthenticated,
+so there is no CSRF privilege and no XSS (textarea sink, sha256-pinned CSP). No code
+change; recorded here so the decline is auditable.
+
+## Rollout
+
+PR 1 (this spec's D1, D2, D5, D6) → PR 2 (D3) → release v8.9.0 → `vercel --prod`
+for the playground → PR 3 (F4 + F7, playground) → PR 4 (D7).
+
+Release is justified under the project's own rule — a build that used to hang now
+completes, so a gate's runtime behaviour changes — and the GitHub Action installs
+`schliff` latest, which is the fork-PR path that carries the worst blast radius.
+
+## Open questions
+
+None blocking. `_RE_SEC_BASE64_CMD` and its siblings in `patterns/base.py` carry
+`[^\n]*` spans that the v8.6.3 pass already bounded to `{0,200}`; the new static gate
+will confirm that mechanically rather than by reading.

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -72,6 +72,40 @@ A first guess of 120 would have sat one character above a real 118-char token an
 would have **truncated** a real 1151-char backtick span. That is the whole argument
 for calibrating: the failure mode of a guessed bound is a silent score change.
 
+### D1a — Bound ONLY the quantifier that causes the blowup, never whitespace
+
+Found in self-review of the first commit, before it was pushed. That commit also bounded
+`rm\s+` to `rm\s{1,8}`, `\s*` to `\s{0,8}` and similar, "for consistency" with the flag
+runs and digit runs that were the real quadratic source. Enumerating the evasion classes
+rather than sampling them showed the cost:
+
+| whitespace run between `rm` and `-rf /` | 8.8.2 | first commit |
+| --- | --- | --- |
+| 1–8 spaces or tabs | detected | detected |
+| **9, 10, 16, 40, 100** spaces | detected | **missed** |
+| **9+ tabs** | detected | **missed** |
+
+Five detections lost in a security detector, for no gain: that whitespace run is prefixed
+by the literal `rm`, which limits how many start positions it is reachable from, so it
+never contributed to the blowup. Verified after reverting it — `_RE_SEC_DANGEROUS_CMD`
+stays linear (1.92–2.04× per doubling) even with a whitespace-run payload, and 0
+detections are lost against 8.8.2.
+
+This is the #149 defect class reproduced by me: narrowing a matcher without enumerating
+its evasion classes, then checking only that the corpus verdict did not move. A corpus
+check cannot see an evasion the corpus does not contain. The rule that follows:
+
+> Bound the quantifier the measurement blames. Leave every other quantifier alone, and
+> prove the bound costs nothing by walking the evasion dimension, not by sampling it.
+
+Gate: `TestDangerousCmdWhitespaceIsNotBounded` walks whitespace-run length 1…100 for
+spaces and tabs, on both sides of the flag cluster. Mutation-tested — re-introducing the
+exact `\s{1,8}` mistake turns 11 assertions red.
+
+Also refuted in the same review, by measurement rather than by argument: `\d{1,12}` in
+`_RE_LENGTH_EXTENDED` does **not** lose the 27-digit case, because the match may start
+anywhere inside the digit run. The suspicion was reasonable and wrong.
+
 ### D2 — The bound alone is NOT sufficient for `clarity` check #2
 
 Measured on the 162 s payload:

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -1,23 +1,34 @@
 # Bounded quantifiers: closing the ReDoS class found by the 2026-07-30 audit
 
-Status: implementing
+Status: D1, D1a, D2, D5, D6 implemented (PR 1). D3, D7, D8 pending.
 Date: 2026-07-30
 Baseline: `main` @ `ab41827`
 
 ## Goal
 
 Close every reachable super-linear regex path found by the whole-repo security audit,
-without moving a single score, and add a gate so a fifth one cannot land.
+without moving a single score, and add a gate so the next one cannot land.
 
 ## Context
 
-A trust-boundary audit of `ab41827` produced seven findings. Four of them are the
-same defect, and it is not the textbook one: **an unbounded quantifier followed by
-a required literal**. No nesting, no overlapping alternation — which is why static
-shape-triage flagged 105 of 169 compiled patterns and isolated neither of the two
-that mattered. An empirical fuzz (warm each pattern, time `.search()` against ~25
-pathological filler alphabets at doubling lengths, keep ratio ≥ 3.0) narrowed 169
-patterns to 32 candidates and then to the reachable ones in a single run.
+A trust-boundary audit of `ab41827` produced seven findings. Three of them (F1, F2, F3)
+are the same defect in **five** patterns, and it is not the textbook one: **an unbounded
+quantifier followed by a required literal**. No nesting, no overlapping alternation.
+
+Four of those five are in this PR's scope; the fifth is `manifest._FM` (D3). A **sixth**
+pattern, `_RE_SKILL_AS_OBJECT`, was not an audit finding at all — the new empirical gate
+found it on its first run, which is the clearest evidence for that gate's value and is
+not credited to the audit.
+
+Both figures below use **one** denominator: the 167 unique compiled patterns reachable
+across the engine's 21 pattern-bearing modules, measured on `main`.
+
+- Static shape-triage flagged **62 of 167** and isolated neither of the two that
+  mattered. Restricted to `scoring/patterns/*` (102 patterns) a stricter rule still
+  flagged 47. Noise, not signal.
+- An empirical fuzz — warm each pattern, time `.search()` against 25 pathological filler
+  alphabets at doubling lengths, keep ratio ≥ 3.0 — narrowed the same 167 to **32
+  candidates** and then to the reachable ones, in a single run.
 
 `[\w/]+` before a required `\.` backtracks one character per start position, so it
 is O(n²) on its own. The same shape appears as `[a-z]*[a-z]*[a-z]*` before `/`, as
@@ -42,13 +53,21 @@ unbounded. **A per-sub-check fix does not generalise itself.**
 
 ## Requirements
 
-1. Every reachable super-linear path measured in the audit becomes linear
-   (ratio ≤ 2.5 per doubling).
+1. Every reachable super-linear path measured in the audit becomes linear. Two numbers,
+   deliberately different: the **measured** post-fix ratio must be ≈2.0 per doubling,
+   while the **gate** trips at 3.0 — the slack is flake margin for a loaded CI runner,
+   not tolerance for a slower fix. Actuals came in at 1.92–2.12.
 2. **Zero score movement** on real data — proven, not asserted.
 3. **Recall preserved** — every malicious shape that was detected before is still
    detected. Two-sided acceptance, because a one-sided "corpus byte-identical" gate
-   is what let the #149 regression through.
-4. A regression gate that fails CI on a new unbounded quantifier.
+   is what let the #149 regression through. D1a shows why this requirement is not
+   optional: the first attempt at this fix violated it.
+4. A regression gate. **Not** "fails CI on a new unbounded quantifier" — that was the
+   original wording and it describes the repo-wide static rule this spec later rejected
+   on measurement (D6). What ships instead: the empirical gate fails on super-linear
+   *growth* across 224 patterns, and the deterministic gate fails if any of the five
+   bounded spellings is removed or tightened below its corpus maximum. An unbounded
+   quantifier that happens to be harmless is not flagged by either, on purpose.
 5. No change to the `grep` matcher in `run-eval.sh` (dialect-regression risk).
 
 ## Technical decisions
@@ -64,7 +83,8 @@ project's own files):
 | `[\w/]+` (`_RE_SPECIFIC_REF`) | 58 | 256 | 4.4× |
 | `[\w/.-]+` (`_RE_CONCRETE_CMD`) | 118 | 256 | 2.2× |
 | `` [^`]+ `` (backtick span) | 1151 | 2000 | 1.7× |
-| `\w+` after a dot | 50 | 64 | 1.3× |
+| `\w+` after a dot | 50 | 128 | 2.6× |
+| `[\w-]+` (`_RE_SKILL_AS_OBJECT`) | 19 | 64 | 3.4× |
 | `[a-z]*` (`rm` flags) | 2 | 12 | 6× |
 | `\d+` (digit run) | 27 | 12 → see D5 | — |
 
@@ -174,16 +194,46 @@ differences) is the authority here, not the raw maximum.
 
 ### D6 — Two gates, static and empirical
 
-- `test_patterns_are_bounded.py` — deterministic, gates: no compiled pattern in
-  `scoring/patterns/*` carries an unbounded quantifier before a required literal.
-  Allowlist entries each carry a reason; no blank skips.
-- `test_patterns_scale_linearly.py` — empirical: every compiled pattern against the
-  filler alphabets at doubling lengths, ratio < 3.0. Generous threshold so a loaded
-  CI runner does not flake, while still catching the 4.0× class.
+**As built** (this section replaces an earlier draft that specified a repo-wide static
+rule with an allowlist; that design was prototyped and rejected on measurement — see
+"rejected" below. The spec is the source of truth, so it records what shipped):
 
-The static test alone is insufficient — the first heuristic written for this audit
-flagged 105 of 169 patterns and isolated neither real one. The empirical test alone
-is timing-based. Both, or the gate is theatre.
+- `test_patterns_are_bounded.py` — deterministic, zero false positives. For each of the
+  five bounded patterns it asserts (a) the **presence** of each bounded spelling, and
+  (b) that each bound stays **above the corpus maximum it was calibrated from** (58, 118,
+  1151, 50, 19). Every assertion mutation-tested: un-bounding a pattern, tightening a
+  bound below its measured maximum, and truncating the backtick span each turn it red.
+- `test_patterns_scale_linearly.py` — empirical, 224 compiled patterns across 30 modules
+  × 25 filler alphabets at doubling lengths, ratio < 3.0. Two-stage: a flagged filler is
+  re-measured with more repetitions **and at a second doubling**, and only fails if both
+  doublings are super-linear. The healthy margin is 1.3–2.4× against a 3.0× threshold,
+  which is too thin to rest on one sample — a single sample under load did flake once
+  during development. Verified red-capable (4.20×, 4.02× confirmed) and green four times
+  over under four busy cores.
+
+**Rejected, with the measurement:** a repo-wide static rule flagging "any unbounded
+quantifier on a character class" marked 47 of the 102 patterns in `scoring/patterns/*`
+(measured on `main`); the refinement "…with no
+required literal prefix, since a literal limits the number of start positions" still
+marked 11, including `_RE_BACKTICK_REF`, where a leading backtick does limit start
+positions. Each further refinement needs its own justification, and a gate whose
+allowlist is longer than its findings is the thing it exists to prevent. The repo-wide
+sweep is therefore the empirical test's job.
+
+**Coverage, and what it does not cover.** The first draft of the empirical gate covered
+11 modules and 138 patterns while the audit harness that found the defects covered 25
+and 224 — a gate narrower than the harness it replaces is not a regression guard. Widened
+to 30 modules (0 additional findings, so the coverage was free), imports no longer behind
+a `try/except` that could shrink coverage silently, and a count assertion that fails if
+the collection ever shrinks.
+
+The remaining blind spot is real: **the gate reaches exactly as far as its filler
+alphabet.** `manifest._FM` (D3) is quadratic on a frontmatter-shaped input at 3.95× per
+doubling and none of the 25 generic fillers trip it — they come in at 1.85×, below the
+absolute floor. The frontmatter filler therefore lands **with** the D3 fix, where it is
+red-before-green rather than red-on-main. The `_MIN_ABS_SECONDS` floor has the same
+character: it suppresses noise, and would also suppress a quadratic with a very small
+constant at this input size.
 
 ### D7 — `run-eval.sh`: make the missing guard visible, do not touch the matcher
 

--- a/skills/schliff/scripts/scoring/clarity.py
+++ b/skills/schliff/scripts/scoring/clarity.py
@@ -71,7 +71,11 @@ def _extract_action_pairs(text, pattern):
 def score_clarity(skill_path: str) -> dict:
     """Score instruction clarity — detect contradictions, ambiguity, vague references.
 
-    Optional 7th dimension with zero default weight. Activated via --clarity.
+    Runs in the DEFAULT scorer set for every instruction-file format, at weight 0.05
+    on the skill.md family — see the module docstring and `scoring/registry.py`. (The
+    previous line here claimed a zero default weight and a `--clarity` opt-in; both
+    were stale, and the contradiction with the module docstring above is exactly what
+    made two quadratic sub-checks in this function look unreachable.)
 
     Sub-checks (100 pts total):
     - Contradiction detection (30 pts): "always X" vs "never X" on same topic
@@ -123,15 +127,28 @@ def score_clarity(skill_path: str) -> dict:
     vague_refs = []
     for i, line in enumerate(lines):
         matches = _RE_VAGUE_REF.findall(line)
+        if not matches:
+            continue
+        # Both tests below are match-INDEPENDENT: they look at the line and at the
+        # preceding 3 lines, never at `match`. Running them once per line instead of
+        # once per match is output-identical by construction (verified on 250 real
+        # files, 0 differing vague-reference lists) and it is what actually closes the
+        # hot path: bounding the regex alone took the 25.9KB worst case from 162.6s to
+        # 11.9s, because O(n^2) had become O(m*n). With the work hoisted: 58.9ms.
+        # See docs/specs/2026-07-30-redos-audit-fixes.md (D2).
+        #
+        # Skip if a backtick-quoted reference is on the same line (e.g. "the file
+        # `output.json`").
+        if _RE_BACKTICK_REF.search(line):
+            continue
+        # Check the preceding 3 lines for a specific file/path reference. If there is
+        # no specific path, filename, or backtick-quoted reference nearby, every
+        # occurrence on this line is vague.
+        context = "\n".join(lines[max(0, i - 3):i])
+        if _RE_SPECIFIC_REF.search(context):
+            continue
         for match in matches:
-            # Skip if backtick-quoted reference is on the same line (e.g., "the file `output.json`")
-            if _RE_BACKTICK_REF.search(line):
-                continue
-            # Check preceding 3 lines for a specific file/path reference
-            context = "\n".join(lines[max(0, i - 3):i])
-            # If no specific path, filename, or backtick-quoted reference nearby, it's vague
-            if not _RE_SPECIFIC_REF.search(context):
-                vague_refs.append(f"line {i + 1}: {match}")
+            vague_refs.append(f"line {i + 1}: {match}")
 
     if vague_refs:
         penalty = min(25, len(vague_refs) * 5)

--- a/skills/schliff/scripts/scoring/output_contract.py
+++ b/skills/schliff/scripts/scoring/output_contract.py
@@ -40,10 +40,10 @@ _RE_JSON_KEY = re.compile(r'"(\w+)"\s*:')
 # digits. Measured 11.7s at 16KB, bounded 18ms (636x), linear, 0 verdict differences
 # across the corpus. See docs/specs/2026-07-30-redos-audit-fixes.md (D5).
 _RE_LENGTH_EXTENDED = re.compile(
-    r"(?i)(max(imum)?\s{1,8}.{0,30}\d{1,12}\s{0,8}(words?|tokens?|sentences?|characters?"
+    r"(?i)(max(imum)?\s+.{0,30}\d{1,12}\s*(words?|tokens?|sentences?|characters?"
     r"|paragraphs?|lines?)"
-    r"|\d{1,12}\s{0,8}(words?|tokens?|sentences?|characters?|paragraphs?|lines?)"
-    r"\s{0,8}(max|limit|cap))"
+    r"|\d{1,12}\s*(words?|tokens?|sentences?|characters?|paragraphs?|lines?)"
+    r"\s*(max|limit|cap))"
 )
 
 # Extended example pattern: "Example N:" or "Example:" with code block nearby

--- a/skills/schliff/scripts/scoring/output_contract.py
+++ b/skills/schliff/scripts/scoring/output_contract.py
@@ -34,10 +34,16 @@ _RE_JSON_SKELETON = re.compile(r'\{[^}]{5,500}\}')
 _RE_JSON_KEY = re.compile(r'"(\w+)"\s*:')
 
 # Extended length constraint: catches "Maximum response size: 2000 tokens" etc.
+# Both branches are bounded. The SECOND one is the expensive branch — `\d+` before a
+# required word unit is O(n^2) on a long digit run — which is why an early probe
+# against the leading `max(imum)?...` branch alone showed nothing: it fails fast on
+# digits. Measured 11.7s at 16KB, bounded 18ms (636x), linear, 0 verdict differences
+# across the corpus. See docs/specs/2026-07-30-redos-audit-fixes.md (D5).
 _RE_LENGTH_EXTENDED = re.compile(
-    r"(?i)(max(imum)?\s+.{0,30}\d+\s*(words?|tokens?|sentences?|characters?"
+    r"(?i)(max(imum)?\s{1,8}.{0,30}\d{1,12}\s{0,8}(words?|tokens?|sentences?|characters?"
     r"|paragraphs?|lines?)"
-    r"|\d+\s*(words?|tokens?|sentences?|characters?|paragraphs?|lines?)\s*(max|limit|cap))"
+    r"|\d{1,12}\s{0,8}(words?|tokens?|sentences?|characters?|paragraphs?|lines?)"
+    r"\s{0,8}(max|limit|cap))"
 )
 
 # Extended example pattern: "Example N:" or "Example:" with code block nearby

--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -89,7 +89,20 @@ _RE_VAGUE_REF = re.compile(
     r"\b(the\s+(?:file|script|output|result|command|path|tool|config))\b", re.IGNORECASE
 )
 _RE_BACKTICK_REF = re.compile(r"`[^`]+`")
-_RE_SPECIFIC_REF = re.compile(r"(`[^`]+`|[\w/]+\.\w+|/[\w/]+)")
+# Every quantifier here is bounded, and the bounds are measured rather than guessed.
+# The shape `[\w/]+` followed by a REQUIRED `\.` is O(n^2) on its own — no nesting
+# and no overlapping alternation, which is why shape-based triage misses it: the run
+# consumes to the end of the input, fails on the dot, and gives back one character at
+# a time, once per start position. Measured 4.4s at 32KB, ratio 4.0x per doubling.
+#
+# Bounds come from the longest run each quantifier actually consumes across 380 real
+# instruction files (installed skills, plugin payloads, benchmarks/, docs/, this
+# project's own files): `[\w/]+` 58, `[\w/.-]+` 118, a backtick span 1151, `\w+`
+# after the dot 50. A first guess of 120 would have sat one character above a real
+# 118-char token and truncated a real 1151-char span — the failure mode of a guessed
+# bound is a silent score change, so calibrate. Verified score-neutral: 0 of 250 real
+# files move. See docs/specs/2026-07-30-redos-audit-fixes.md (D1).
+_RE_SPECIFIC_REF = re.compile(r"(`[^`]{1,2000}`|[\w/]{1,256}\.\w{1,64}|/[\w/]{1,256})")
 _RE_AMBIGUOUS_PRONOUN = re.compile(
     r"^\s*(It|This|That)\s+(is|does|will|can|should|has|was|means)\b"
 )
@@ -100,7 +113,8 @@ _RE_CONCEPTUAL = re.compile(
     r"(?i)(baseline|all\s+\d+|VERIFY|evolution|"
     r"the\s+(?:process|workflow|pipeline|approach|system|loop|strategy)\s+(?:on|for|to|with|against))"
 )
-_RE_CONCRETE_CMD = re.compile(r"(`[^`]+`|[\w/.-]+\.\w+|/[\w/]+)")
+# Same shape, same bounds, same reason as _RE_SPECIFIC_REF above.
+_RE_CONCRETE_CMD = re.compile(r"(`[^`]{1,2000}`|[\w/.-]{1,256}\.\w{1,64}|/[\w/]{1,256})")
 _RE_CODE_BLOCK_START = re.compile(r"^```")
 
 # ---------------------------------------------------------------------------
@@ -222,9 +236,16 @@ _RE_SEC_ENV_LEAK = re.compile(
 # `rm -rf /var/lib/apt/lists/*` was reported as a root wipe (all 13 dangerous_cmd hits in
 # a 670-skill field scan were this). `rm -rf /` and `rm -rf /*` still match; a scoped
 # delete no longer does.
+# The three consecutive `[a-z]*` runs before a required `/` were polynomial: on
+# `rm -rrrr...r` they can split the run in many ways before the match fails.
+# Measured 2.7s at 16KB; bounded it is linear (12,946x faster) with 0 verdict
+# differences across 380 real files. Longest real flag run is 2 chars (`rf`), so 12
+# is 6x headroom; `\s{1,8}` likewise covers every real spelling of `rm  -rf  /`.
+# Reachable from the shipping CLI via the system_prompt format, where `security` is a
+# core headline dimension — see the reachability pin in tests/unit/test_scoring_redos.py.
 _RE_SEC_DANGEROUS_CMD = re.compile(
-    r"(?:rm\s+-[a-z]*r[a-z]*f[a-z]*\s+/(?![A-Za-z0-9_.-])|"
-    r"rm\s+-[a-z]*f[a-z]*r[a-z]*\s+/(?![A-Za-z0-9_.-])|"
+    r"(?:rm\s{1,8}-[a-z]{0,12}r[a-z]{0,12}f[a-z]{0,12}\s{1,8}/(?![A-Za-z0-9_.-])|"
+    r"rm\s{1,8}-[a-z]{0,12}f[a-z]{0,12}r[a-z]{0,12}\s{1,8}/(?![A-Za-z0-9_.-])|"
     r"chmod\s+777\s|"
     r"dd\s+if=/dev/(?:zero|random|urandom)\s+of=/dev/|"
     r"mkfs\.\w+\s+/dev/|"

--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -98,11 +98,16 @@ _RE_BACKTICK_REF = re.compile(r"`[^`]+`")
 # Bounds come from the longest run each quantifier actually consumes across 380 real
 # instruction files (installed skills, plugin payloads, benchmarks/, docs/, this
 # project's own files): `[\w/]+` 58, `[\w/.-]+` 118, a backtick span 1151, `\w+`
-# after the dot 50. A first guess of 120 would have sat one character above a real
-# 118-char token and truncated a real 1151-char span — the failure mode of a guessed
-# bound is a silent score change, so calibrate. Verified score-neutral: 0 of 250 real
-# files move. See docs/specs/2026-07-30-redos-audit-fixes.md (D1).
-_RE_SPECIFIC_REF = re.compile(r"(`[^`]{1,2000}`|[\w/]{1,256}\.\w{1,64}|/[\w/]{1,256})")
+# after the dot 50. The bounds below carry 4.4x / 2.2x / 1.7x / 2.6x headroom over those.
+#
+# A first guess of 120 would have sat one character above a real 118-char token and
+# truncated a real 1151-char span; a first pass at the dot suffix used 64, only 1.28x
+# over the measured 50. The failure mode of a guessed bound is a silent score change, so
+# calibrate and keep the headroom generous — widening a bound costs nothing here, since
+# the cost per start position is O(bound) either way and the pattern stays linear.
+# Verified score-neutral: 0 of 250 real files move.
+# See docs/specs/2026-07-30-redos-audit-fixes.md (D1).
+_RE_SPECIFIC_REF = re.compile(r"(`[^`]{1,2000}`|[\w/]{1,256}\.\w{1,128}|/[\w/]{1,256})")
 _RE_AMBIGUOUS_PRONOUN = re.compile(
     r"^\s*(It|This|That)\s+(is|does|will|can|should|has|was|means)\b"
 )
@@ -114,7 +119,7 @@ _RE_CONCEPTUAL = re.compile(
     r"the\s+(?:process|workflow|pipeline|approach|system|loop|strategy)\s+(?:on|for|to|with|against))"
 )
 # Same shape, same bounds, same reason as _RE_SPECIFIC_REF above.
-_RE_CONCRETE_CMD = re.compile(r"(`[^`]{1,2000}`|[\w/.-]{1,256}\.\w{1,64}|/[\w/]{1,256})")
+_RE_CONCRETE_CMD = re.compile(r"(`[^`]{1,2000}`|[\w/.-]{1,256}\.\w{1,128}|/[\w/]{1,256})")
 _RE_CODE_BLOCK_START = re.compile(r"^```")
 
 # ---------------------------------------------------------------------------
@@ -240,12 +245,22 @@ _RE_SEC_ENV_LEAK = re.compile(
 # `rm -rrrr...r` they can split the run in many ways before the match fails.
 # Measured 2.7s at 16KB; bounded it is linear (12,946x faster) with 0 verdict
 # differences across 380 real files. Longest real flag run is 2 chars (`rf`), so 12
-# is 6x headroom; `\s{1,8}` likewise covers every real spelling of `rm  -rf  /`.
+# is 6x headroom.
+#
+# The surrounding `\s+` runs are deliberately NOT bounded. They are prefixed by the
+# literal `rm`, which limits how many start positions they are reachable from, so they
+# never contributed to the blowup — and bounding them to `\s{1,8}` in the first draft of
+# this fix cost five detections 8.8.2 caught (`rm` + >=9 spaces or tabs + `-rf /`).
+# Verified linear without the bound (1.92-2.04x per doubling on a whitespace-run
+# payload). Narrowing a detector without enumerating its evasion classes is the #149
+# defect; the enumeration is TestDangerousCmdWhitespaceIsNotBounded in
+# tests/unit/test_security_field_false_positives.py.
+#
 # Reachable from the shipping CLI via the system_prompt format, where `security` is a
 # core headline dimension — see the reachability pin in tests/unit/test_scoring_redos.py.
 _RE_SEC_DANGEROUS_CMD = re.compile(
-    r"(?:rm\s{1,8}-[a-z]{0,12}r[a-z]{0,12}f[a-z]{0,12}\s{1,8}/(?![A-Za-z0-9_.-])|"
-    r"rm\s{1,8}-[a-z]{0,12}f[a-z]{0,12}r[a-z]{0,12}\s{1,8}/(?![A-Za-z0-9_.-])|"
+    r"(?:rm\s+-[a-z]{0,12}r[a-z]{0,12}f[a-z]{0,12}\s+/(?![A-Za-z0-9_.-])|"
+    r"rm\s+-[a-z]{0,12}f[a-z]{0,12}r[a-z]{0,12}\s+/(?![A-Za-z0-9_.-])|"
     r"chmod\s+777\s|"
     r"dd\s+if=/dev/(?:zero|random|urandom)\s+of=/dev/|"
     r"mkfs\.\w+\s+/dev/|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -148,8 +148,8 @@ _RE_ANTI_DOMAIN_SIGNAL = re.compile(
 # Found by tests/unit/test_patterns_scale_linearly.py, not by the audit's fix list —
 # which is the reason that gate exists.
 _RE_SKILL_AS_OBJECT = re.compile(
-    r"(?i)(?:my|this|the|our|your|a|an)\s{1,8}(?:[\w-]{1,64}\s{1,8}){0,3}skills?\b|"
-    r"[\w-]{1,64}\s{1,8}skills?\b\s{1,8}(?:conflicts?|needs?|works?|is\b|when\b|that\b)"
+    r"(?i)(?:my|this|the|our|your|a|an)\s+(?:[\w-]{1,64}\s+){0,3}skills?\b|"
+    r"[\w-]{1,64}\s+skills?\b\s+(?:conflicts?|needs?|works?|is\b|when\b|that\b)"
 )
 
 

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -135,9 +135,21 @@ _RE_ANTI_DOMAIN_SIGNAL = re.compile(
 # mention. When this is present the anti-domain suppression must NOT fire,
 # otherwise legitimate skill-improvement prompts that name a domain
 # ("improve the composability of my database skill") get wrongly suppressed.
+# Bounded quantifiers: the SECOND alternative starts with `[\w-]+` and therefore has
+# no literal prefix to limit start positions, so an unbounded run before the required
+# `\s+` was O(n^2) — measured 2.8s at 16KB, ratio 4.1x per doubling. This pattern is
+# fed eval-suite trigger prompts, i.e. untrusted JSON, so the input is attacker-chosen
+# on any `score --eval-suite` / `run-eval.sh` / Action `eval-suite` path.
+#
+# Bound 64 against a measured longest real run of 19 chars across 494 trigger and test
+# prompts (3.4x headroom). Verified identical on the two cases this pattern exists to
+# protect ("improve the composability of my database skill", "the migration skill") and
+# on the anti-signal it must keep rejecting ("optimize my database queries").
+# Found by tests/unit/test_patterns_scale_linearly.py, not by the audit's fix list —
+# which is the reason that gate exists.
 _RE_SKILL_AS_OBJECT = re.compile(
-    r"(?i)(?:my|this|the|our|your|a|an)\s+(?:[\w-]+\s+){0,3}skills?\b|"
-    r"[\w-]+\s+skills?\b\s+(?:conflicts?|needs?|works?|is\b|when\b|that\b)"
+    r"(?i)(?:my|this|the|our|your|a|an)\s{1,8}(?:[\w-]{1,64}\s{1,8}){0,3}skills?\b|"
+    r"[\w-]{1,64}\s{1,8}skills?\b\s{1,8}(?:conflicts?|needs?|works?|is\b|when\b|that\b)"
 )
 
 

--- a/skills/schliff/tests/unit/test_patterns_are_bounded.py
+++ b/skills/schliff/tests/unit/test_patterns_are_bounded.py
@@ -44,8 +44,10 @@ BOUNDED_SPELLINGS = [
      [r"\[\^`\]\{1,\d+\}", r"\[\\w/\]\{1,\d+\}", r"\\w\{1,\d+\}"]),
     (_RE_CONCRETE_CMD, "_RE_CONCRETE_CMD",
      [r"\[\^`\]\{1,\d+\}", r"\[\\w/\.-\]\{1,\d+\}", r"\\w\{1,\d+\}"]),
+    # Only the flag runs — the whitespace around them is deliberately unbounded, see
+    # TestDangerousCmdWhitespaceIsNotBounded in test_security_field_false_positives.py.
     (_RE_SEC_DANGEROUS_CMD, "_RE_SEC_DANGEROUS_CMD",
-     [r"rm\\s\{1,\d+\}-\[a-z\]\{0,\d+\}"]),
+     [r"rm\\s\+-\[a-z\]\{0,\d+\}r\[a-z\]\{0,\d+\}f\[a-z\]\{0,\d+\}"]),
     (_RE_LENGTH_EXTENDED, "_RE_LENGTH_EXTENDED",
      [r"\\d\{1,\d+\}"]),
     (_RE_SKILL_AS_OBJECT, "_RE_SKILL_AS_OBJECT",
@@ -73,6 +75,12 @@ CORPUS_MAXIMA = {
     "_RE_SPECIFIC_REF word/slash run": (_RE_SPECIFIC_REF, r"\[\\w/\]\{1,(\d+)\}", 58),
     "_RE_CONCRETE_CMD word/slash/dot run": (
         _RE_CONCRETE_CMD, r"\[\\w/\.-\]\{1,(\d+)\}", 118),
+    # The suffix after the dot. Widened from 64 to 128 in self-review: 64 carried only
+    # 1.28x headroom over the measured 50, which is too thin for a value that moves
+    # scores when it is wrong. Verified linear at 128 and 0 corpus differences.
+    "_RE_SPECIFIC_REF dot suffix": (_RE_SPECIFIC_REF, r"\\w\{1,(\d+)\}", 50),
+    "_RE_CONCRETE_CMD dot suffix": (_RE_CONCRETE_CMD, r"\\w\{1,(\d+)\}", 50),
+    "_RE_SKILL_AS_OBJECT word run": (_RE_SKILL_AS_OBJECT, r"\[\\w-\]\{1,(\d+)\}", 19),
 }
 
 

--- a/skills/schliff/tests/unit/test_patterns_are_bounded.py
+++ b/skills/schliff/tests/unit/test_patterns_are_bounded.py
@@ -6,12 +6,12 @@ empirically. This file is the zero-false-positive half: it pins the exact patter
 the corpus measurements they were calibrated from.
 
 Scope note, recorded deliberately. A repo-wide static rule was prototyped and
-rejected on measurement: flagging "any unbounded quantifier on a character class"
-marked 45 of 102 patterns, and the refinement "…with no required literal prefix,
-since a literal limits the number of start positions" still marked 11 — including
-`_RE_BACKTICK_REF`, where a leading backtick does limit start positions. A gate whose
-allowlist is longer than its findings is the thing it is supposed to prevent, so the
-repo-wide sweep is left to the empirical test and this file stays exact.
+rejected on measurement: flagging "any unbounded quantifier on a character class" marked
+47 of the 102 patterns in `scoring/patterns/*`, and the refinement "…with no required
+literal prefix, since a literal limits the number of start positions" still marked 11 —
+including `_RE_BACKTICK_REF`, where a leading backtick does limit start positions. A gate
+whose allowlist is longer than its findings is the thing it is supposed to prevent, so
+the repo-wide sweep is left to the empirical test and this file stays exact.
 
 Why the bounds are load-bearing and not cosmetic: they were calibrated from the
 longest run each quantifier actually consumes across 380 real instruction files. Lower

--- a/skills/schliff/tests/unit/test_patterns_are_bounded.py
+++ b/skills/schliff/tests/unit/test_patterns_are_bounded.py
@@ -1,0 +1,102 @@
+"""Deterministic guard: the patterns bounded by the 2026-07-30 audit stay bounded.
+
+Companion to `test_patterns_scale_linearly.py`, which fuzzes every compiled pattern
+empirically. This file is the zero-false-positive half: it pins the exact patterns a
+"simplification" is most likely to un-bound, and it pins the BOUNDS themselves against
+the corpus measurements they were calibrated from.
+
+Scope note, recorded deliberately. A repo-wide static rule was prototyped and
+rejected on measurement: flagging "any unbounded quantifier on a character class"
+marked 45 of 102 patterns, and the refinement "…with no required literal prefix,
+since a literal limits the number of start positions" still marked 11 — including
+`_RE_BACKTICK_REF`, where a leading backtick does limit start positions. A gate whose
+allowlist is longer than its findings is the thing it is supposed to prevent, so the
+repo-wide sweep is left to the empirical test and this file stays exact.
+
+Why the bounds are load-bearing and not cosmetic: they were calibrated from the
+longest run each quantifier actually consumes across 380 real instruction files. Lower
+them and real files start scoring differently; remove them and the O(n^2) returns.
+See docs/specs/2026-07-30-redos-audit-fixes.md (D1, D6).
+"""
+import re
+
+import pytest
+
+from scoring.output_contract import _RE_LENGTH_EXTENDED
+from scoring.patterns.base import (
+    _RE_CONCRETE_CMD,
+    _RE_SEC_DANGEROUS_CMD,
+    _RE_SPECIFIC_REF,
+)
+from scoring.patterns.skill_md import _RE_SKILL_AS_OBJECT
+
+# Assert the PRESENCE of each bounded spelling rather than the ABSENCE of any
+# unbounded quantifier. The absence form was tried and rejected: it fails
+# `_RE_SEC_DANGEROUS_CMD`, whose other alternatives keep `chmod\s+777` and `mkfs\.\w+`
+# — literal-prefixed runs that the empirical gate measures as linear, because a
+# required literal limits how many start positions the run is reachable from. Asserting
+# presence targets the exact regression (someone "simplifying" a bound away) with no
+# false positives and no allowlist.
+#
+# (regex object, name, [sub-expressions that must remain bounded])
+BOUNDED_SPELLINGS = [
+    (_RE_SPECIFIC_REF, "_RE_SPECIFIC_REF",
+     [r"\[\^`\]\{1,\d+\}", r"\[\\w/\]\{1,\d+\}", r"\\w\{1,\d+\}"]),
+    (_RE_CONCRETE_CMD, "_RE_CONCRETE_CMD",
+     [r"\[\^`\]\{1,\d+\}", r"\[\\w/\.-\]\{1,\d+\}", r"\\w\{1,\d+\}"]),
+    (_RE_SEC_DANGEROUS_CMD, "_RE_SEC_DANGEROUS_CMD",
+     [r"rm\\s\{1,\d+\}-\[a-z\]\{0,\d+\}"]),
+    (_RE_LENGTH_EXTENDED, "_RE_LENGTH_EXTENDED",
+     [r"\\d\{1,\d+\}"]),
+    (_RE_SKILL_AS_OBJECT, "_RE_SKILL_AS_OBJECT",
+     [r"\[\\w-\]\{1,\d+\}"]),
+]
+
+
+@pytest.mark.parametrize(
+    "rx,name,required", BOUNDED_SPELLINGS, ids=[n for _, n, _ in BOUNDED_SPELLINGS]
+)
+def test_bounded_quantifiers_are_still_bounded(rx, name, required):
+    for expected in required:
+        assert re.search(expected, rx.pattern), (
+            f"{name} lost its bounded spelling /{expected}/. This pattern runs on "
+            f"untrusted content — from a public HTTP endpoint, from third-party CI, or "
+            f"from a user-written eval suite — and an unbounded run before a required "
+            f"literal is O(n^2). Current pattern:\n  {rx.pattern}\n"
+            f"See docs/specs/2026-07-30-redos-audit-fixes.md"
+        )
+
+
+# Longest run measured across 380 real instruction files, per quantifier site. The
+# bound must stay comfortably ABOVE these or real files change score.
+CORPUS_MAXIMA = {
+    "_RE_SPECIFIC_REF word/slash run": (_RE_SPECIFIC_REF, r"\[\\w/\]\{1,(\d+)\}", 58),
+    "_RE_CONCRETE_CMD word/slash/dot run": (
+        _RE_CONCRETE_CMD, r"\[\\w/\.-\]\{1,(\d+)\}", 118),
+}
+
+
+@pytest.mark.parametrize("label", sorted(CORPUS_MAXIMA))
+def test_bound_stays_above_the_measured_corpus_maximum(label):
+    rx, extractor, corpus_max = CORPUS_MAXIMA[label]
+    m = re.search(extractor, rx.pattern)
+    assert m, f"{label}: bounded quantifier not found — was the pattern rewritten?"
+    bound = int(m.group(1))
+    assert bound > corpus_max, (
+        f"{label}: bound {bound} is not above the measured corpus maximum "
+        f"{corpus_max}. Tightening below it silently changes real scores — the "
+        f"failure mode of a guessed bound. Re-measure before changing this."
+    )
+
+
+def test_backtick_span_bound_covers_the_longest_real_span():
+    """The longest backtick span in the corpus is 1151 chars (a canvas-design skill).
+    A tighter bound would stop crediting it as a specific reference."""
+    for rx, name in ((_RE_SPECIFIC_REF, "_RE_SPECIFIC_REF"),
+                     (_RE_CONCRETE_CMD, "_RE_CONCRETE_CMD")):
+        m = re.search(r"\[\^`\]\{1,(\d+)\}", rx.pattern)
+        assert m, f"{name}: backtick span bound not found"
+        assert int(m.group(1)) > 1151, (
+            f"{name}: backtick bound {m.group(1)} would truncate the longest real "
+            f"span (1151 chars)"
+        )

--- a/skills/schliff/tests/unit/test_patterns_scale_linearly.py
+++ b/skills/schliff/tests/unit/test_patterns_scale_linearly.py
@@ -1,10 +1,10 @@
 """Empirical ReDoS gate: no compiled scoring pattern may scale super-linearly.
 
 This is the test that would have found the 2026-07-30 audit's findings on its own.
-Static shape-triage did not: "any unbounded quantifier on a character class" flagged
-45 of 102 patterns and isolated neither of the two that mattered, because the shape
-that actually blew up has no nesting and no overlapping alternation — just an
-unbounded run before a required literal.
+Static shape-triage did not: "any unbounded quantifier on a character class" flagged 47
+of the 102 patterns in `scoring/patterns/*` and isolated neither of the two that mattered,
+because the shape that actually blew up has no nesting and no overlapping alternation —
+just an unbounded run before a required literal.
 
 Method: warm each pattern, then time `.search()` against a family of pathological
 filler alphabets at two sizes one doubling apart. Linear patterns come in near 2.0x;

--- a/skills/schliff/tests/unit/test_patterns_scale_linearly.py
+++ b/skills/schliff/tests/unit/test_patterns_scale_linearly.py
@@ -1,0 +1,166 @@
+"""Empirical ReDoS gate: no compiled scoring pattern may scale super-linearly.
+
+This is the test that would have found the 2026-07-30 audit's findings on its own.
+Static shape-triage did not: "any unbounded quantifier on a character class" flagged
+45 of 102 patterns and isolated neither of the two that mattered, because the shape
+that actually blew up has no nesting and no overlapping alternation — just an
+unbounded run before a required literal.
+
+Method: warm each pattern, then time `.search()` against a family of pathological
+filler alphabets at two sizes one doubling apart. Linear patterns come in near 2.0x;
+the measured defects were 3.9x-4.1x. The threshold is 3.0x with an absolute floor, so
+a loaded CI runner cannot flake it while the 4.0x class is still caught with margin.
+
+Cost: ~10-25s. That is the price of the only gate here that does not depend on a
+heuristic being right. Its deterministic companion is `test_patterns_are_bounded.py`.
+See docs/specs/2026-07-30-redos-audit-fixes.md (D6).
+"""
+import importlib
+import re
+import time
+
+import pytest
+
+# Every module that compiles patterns applied to untrusted instruction-file content.
+_PATTERN_MODULES = [
+    "scoring.patterns.base",
+    "scoring.patterns.skill_md",
+    "scoring.patterns.system_prompt",
+    "scoring.output_contract",
+    "scoring.structure_prompt",
+    "scoring.completeness",
+    "scoring.security",
+    "scoring.clarity",
+    "scoring.composability",
+    "scoring.efficiency",
+    "scoring.guards",
+]
+
+# Filler alphabets. Each one is the worst case for a different quantifier shape:
+# a bare word run for `[\w/]+`, a flag run for `[a-z]*`, a digit run for `\d+`, a
+# newline run for `\s*` spanning the record separator, and so on.
+_FILLERS = {
+    "word": lambda n: "a" * n,
+    "word_space": lambda n: "a " * (n // 2),
+    "word_underscore": lambda n: "a_" * (n // 2),
+    "dots": lambda n: "." * n,
+    "slashes": lambda n: "/" * n,
+    "backticks": lambda n: "`" * n,
+    "pipes": lambda n: "|" * n,
+    "dashes": lambda n: "-" * n,
+    "spaces": lambda n: " " * n,
+    "tabs": lambda n: "\t" * n,
+    "newlines": lambda n: "\n" * n,
+    "digits": lambda n: "1" * n,
+    "punct": lambda n: ".,;:" * (n // 4),
+    "colon_space": lambda n: ": " * (n // 2),
+    "equals": lambda n: "a=b " * (n // 4),
+    "rm_flags": lambda n: "rm -" + "r" * (n - 4),
+    "run_prefix": lambda n: "Run " + "a" * (n - 4),
+    "always_run": lambda n: "always " + "a " * ((n - 7) // 2),
+    "never_word": lambda n: "never " + "x" * (n - 6),
+    "sudo": lambda n: "sudo " + "a" * (n - 5),
+    "curl": lambda n: "curl " + "a" * (n - 5),
+    "echo": lambda n: "echo " + "a" * (n - 5),
+    "the_file": lambda n: "the file " * (n // 9),
+    "urlish": lambda n: "http://a/" * (n // 9),
+    "md_link": lambda n: "- [x](y.md) " * (n // 12),
+}
+
+_N = 2000                 # base size; the comparison runs at 2*_N
+_MAX_RATIO = 3.0          # linear ~2.0, the measured defects were 3.9-4.1
+_MIN_ABS_SECONDS = 0.004  # below this, timing noise dominates — ignore the ratio
+
+
+def _collect_patterns():
+    found, seen = [], set()
+
+    def walk(obj, path, depth=0):
+        if depth > 3:
+            return
+        if isinstance(obj, re.Pattern):
+            key = (obj.pattern, obj.flags)
+            if key not in seen:
+                seen.add(key)
+                found.append((path, obj))
+            return
+        if isinstance(obj, (list, tuple)):
+            for i, item in enumerate(obj):
+                walk(item, f"{path}[{i}]", depth + 1)
+        elif isinstance(obj, dict):
+            for k, v in obj.items():
+                walk(v, f"{path}[{k!r}]", depth + 1)
+
+    for mod_name in _PATTERN_MODULES:
+        mod = importlib.import_module(mod_name)
+        short = mod_name.rsplit(".", 1)[-1]
+        for attr in dir(mod):
+            if attr.startswith("__"):
+                continue
+            walk(getattr(mod, attr), f"{short}.{attr}")
+    return found
+
+
+_PATTERNS = _collect_patterns()
+
+
+def test_the_gate_actually_sees_the_patterns():
+    """A gate that collects nothing passes vacuously. The engine had 169 compiled
+    patterns at the time of the audit; anything near zero means the walker broke."""
+    assert len(_PATTERNS) > 80, f"only collected {len(_PATTERNS)} patterns"
+
+
+def _best_of(rx, text, reps=2):
+    """Minimum of `reps` timings. Min, not mean: scheduler noise only ever ADDS time,
+    so the minimum is the estimate closest to the true cost."""
+    best = float("inf")
+    for _ in range(reps):
+        start = time.perf_counter()
+        rx.search(text)
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+def _ratio(rx, make, n, reps):
+    small, large = make(n), make(n * 2)
+    t_small = _best_of(rx, small, reps)
+    t_large = _best_of(rx, large, reps)
+    if t_large < _MIN_ABS_SECONDS or t_small <= 0:
+        return None, t_small, t_large
+    return t_large / t_small, t_small, t_large
+
+
+@pytest.mark.parametrize("path,rx", _PATTERNS, ids=[p for p, _ in _PATTERNS])
+def test_pattern_scales_linearly(path, rx):
+    """Two-stage so a loaded runner cannot flake it.
+
+    Stage 1 is a cheap sweep over every filler. Anything it flags is re-measured in
+    stage 2 with more repetitions AND at a second doubling, and only counts if BOTH
+    doublings are super-linear. A quadratic pattern shows ~4.0x at every doubling; a
+    scheduling hiccup shows once. Measured margin for the healthy patterns is 1.3-2.4x
+    against a 3.0x threshold, which is too thin to rest on a single sample — a flaky
+    gate gets disabled, and a disabled gate is worse than none.
+    """
+    offenders = []
+    for filler_name, make in _FILLERS.items():
+        rx.search(make(200))  # warm
+        ratio, t_small, t_large = _ratio(rx, make, _N, reps=2)
+        if ratio is None or ratio < _MAX_RATIO:
+            continue
+        # Stage 2: confirm at two consecutive doublings before failing.
+        r1, s1, l1 = _ratio(rx, make, _N, reps=5)
+        r2, _, l2 = _ratio(rx, make, _N * 2, reps=5)
+        if r1 is None or r1 < _MAX_RATIO or r2 is None or r2 < _MAX_RATIO:
+            continue
+        offenders.append(
+            f"{filler_name}: {s1 * 1000:.1f}ms -> {l1 * 1000:.1f}ms -> {l2 * 1000:.1f}ms "
+            f"(ratios {r1:.2f}x, {r2:.2f}x per doubling)"
+        )
+    assert not offenders, (
+        f"{path} scales super-linearly on untrusted input:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nA ratio near 4.0x per doubling is quadratic. This pattern runs on "
+          "content from a public HTTP endpoint and from third-party CI. Bound the "
+          "quantifier, and calibrate the bound against the real corpus rather than "
+          "guessing it — see docs/specs/2026-07-30-redos-audit-fixes.md"
+    )

--- a/skills/schliff/tests/unit/test_patterns_scale_linearly.py
+++ b/skills/schliff/tests/unit/test_patterns_scale_linearly.py
@@ -11,6 +11,13 @@ filler alphabets at two sizes one doubling apart. Linear patterns come in near 2
 the measured defects were 3.9x-4.1x. The threshold is 3.0x with an absolute floor, so
 a loaded CI runner cannot flake it while the 4.0x class is still caught with margin.
 
+Known limit, stated rather than glossed: this gate reaches exactly as far as its filler
+alphabet. `manifest._FM` is quadratic on a frontmatter-shaped input (`"---" + "\n" * n`,
+3.95x per doubling) and NONE of the generic fillers below trip it — they come in at
+1.85x, below the absolute floor. So a shape nobody thought of stays invisible here. The
+`_MIN_ABS_SECONDS` floor has the same character: it suppresses noise, and it would also
+suppress a quadratic with a very small constant at this input size.
+
 Cost: ~10-25s. That is the price of the only gate here that does not depend on a
 heuristic being right. Its deterministic companion is `test_patterns_are_bounded.py`.
 See docs/specs/2026-07-30-redos-audit-fixes.md (D6).
@@ -21,19 +28,48 @@ import time
 
 import pytest
 
-# Every module that compiles patterns applied to untrusted instruction-file content.
+# Every module that compiles a regex applied to untrusted content — instruction files,
+# eval suites, or foreign directory trees. The list is deliberately WIDER than "the
+# scoring dimensions": the first draft of this gate covered 11 modules and 138 patterns
+# while the audit harness that actually found the defects covered 25 and 224, and a gate
+# narrower than the harness it replaces is not a regression guard. Expanding it to the
+# list below found 0 additional super-linear patterns, so the coverage is free.
 _PATTERN_MODULES = [
+    # pattern data
     "scoring.patterns.base",
     "scoring.patterns.skill_md",
     "scoring.patterns.system_prompt",
-    "scoring.output_contract",
-    "scoring.structure_prompt",
-    "scoring.completeness",
-    "scoring.security",
-    "scoring.clarity",
-    "scoring.composability",
+    # skill.md-family dimensions
+    "scoring.structure",
+    "scoring.triggers",
+    "scoring.quality",
+    "scoring.edges",
     "scoring.efficiency",
+    "scoring.composability",
+    "scoring.clarity",
+    "scoring.security",
+    "scoring.operational_coverage",
+    "scoring.runtime",
+    # system_prompt dimensions
+    "scoring.structure_prompt",
+    "scoring.output_contract",
+    "scoring.completeness",
+    "scoring.coherence",
+    # engine plumbing that also compiles content-facing patterns
+    "scoring.formats",
+    "scoring.composite",
+    "scoring.diff",
     "scoring.guards",
+    "scoring.registry",
+    "shared",
+    "nlp",
+    # consumers that read foreign trees / foreign files
+    "manifest",
+    "doctor",
+    "verify",
+    "drift",
+    "sync",
+    "text_gradient",
 ]
 
 # Filler alphabets. Each one is the worst case for a different quantifier shape:
@@ -92,6 +128,8 @@ def _collect_patterns():
                 walk(v, f"{path}[{k!r}]", depth + 1)
 
     for mod_name in _PATTERN_MODULES:
+        # No try/except: a module that stops importing must fail this gate loudly, not
+        # silently shrink its coverage.
         mod = importlib.import_module(mod_name)
         short = mod_name.rsplit(".", 1)[-1]
         for attr in dir(mod):
@@ -105,9 +143,13 @@ _PATTERNS = _collect_patterns()
 
 
 def test_the_gate_actually_sees_the_patterns():
-    """A gate that collects nothing passes vacuously. The engine had 169 compiled
-    patterns at the time of the audit; anything near zero means the walker broke."""
-    assert len(_PATTERNS) > 80, f"only collected {len(_PATTERNS)} patterns"
+    """A gate that collects nothing passes vacuously — and one that collects less than it
+    used to has quietly stopped guarding part of the engine. 224 unique compiled patterns
+    were reachable across `_PATTERN_MODULES` when this was written."""
+    assert len(_PATTERNS) > 200, (
+        f"only collected {len(_PATTERNS)} patterns; the audit harness saw 224 across "
+        f"these modules. A shrinking count means the walker or an import broke."
+    )
 
 
 def _best_of(rx, text, reps=2):

--- a/skills/schliff/tests/unit/test_scoring_redos.py
+++ b/skills/schliff/tests/unit/test_scoring_redos.py
@@ -93,3 +93,134 @@ def test_build_scores_no_redos_end_to_end():
         assert elapsed < 8.0, f"possible ReDoS regression in build_scores: {elapsed:.2f}s"
     finally:
         os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Audit 2026-07-30: the SIBLINGS of the bound above.
+#
+# `test_clarity_is_linear_on_newline_free_line` covers sub-check #1 (the action-pair
+# extractor) and has passed since v8.6.3 — while sub-checks #2 and #4 of the SAME
+# function stayed unbounded. A per-sub-check fix does not generalise itself, and a
+# test named "clarity is linear" is not evidence that clarity is linear.
+#
+# Both payloads below sit INSIDE the playground's MAX_SKILL_CHARS = 32KB cap, whose
+# own comment claims that cap bounds "any residual O(n^2) hot path to well under a
+# second". Measured before the fix: 4.75s and 162.6s.
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER = ("---\nname: probe\ndescription: Use when probing. Trigger on probe.\n"
+                "---\n\n# Probe\n\n")
+
+# clarity check #4: `_RE_RUN_PATTERN` hands the whole rest of the line to
+# `_RE_CONCRETE_CMD`, whose `[\w/.-]+` ran unbounded before a required `\.`.
+_CLARITY_RUN_PAYLOAD = _FRONTMATTER + "Run " + "a" * 32000 + "\n"
+
+# clarity check #2: the 3-line `context` is rebuilt and re-searched INSIDE the
+# per-match loop, so the quadratic search is multiplied by the number of vague
+# references on the line — O(m * n^2).
+_CLARITY_VAGUE_PAYLOAD = (_FRONTMATTER + ("a" * 8000 + "\n") * 3
+                          + "the file " * 200 + "\n")
+
+
+def _time_clarity(payload):
+    from scoring.clarity import score_clarity
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+        f.write(payload)
+        path = f.name
+    try:
+        start = time.perf_counter()
+        result = score_clarity(path)
+        return time.perf_counter() - start, result
+    finally:
+        os.unlink(path)
+
+
+def test_clarity_run_instruction_check_is_linear():
+    """clarity check #4 on one long `Run ...` line. Pre-fix 4.75s at 32KB."""
+    elapsed, _ = _time_clarity(_CLARITY_RUN_PAYLOAD)
+    assert elapsed < 3.0, f"possible clarity check-#4 O(n^2) regression: {elapsed:.2f}s"
+
+
+def test_clarity_vague_reference_check_is_linear():
+    """clarity check #2, the worst path in the engine. Pre-fix 162.6s at 25.9KB."""
+    elapsed, _ = _time_clarity(_CLARITY_VAGUE_PAYLOAD)
+    assert elapsed < 3.0, f"possible clarity check-#2 O(m*n^2) regression: {elapsed:.2f}s"
+
+
+def test_clarity_bounds_do_not_silence_the_findings():
+    """Two-sided gate: the bound must make it fast WITHOUT detecting less.
+
+    A one-sided "is it fast now" assertion is how a narrowing ships as a silent
+    detection loss (#149). Both counts are the pre-fix values.
+    """
+    _, run_result = _time_clarity(_CLARITY_RUN_PAYLOAD)
+    assert "incomplete_instructions:1" in run_result["issues"], run_result["issues"]
+
+    _, vague_result = _time_clarity(_CLARITY_VAGUE_PAYLOAD)
+    assert vague_result["details"]["vague_references"] == 200, vague_result["details"]
+
+
+def test_dangerous_cmd_regex_is_linear():
+    """`rm\\s+-[a-z]*r[a-z]*f[a-z]*\\s+/` — three unbounded runs before a required
+    `/`. Reachable from the shipping CLI via the system_prompt format, where
+    `security` is a core headline dimension. Pre-fix 2.66s at 16KB."""
+    from scoring.patterns.base import _RE_SEC_DANGEROUS_CMD
+    payload = "rm -" + "r" * 16000
+    start = time.perf_counter()
+    _RE_SEC_DANGEROUS_CMD.search(payload)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"possible dangerous-cmd O(n^3) regression: {elapsed:.2f}s"
+
+
+def test_dangerous_cmd_still_matches_root_wipe():
+    from scoring.patterns.base import _RE_SEC_DANGEROUS_CMD
+    for payload in ("rm -rf /", "rm -fr /", "rm  -Rf  /", "chmod 777 x",
+                    "mkfs.ext4 /dev/sda"):
+        assert _RE_SEC_DANGEROUS_CMD.search(payload), payload
+    # ...and still does NOT match the canonical Docker layer cleanup (#148 guard).
+    assert not _RE_SEC_DANGEROUS_CMD.search("rm -rf /var/lib/apt/lists/*")
+
+
+def test_length_constraint_regex_is_linear():
+    """`_RE_LENGTH_EXTENDED`'s SECOND branch (`\\d+\\s*(words?|...)`) is the culprit;
+    the first branch fails fast on digits, which is why a probe against one branch
+    alone showed nothing. Pre-fix 11.66s at 16KB."""
+    from scoring.output_contract import _RE_LENGTH_EXTENDED
+    payload = "1" * 16000
+    start = time.perf_counter()
+    _RE_LENGTH_EXTENDED.search(payload)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"possible length-constraint O(n^2) regression: {elapsed:.2f}s"
+
+
+def test_length_constraint_still_matches_real_phrasings():
+    from scoring.output_contract import _RE_LENGTH_EXTENDED
+    for payload in ("Maximum response size: 200 words", "reply in 50 words max",
+                    "300 tokens limit", "keep it under 3 sentences cap"):
+        assert _RE_LENGTH_EXTENDED.search(payload), payload
+
+
+def test_system_prompt_format_always_scores_security():
+    """Pin the reachability that makes the two bounds above load-bearing.
+
+    `build_scores`' system_prompt branch is an early return that never consults
+    `include_security`, so `security` is scored there even when the caller asked for
+    it to be skipped. That is CORRECT for this format — security is a documented core
+    headline dimension at weight 0.15 — but it was accidental and undocumented, and a
+    standing project note claimed the dimension was reachable from no shipping entry
+    point. Pinned so it is a contract, and so `security.py` is never mistaken for
+    dead weight again.
+    """
+    from shared import build_scores
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf-8") as f:
+        f.write("You are a helpful assistant.\n\nNever run: rm -rf /etc\n")
+        path = f.name
+    try:
+        scores = build_scores(path, fmt="system_prompt", include_security=False)
+        assert "security" in scores, sorted(scores)
+        # ...and the skill.md family still honours the opt-out, so the two branches
+        # are not accidentally unified.
+        md_scores = build_scores(path, fmt="skill.md", include_security=False)
+        assert "security" not in md_scores, sorted(md_scores)
+    finally:
+        os.unlink(path)

--- a/skills/schliff/tests/unit/test_security_field_false_positives.py
+++ b/skills/schliff/tests/unit/test_security_field_false_positives.py
@@ -271,3 +271,46 @@ class TestEnvLeakWordBoundary:
     @pytest.mark.parametrize("text", TRUE_POSITIVES)
     def test_genuine_env_leak_still_matches(self, text):
         assert _RE_SEC_ENV_LEAK.search(text) is not None, f"detector disarmed for {text!r}"
+
+
+class TestDangerousCmdWhitespaceIsNotBounded:
+    """A ReDoS bound must not be placed on whitespace inside a detector.
+
+    Caught in self-review of the 2026-07-30 ReDoS commit, before it was pushed. That
+    commit bounded `rm\\s+` to `rm\\s{1,8}` "for consistency" while bounding the flag
+    runs that were the actual quadratic source. The flag runs needed it; the whitespace
+    did not — it is prefixed by the literal `rm`, which limits how many start positions
+    it is reachable from, so it never contributed to the blowup. Bounding it anyway cost
+    five detections that 8.8.2 caught.
+
+    This is the #149 defect class exactly: narrowing a matcher without enumerating its
+    evasion classes. The enumeration below is the gate — it walks the whitespace-run
+    length rather than sampling it, so any future bound on this run fails here.
+    """
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 5, 8, 9, 10, 16, 40, 100])
+    @pytest.mark.parametrize("ws", [" ", "\t"], ids=["space", "tab"])
+    def test_any_whitespace_run_before_the_flags_still_matches(self, count, ws):
+        payload = "rm" + ws * count + "-rf /"
+        assert _RE_SEC_DANGEROUS_CMD.search(payload) is not None, (
+            f"detector disarmed by a {count}-char whitespace run — a bound was placed "
+            f"on whitespace that was never the quadratic source"
+        )
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 5, 8, 9, 16, 40])
+    def test_any_whitespace_run_before_the_path_still_matches(self, count):
+        payload = "rm -rf" + " " * count + "/"
+        assert _RE_SEC_DANGEROUS_CMD.search(payload) is not None, (
+            f"detector disarmed by a {count}-char whitespace run before the path"
+        )
+
+    def test_the_flag_run_bound_is_wide_enough_for_real_flag_sets(self):
+        """The flag runs ARE bounded (they were the O(n^3) source). The bound must still
+        cover any plausible real flag spelling."""
+        # Long-form flags (`rm -recursive -force /`) are deliberately absent: 8.8.2
+        # did not match them either, because the pattern requires `r` and `f` in ONE
+        # flag cluster. Asserting a capability the detector never had would be a test
+        # written against an imagined feature.
+        for payload in ("rm -rf /", "rm -fr /", "rm -Rf /", "rm -rfv /", "rm -vrf /",
+                        "rm -rfvi /", "rm -rfvid /"):
+            assert _RE_SEC_DANGEROUS_CMD.search(payload) is not None, payload


### PR DESCRIPTION
**1 of 4 in a stack.** Base `main`. Follow-ups: manifest → playground → run-eval.

A trust-boundary audit of `ab41827` found the same defect in five regexes, and it is not
the textbook ReDoS shape — no nested quantifier, no overlapping alternation, just **an
unbounded run followed by a required literal**. `[\w/]+` before a required `\.` consumes to
the end of the input, fails on the dot, and gives back one character at a time, once per
start position.

## The measurement

The worst case sits **inside** the public playground's 32 KB input cap, whose own comment
claimed that cap bounded "any residual O(n^2) hot path to well under a second":

| payload | before | after | scaling |
| --- | --- | --- | --- |
| `clarity` check #2, 25,883 bytes | **162,629 ms** | **58.9 ms** | 4.01× → 1.98× per doubling |
| `clarity` check #4, 32 KB | 4,629 ms | 78.7 ms | linear |
| `_RE_SEC_DANGEROUS_CMD` @16 KB | 2,732 ms | 0.21 ms | linear |
| `_RE_LENGTH_EXTENDED` @16 KB | 11,857 ms | 18.3 ms | linear |
| `_RE_SKILL_AS_OBJECT` @16 KB | 2,807 ms | 24.5 ms | linear |

Benign payload of the same length: 46 ms. So 3,533× the honest cost, for one
unauthenticated `POST /api/score`.

**Reachable from** `POST /api/score` and `GET /api/badge?repo=` (both unauthenticated), the
CLI at the 1 MB cap, and — the worst blast radius — the GitHub Action on a fork PR's
AGENTS.md, i.e. in other people's CI.

## Two halves, both needed

Bounding the quantifiers alone took the worst case from 162.6 s only to **11.9 s**: the
match-independent context build and search sat *inside* the per-match loop, so O(n²) had
become O(m·n²). Hoisting them out is output-identical by construction. Bound **plus** hoist
gives 58.9 ms.

## Bounds are calibrated, not guessed

Longest run each quantifier actually consumes across 380 real instruction files: 58, 118,
1151, 50, 19. A first guessed bound of 120 would have sat one character above a real
118-char token and **truncated** a real 1,151-char span. The failure mode of a guessed
bound is a silent score change.

## Two-sided acceptance

A one-sided "is it fast now" check is how a narrowing ships as a silent detection loss
(#149), so both directions are proven:

- **0 of 250** real files change their clarity result.
- Hero score and every case-study number reproduce **byte-identically** against a clean
  `main` worktree under identical commands (95.6 / 84.5 / 94.6 / 87.4, per-dimension too).
- Every malicious shape is still detected with **identical finding counts**; `rm -rf /`
  still matches and the Docker layer-cleanup false positive stays fixed.

## Review found a real regression in the first commit

`b4007a7` reverts it: the first pass also bounded `rm\s+` to `rm\s{1,8}` "for consistency"
with the flag runs that were the actual quadratic source. Enumerating the evasion dimension
rather than sampling it showed **five detections lost** that 8.8.2 caught (`rm` plus ≥9
spaces or tabs, then `-rf /`) — for no gain, since that run is prefixed by the literal `rm`
and never contributed to the blowup. Gated by an enumeration over whitespace-run length
1…100.

## Gates

Two, and their limits are stated rather than implied.

- `test_patterns_scale_linearly.py` — 224 patterns across 30 modules × 25 filler alphabets
  at doubling lengths. **It found `_RE_SKILL_AS_OBJECT`, which was not on the audit's fix
  list, on its first run.** Confirms an offender at two consecutive doublings before
  failing, because the healthy margin is 1.3–2.4× against a 3.0× threshold and a single
  sample under load flaked once during development; verified red-capable (4.20×, 4.02×) and
  green four times over under four busy cores.
- `test_patterns_are_bounded.py` — deterministic: pins each bounded spelling and pins each
  bound *above the corpus maximum it came from*, so tightening one below the real data
  fails too.

A repo-wide **static** rule was prototyped and rejected on measurement: it flagged 47 of the
102 patterns in `scoring/patterns/*`, and the refinement "…with no required literal prefix"
still flagged 11 including a certain false positive. A gate whose allowlist is longer than
its findings is the thing it exists to prevent.

## Gates run

1876 pytest (1603 on `main`) · test-self 21/0 · integration 100/0 · proof 6/0 · golden
21/21 · ruff clean · markdownlint 0/67 · 0 dangling.

Spec: `docs/specs/2026-07-30-redos-audit-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
