### PR TITLE
security(manifest): bound the frontmatter parse and the read behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   certain false positive. A gate whose allowlist is longer than its findings is the thing
   it exists to prevent.
 
+- **`schliff manifest` parsed third-party frontmatter quadratically and read files with
+  no size cap at all.** `manifest` walks every SKILL.md under `~/.claude/skills`, every
+  command under `~/.claude/commands`, the project's `.claude/`, and the payload of every
+  enabled plugin — all third-party content — and its frontmatter regex opened with
+  `^---\s*\n`. `\s` matches the newline itself, so every possible `\s*` length restarted
+  the lazy body scan: 25.6 s at 64 KB, 4.04× per doubling, ~1.9 h extrapolated at 1 MB.
+  Through the shipping CLI on one hostile 64 KB skill: **30.77 s → 0.22 s**.
+
+  Anchoring the whitespace class away from the record separator (`[ \t]*\r?\n`) is
+  32,823× faster at 64 KB with a byte-identical verdict *and* body on every real shape,
+  including CRLF and unterminated frontmatter.
+
+  Separately, the read was a raw `read_text()` with no `MAX_SKILL_SIZE` — the only reader
+  in the engine without one. Both call sites did `fm, _ = parse_frontmatter(...)`, so the
+  body was the only reason a whole file had to be in memory: the fix reads a bounded
+  64 KB head and drops the body from the signature, which removes the unbounded read, the
+  quadratic trigger and a dead return value together. 64 KB is calibrated, not guessed —
+  across 248 real skills, commands and plugin payloads the frontmatter block runs a median
+  of 694 bytes, p95 4,476, max 15,711, so it carries 100% with 4× headroom.
+
+  Verified against the real install: `manifest --json` output is byte-identical to `main`
+  (same sha256, 109 artifacts, 8,240 resident tokens, 19 findings). The empirical ReDoS
+  gate gained the frontmatter-shaped fillers that were the documented blind spot, so this
+  defect is now caught by the gate rather than by hand.
+
 - **`clarity`'s function docstring contradicted its own module docstring**, claiming a
   zero default weight and a `--clarity` opt-in. Both were stale — clarity runs in the
   default scorer set for every format — and that contradiction is exactly what made two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,10 +98,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   record separator cannot restart that scan: 1.5 ms at 64 KB, linear, and every code point
   the class admits was probed individually for a revived blowup (1.97–2.07× per doubling).
   **0 divergences from 8.8.2 across 14 enumerated separators.** The narrower `[ \t]*\r?`
-  tried first lost six of them — form feed, vertical tab, `\r\r\n`, NBSP, em space, a
-  mixed run — which for a tool that reports resolved state means a
-  `disable-model-invocation: true` skill reads as LOADED. Caught in review by enumerating
-  the dimension, not sampling it; gated for all 14 shapes including that consequence.
+  tried first lost four of them — form feed, vertical tab, NBSP, em space — which for a
+  tool that reports resolved state means a `disable-model-invocation: true` skill reads as
+  LOADED. Caught in review by enumerating the dimension, not sampling it; gated for all 14
+  shapes including that consequence. The count was first published as six, from an
+  enumeration run against in-memory strings — `parse_frontmatter` reads with universal
+  newlines, which collapses the CR-based shapes before the regex sees them, so `\r` is
+  harmless but not load-bearing on this path. The translation is now pinned by a test.
 
   Separately, the read was a raw `read_text()` with no `MAX_SKILL_SIZE` — the only reader
   in the engine without one. Both call sites did `fm, _ = parse_frontmatter(...)`, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,17 +94,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   the lazy body scan: 25.6 s at 64 KB, 4.04× per doubling, ~1.9 h extrapolated at 1 MB.
   Through the shipping CLI on one hostile 64 KB skill: **30.77 s → 0.22 s**.
 
-  Anchoring the whitespace class away from the record separator (`[ \t]*\r?\n`) is
-  32,823× faster at 64 KB with a byte-identical verdict *and* body on every real shape,
-  including CRLF and unterminated frontmatter.
+  Fixed with `[^\S\n]*` — whitespace except the newline. A class that cannot span the
+  record separator cannot restart that scan: 1.5 ms at 64 KB, linear, and every code point
+  the class admits was probed individually for a revived blowup (1.97–2.07× per doubling).
+  **0 divergences from 8.8.2 across 14 enumerated separators.** The narrower `[ \t]*\r?`
+  tried first lost six of them — form feed, vertical tab, `\r\r\n`, NBSP, em space, a
+  mixed run — which for a tool that reports resolved state means a
+  `disable-model-invocation: true` skill reads as LOADED. Caught in review by enumerating
+  the dimension, not sampling it; gated for all 14 shapes including that consequence.
 
   Separately, the read was a raw `read_text()` with no `MAX_SKILL_SIZE` — the only reader
   in the engine without one. Both call sites did `fm, _ = parse_frontmatter(...)`, so the
   body was the only reason a whole file had to be in memory: the fix reads a bounded
-  64 KB head and drops the body from the signature, which removes the unbounded read, the
-  quadratic trigger and a dead return value together. 64 KB is calibrated, not guessed —
-  across 248 real skills, commands and plugin payloads the frontmatter block runs a median
-  of 694 bytes, p95 4,476, max 15,711, so it carries 100% with 4× headroom.
+  65,536-character head and drops the body from the signature, which removes the unbounded
+  read, the quadratic trigger and a dead return value together. The bound is calibrated,
+  not guessed — across 248 real skills, commands and plugin payloads the frontmatter block
+  runs a median of 694 characters, p95 4,476, max 15,711, so it carries 100% with 4×
+  headroom. Characters, not bytes: `read(n)` on a text handle counts code points, so the
+  constant is named `_FM_READ_CHARS` rather than promising a byte guarantee the call does
+  not make.
 
   Verified against the real install: `manifest --json` output is byte-identical to `main`
   (same sha256, 109 artifacts, 8,240 resident tokens, 19 findings). The empirical ReDoS

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -1,6 +1,6 @@
 # Bounded quantifiers: closing the ReDoS class found by the 2026-07-30 audit
 
-Status: D1, D1a, D2, D5, D6 implemented (PR 1). D3, D7, D8 pending.
+Status: D1, D1a, D2, D5, D6 implemented (PR 1). D3 implemented (PR 2). D7, D8 pending.
 Date: 2026-07-30
 Baseline: `main` @ `ab41827`
 
@@ -159,6 +159,24 @@ Independently, `manifest.py:54` reads with a raw `read_text()` — no
 not a size cap on a full read — it is to read a bounded head and drop the body from
 the signature. That removes the unbounded read, the quadratic trigger, and a dead
 return value at once.
+
+Head size calibrated, not guessed: across 248 real skills, commands and plugin payloads
+the frontmatter block runs a median of 694 bytes, p95 4,476, max 15,711 (vercel's
+`ai-sdk`). 64 KB carries 100% of them with 4× headroom, and a test pins it above that
+maximum — truncating a real artifact's frontmatter would make its description silently
+read as empty.
+
+**Measured:** through the shipping CLI on one hostile 64 KB skill, 30.77 s → 0.22 s.
+`manifest --json` over the real install is byte-identical to `main` (same sha256, 109
+artifacts, 8,240 resident tokens, 19 findings).
+
+Two of this fix's own tests were **non-discriminating on first write**, found by mutation
+and fixed: `test_oversized_file_is_not_read_whole` asserted only that the constant was
+small and that parsing still worked, so it passed with the bounded read reverted to a full
+`read_text()` — a full read yields the same mapping. It now instruments `Path.open` and
+asserts the actual `read(n)` argument. And nothing pinned the head against the corpus
+maximum, so shrinking it to 8 KB passed; that assertion now exists, mirroring D1's bound
+checks. A test that cannot fail on the defect it names is not a test.
 
 ### D4 — F3 is a reachability correction, not a gate change
 

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -152,8 +152,8 @@ unnecessary.
 every `\s*` length restarts the lazy `(.*?)` scan.
 
 **The class must exclude the newline — and nothing else.** Review of this fix caught the
-first attempt, `[ \t]*\r?`, losing **six** shapes 8.8.2 parsed: form feed, vertical tab,
-`\r\r\n`, NBSP, em space, and a mixed run. Material rather than cosmetic, because
+first attempt, `[ \t]*\r?`, losing **four** shapes 8.8.2 parsed: form feed, vertical tab,
+NBSP and em space. Material rather than cosmetic, because
 `manifest` reports resolved state: frontmatter it fails to parse makes a
 `disable-model-invocation: true` skill read as **LOADED** and drops the description that
 carries the per-turn cost. That is D1a's rule violated a second time, in a different file
@@ -161,7 +161,16 @@ carries the per-turn cost. That is D1a's rule violated a second time, in a diffe
 
 `[^\S\n]*` — whitespace except newline — is the class that keeps every shape and still
 cannot restart the lazy scan: **0 divergences** from 8.8.2 across all 14 enumerated
-separators (the first attempt had 6), 1.5 ms at 64 KB, linear. Every code point the class
+separators (the first attempt had 4), 1.5 ms at 64 KB, linear.
+
+**The first count published for this was six, and it was wrong.** That enumeration ran
+against in-memory strings; `parse_frontmatter` reads through `path.open("r")`, i.e.
+universal newlines, which collapses every CR-based shape before the regex sees it. The
+mutation test disagreed with the hand-run enumeration — four red, not six — and the read
+path was the difference. A probe against a substrate the code does not use is not a probe,
+and the error went in the direction that flattered the finding. Consequence recorded in
+code and pinned by `TestUniversalNewlineContract`: the `\r` inside `[^\S\n]` is harmless
+but not load-bearing here, and `newline=""` would change which separators are equivalent. Every code point the class
 admits was probed individually for a revived blowup (`\r`, `\f`, `\v`, U+2028, U+2029,
 U+0085, NBSP, U+001C, mixed): 1.97–2.07× per doubling, none above the 3.0 threshold.
 Gated by `TestFrontmatterWhitespaceClassIsNotNarrowed`, which asserts both the parse and

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -149,9 +149,24 @@ unnecessary.
 ### D3 — `manifest.py`: read the head, drop the unused body
 
 `_FM = r"^---\s*\n(.*?)\n---\s*\n"` is O(n²) because `\s*` may consume newlines:
-every `\s*` length restarts the lazy `(.*?)` scan. `^---[ \t]*\r?\n…` is 32,823×
-faster at 64 KB with a byte-identical verdict **and** `group(1)` on every real shape
-including CRLF and unterminated frontmatter.
+every `\s*` length restarts the lazy `(.*?)` scan.
+
+**The class must exclude the newline — and nothing else.** Review of this fix caught the
+first attempt, `[ \t]*\r?`, losing **six** shapes 8.8.2 parsed: form feed, vertical tab,
+`\r\r\n`, NBSP, em space, and a mixed run. Material rather than cosmetic, because
+`manifest` reports resolved state: frontmatter it fails to parse makes a
+`disable-model-invocation: true` skill read as **LOADED** and drops the description that
+carries the per-turn cost. That is D1a's rule violated a second time, in a different file
+— narrowing a class without enumerating the dimension.
+
+`[^\S\n]*` — whitespace except newline — is the class that keeps every shape and still
+cannot restart the lazy scan: **0 divergences** from 8.8.2 across all 14 enumerated
+separators (the first attempt had 6), 1.5 ms at 64 KB, linear. Every code point the class
+admits was probed individually for a revived blowup (`\r`, `\f`, `\v`, U+2028, U+2029,
+U+0085, NBSP, U+001C, mixed): 1.97–2.07× per doubling, none above the 3.0 threshold.
+Gated by `TestFrontmatterWhitespaceClassIsNotNarrowed`, which asserts both the parse and
+the disabled-skill consequence for all 14; re-introducing the over-narrowing turns 8
+assertions red.
 
 Independently, `manifest.py:54` reads with a raw `read_text()` — no
 `MAX_SKILL_SIZE`, unlike every other reader in the engine. Both call sites do
@@ -161,10 +176,16 @@ the signature. That removes the unbounded read, the quadratic trigger, and a dea
 return value at once.
 
 Head size calibrated, not guessed: across 248 real skills, commands and plugin payloads
-the frontmatter block runs a median of 694 bytes, p95 4,476, max 15,711 (vercel's
-`ai-sdk`). 64 KB carries 100% of them with 4× headroom, and a test pins it above that
+the frontmatter block runs a median of 694 characters, p95 4,476, max 15,711 (vercel's
+`ai-sdk`). 65,536 carries 100% of them with 4× headroom, and a test pins it above that
 maximum — truncating a real artifact's frontmatter would make its description silently
 read as empty.
+
+**Characters, not bytes.** `read(n)` on a text handle counts code points, so on CJK
+frontmatter this reads up to 4× as many bytes — still bounded. The constant was first
+named `_FM_READ_BYTES`, which promised a guarantee the call does not make; renamed
+`_FM_READ_CHARS`, and the calibration figures above are character counts because that is
+what `m.end()` measured.
 
 **Measured:** through the shipping CLI on one hostile 64 KB skill, 30.77 s → 0.22 s.
 `manifest --json` over the real install is byte-identical to `main` (same sha256, 109

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -200,13 +200,25 @@ what `m.end()` measured.
 `manifest --json` over the real install is byte-identical to `main` (same sha256, 109
 artifacts, 8,240 resident tokens, 19 findings).
 
-Two of this fix's own tests were **non-discriminating on first write**, found by mutation
-and fixed: `test_oversized_file_is_not_read_whole` asserted only that the constant was
-small and that parsing still worked, so it passed with the bounded read reverted to a full
-`read_text()` — a full read yields the same mapping. It now instruments `Path.open` and
-asserts the actual `read(n)` argument. And nothing pinned the head against the corpus
-maximum, so shrinking it to 8 KB passed; that assertion now exists, mirroring D1's bound
-checks. A test that cannot fail on the defect it names is not a test.
+**Three of this fix's own tests were non-discriminating**, every one found by mutation
+rather than by rereading it, and one of them twice:
+
+1. `test_oversized_file_is_not_read_whole` asserted only that the constant was small and
+   that parsing still worked, so it passed with the bounded read reverted to a full
+   `read_text()` — a full read yields the same mapping. It now instruments `Path.open` and
+   asserts the actual `read(n)` argument.
+2. Nothing pinned the head against the corpus maximum, so shrinking it to 8 KB passed.
+   That assertion now exists, mirroring D1's bound checks.
+3. `test_carriage_returns_never_reach_the_regex`, written specifically to catch a switch to
+   `newline=""`, opened the file *itself* and asserted no CR in its own buffer — a property
+   of the test's read, not the production one. It stayed green on that exact mutation. The
+   repair inspected `kwargs` only, so it stayed green a **second** time for the same
+   mutation spelled positionally. Arguments are now normalised through
+   `inspect.signature(...).bind(...)`; both spellings turn it red.
+
+A test that cannot fail on the defect it names is not a test — and an assertion a spelling
+can walk around is not an assertion. Across this whole spec, every instance of this class
+was found by a mutation test and none by rereading the test.
 
 ### D4 — F3 is a reachability correction, not a gate change
 

--- a/skills/schliff/scripts/manifest.py
+++ b/skills/schliff/scripts/manifest.py
@@ -29,8 +29,28 @@ from pathlib import Path
 
 HOME = Path.home()
 
-_FM = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.S)
+# `[ \t]*\r?\n`, not `\s*\n`: `\s` matches the newline itself, so every possible
+# `\s*` length restarted the lazy `(.*?)` body scan — O(n^2) on a file that opens the
+# delimiter and never closes it. Measured 25.6s at 64KB, 4.04x per doubling, ~1.9h
+# extrapolated at 1MB. Anchoring the whitespace class away from the record separator is
+# 32,823x faster at 64KB with a byte-identical verdict and body on every real shape,
+# including CRLF and unterminated frontmatter.
+#
+# This parser reads THIRD-PARTY content: `schliff manifest` walks every SKILL.md under
+# ~/.claude/skills, every command under ~/.claude/commands, the project's .claude/, and
+# the payload of every enabled plugin. See docs/specs/2026-07-30-redos-audit-fixes.md (D3).
+_FM = re.compile(r"^---[ \t]*\r?\n(.*?)\n---[ \t]*\r?\n", re.S)
 _KV = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):[ \t]*(.*)$")
+
+# Frontmatter lives at the top of the file, so only a head read is needed — and a head
+# read is what keeps a hostile or merely huge artifact from being pulled into memory.
+# Every other reader in the engine goes through `read_skill_safe` at MAX_SKILL_SIZE (1MB);
+# this one used a raw `read_text()` with no cap at all.
+#
+# Calibrated, not guessed: across 248 real skills, commands and plugin payloads the
+# frontmatter block runs a median of 694 bytes, p95 4,476, max 15,711 (vercel's ai-sdk
+# skill). 64KB carries 100% of them with 4x headroom over the largest.
+_FM_READ_BYTES = 64 * 1024
 
 # Rough chars-per-token. schliff uses the same approximation elsewhere; the number
 # only needs to be stable and honest about being an estimate.
@@ -43,20 +63,26 @@ def _tilde(p: str | Path) -> str:
     return "~" + s[len(h):] if s.startswith(h) else s
 
 
-def parse_frontmatter(path: Path) -> tuple[dict, str]:
-    """Flat-key frontmatter parse with block-scalar support.
+def parse_frontmatter(path: Path) -> dict:
+    """Flat-key frontmatter parse with block-scalar support. Returns the mapping only.
 
     Deliberately regex-based rather than pyyaml: pyyaml is absent from a stock
     Python and from schliff's own environment, and schliff parses frontmatter this
     way everywhere else. A silent ImportError here would make findings vanish.
+
+    Returns the mapping and nothing else. It used to return `(mapping, body)` and both
+    call sites discarded the body with `fm, _ = ...` — so the body was the only reason a
+    whole file had to be in memory. Dropping it is what makes the bounded head read below
+    a simplification rather than a truncation.
     """
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read(_FM_READ_BYTES)
     except OSError:
-        return {}, ""
+        return {}
     m = _FM.match(text)
     if not m:
-        return {}, text
+        return {}
 
     out: dict[str, object] = {}
     block_key: str | None = None
@@ -83,7 +109,7 @@ def parse_frontmatter(path: Path) -> tuple[dict, str]:
             out[key] = val
     if block_key is not None:
         out[block_key] = " ".join(block)
-    return out, text[m.end():]
+    return out
 
 
 def invoke_cost_chars(skill_md: Path) -> int:
@@ -164,7 +190,7 @@ def _scan_skill_root(root: Path, prefix: str, source: str, out: Manifest) -> Non
             out.findings.append(Finding(
                 "no-skill-md", name, "directory has no SKILL.md — it never loads"))
             continue
-        fm, _ = parse_frontmatter(skill_md)
+        fm = parse_frontmatter(skill_md)
         if fm.get("disable-model-invocation") is True:
             out.findings.append(Finding(
                 "disabled", name, "frontmatter disable-model-invocation: true"))
@@ -194,7 +220,7 @@ def _scan_command_root(root: Path, prefix: str, source: str, out: Manifest) -> N
         if segments[-1].startswith("_"):
             continue  # leading underscore is the partial/include convention
         name = prefix + ":".join(segments)
-        fm, _ = parse_frontmatter(path)
+        fm = parse_frontmatter(path)
         if fm.get("disable-model-invocation") is True:
             out.findings.append(Finding(
                 "disabled", name, "frontmatter disable-model-invocation: true"))

--- a/skills/schliff/scripts/manifest.py
+++ b/skills/schliff/scripts/manifest.py
@@ -29,17 +29,24 @@ from pathlib import Path
 
 HOME = Path.home()
 
-# `[ \t]*\r?\n`, not `\s*\n`: `\s` matches the newline itself, so every possible
-# `\s*` length restarted the lazy `(.*?)` body scan — O(n^2) on a file that opens the
-# delimiter and never closes it. Measured 25.6s at 64KB, 4.04x per doubling, ~1.9h
-# extrapolated at 1MB. Anchoring the whitespace class away from the record separator is
-# 32,823x faster at 64KB with a byte-identical verdict and body on every real shape,
-# including CRLF and unterminated frontmatter.
+# `[^\S\n]*`, not `\s*`: the quadratic came from `\s` matching the newline ITSELF, so
+# every possible `\s*` length restarted the lazy `(.*?)` body scan — O(n^2) on a file that
+# opens the delimiter and never closes it. Measured 25.6s at 64KB, 4.04x per doubling,
+# ~1.9h extrapolated at 1MB. A class that cannot span the record separator cannot restart
+# that scan: 1.5ms at 64KB, linear.
+#
+# `[^\S\n]` is "whitespace except newline" and is deliberately NOT the narrower
+# `[ \t]*\r?`. The first attempt at this fix used `[ \t]*\r?` and lost six shapes 8.8.2
+# parsed: form feed, vertical tab, `\r\r\n`, NBSP, em space, and a mixed run. That is
+# not cosmetic here — this tool reports resolved state, so a frontmatter it fails to parse
+# makes a `disable-model-invocation: true` skill read as LOADED. Enumerating the
+# whitespace dimension instead of sampling it is what caught it; the enumeration lives in
+# tests/unit/test_manifest.py and covers all 14 shapes with 0 divergence from 8.8.2.
 #
 # This parser reads THIRD-PARTY content: `schliff manifest` walks every SKILL.md under
 # ~/.claude/skills, every command under ~/.claude/commands, the project's .claude/, and
 # the payload of every enabled plugin. See docs/specs/2026-07-30-redos-audit-fixes.md (D3).
-_FM = re.compile(r"^---[ \t]*\r?\n(.*?)\n---[ \t]*\r?\n", re.S)
+_FM = re.compile(r"^---[^\S\n]*\n(.*?)\n---[^\S\n]*\n", re.S)
 _KV = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):[ \t]*(.*)$")
 
 # Frontmatter lives at the top of the file, so only a head read is needed — and a head
@@ -48,9 +55,14 @@ _KV = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):[ \t]*(.*)$")
 # this one used a raw `read_text()` with no cap at all.
 #
 # Calibrated, not guessed: across 248 real skills, commands and plugin payloads the
-# frontmatter block runs a median of 694 bytes, p95 4,476, max 15,711 (vercel's ai-sdk
-# skill). 64KB carries 100% of them with 4x headroom over the largest.
-_FM_READ_BYTES = 64 * 1024
+# frontmatter block runs a median of 694 characters, p95 4,476, max 15,711 (vercel's
+# ai-sdk skill). 65,536 carries 100% of them with 4x headroom over the largest.
+#
+# CHARACTERS, not bytes — `read(n)` on a text handle counts code points, so on CJK
+# frontmatter this reads up to 4x as many bytes. Still bounded, and named for what it
+# actually limits: the first version of this constant was called `_FM_READ_BYTES`, which
+# promised a guarantee the call does not make.
+_FM_READ_CHARS = 64 * 1024
 
 # Rough chars-per-token. schliff uses the same approximation elsewhere; the number
 # only needs to be stable and honest about being an estimate.
@@ -77,7 +89,7 @@ def parse_frontmatter(path: Path) -> dict:
     """
     try:
         with path.open("r", encoding="utf-8", errors="replace") as fh:
-            text = fh.read(_FM_READ_BYTES)
+            text = fh.read(_FM_READ_CHARS)
     except OSError:
         return {}
     m = _FM.match(text)

--- a/skills/schliff/scripts/manifest.py
+++ b/skills/schliff/scripts/manifest.py
@@ -36,12 +36,18 @@ HOME = Path.home()
 # that scan: 1.5ms at 64KB, linear.
 #
 # `[^\S\n]` is "whitespace except newline" and is deliberately NOT the narrower
-# `[ \t]*\r?`. The first attempt at this fix used `[ \t]*\r?` and lost six shapes 8.8.2
-# parsed: form feed, vertical tab, `\r\r\n`, NBSP, em space, and a mixed run. That is
-# not cosmetic here — this tool reports resolved state, so a frontmatter it fails to parse
-# makes a `disable-model-invocation: true` skill read as LOADED. Enumerating the
-# whitespace dimension instead of sampling it is what caught it; the enumeration lives in
+# `[ \t]*\r?`. The first attempt at this fix used `[ \t]*\r?` and lost four shapes 8.8.2
+# parsed: form feed, vertical tab, NBSP and em space. Not cosmetic here — this tool
+# reports resolved state, so frontmatter it fails to parse makes a
+# `disable-model-invocation: true` skill read as LOADED. Enumerating the whitespace
+# dimension instead of sampling it is what caught it; the enumeration lives in
 # tests/unit/test_manifest.py and covers all 14 shapes with 0 divergence from 8.8.2.
+#
+# The `\r` that `[^\S\n]` admits is NOT load-bearing on this path: the read below opens
+# in universal-newline mode, so CR is translated to LF before the regex sees it. It is
+# kept because removing a class member for no measured reason is how the first attempt
+# went wrong. `TestUniversalNewlineContract` pins the translation, since `newline=""`
+# would make CR reachable and change which separators are equivalent.
 #
 # This parser reads THIRD-PARTY content: `schliff manifest` walks every SKILL.md under
 # ~/.claude/skills, every command under ~/.claude/commands, the project's .claude/, and

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -206,20 +206,21 @@ class TestFrontmatterParseIsBoundedAndLinear:
         assert max(requested) <= 64 * 1024, f"read too much at once: {max(requested)} bytes"
 
     # Largest frontmatter block measured across 248 real skills, commands and plugin
-    # payloads (vercel's ai-sdk SKILL.md). The head read must stay above it or the
+    # payloads (vercel's ai-sdk SKILL.md), in CHARACTERS — `read(n)` on a text handle
+    # counts code points. The head read must stay above it or the
     # frontmatter of a real artifact gets truncated and its description silently reads
     # as empty — the same "calibrate the bound, do not guess it" rule as the pattern
     # bounds in PR 1, and it needs its own assertion for the same reason.
-    CORPUS_MAX_FRONTMATTER_BYTES = 15_711
+    CORPUS_MAX_FRONTMATTER_CHARS = 15_711
 
     def test_head_read_stays_above_the_measured_frontmatter_maximum(self):
-        from manifest import _FM_READ_BYTES
-        assert _FM_READ_BYTES > self.CORPUS_MAX_FRONTMATTER_BYTES, (
-            f"head read {_FM_READ_BYTES} is not above the largest real frontmatter block "
-            f"({self.CORPUS_MAX_FRONTMATTER_BYTES}); a real artifact would parse as if it "
+        from manifest import _FM_READ_CHARS
+        assert _FM_READ_CHARS > self.CORPUS_MAX_FRONTMATTER_CHARS, (
+            f"head read {_FM_READ_CHARS} is not above the largest real frontmatter block "
+            f"({self.CORPUS_MAX_FRONTMATTER_CHARS}); a real artifact would parse as if it "
             f"had no frontmatter. Re-measure before changing this."
         )
-        assert _FM_READ_BYTES < 1024 * 1024, (
+        assert _FM_READ_CHARS < 1024 * 1024, (
             "the head read must stay well under MAX_SKILL_SIZE (1MB) or it is not a bound"
         )
 
@@ -255,3 +256,64 @@ class TestFrontmatterParseIsBoundedAndLinear:
         p = tmp_path / "SKILL.md"
         p.write_text(text, encoding="utf-8")
         assert parse_frontmatter(p) == expected, label
+
+
+class TestFrontmatterWhitespaceClassIsNotNarrowed:
+    """The ReDoS fix replaced `\\s*` with a class that cannot span the newline. That is a
+    NARROWING of the whitespace class, and the first attempt narrowed too far.
+
+    `[ \\t]*\\r?` lost six shapes 8.8.2 parsed — form feed, vertical tab, `\\r\\r\\n`,
+    NBSP, em space, and a mixed run. Material, not cosmetic: `manifest` reports resolved
+    state, so frontmatter it fails to parse makes a `disable-model-invocation: true` skill
+    read as LOADED, and drops the description that carries the per-turn cost.
+
+    `[^\\S\\n]*` — whitespace except newline — is the class that keeps every shape and
+    still cannot restart the lazy body scan. This enumerates the dimension rather than
+    sampling it, which is the only way the six losses became visible.
+    """
+
+    SEPARATORS = [
+        ("lf", "\n"),
+        ("crlf", "\r\n"),
+        ("space_lf", " \n"),
+        ("tab_lf", "\t\n"),
+        ("two_spaces_lf", "  \n"),
+        ("formfeed_lf", "\f\n"),
+        ("vtab_lf", "\v\n"),
+        ("cr_cr_lf", "\r\r\n"),
+        ("lf_lf", "\n\n"),
+        ("space_cr_lf", " \r\n"),
+        ("nbsp_lf", "\u00a0\n"),
+        ("emspace_lf", "\u2003\n"),
+        ("tab_cr_lf", "\t\r\n"),
+        ("mixed_ws_lf", "\t \r\f\v\n"),
+    ]
+
+    @pytest.mark.parametrize("label,sep", SEPARATORS, ids=[s[0] for s in SEPARATORS])
+    def test_every_whitespace_separator_still_parses(self, tmp_path, label, sep):
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        p.write_text(f"---{sep}name: a{sep}description: b{sep}---{sep}body", encoding="utf-8")
+        fm = parse_frontmatter(p)
+        assert fm.get("name") == "a", (
+            f"separator {label!r} no longer parses — the whitespace class was narrowed "
+            f"past what 8.8.2 accepted. A frontmatter this parser misses makes a disabled "
+            f"skill report as loaded."
+        )
+
+    @pytest.mark.parametrize("label,sep", SEPARATORS, ids=[s[0] for s in SEPARATORS])
+    def test_disabled_skill_is_never_reported_as_loaded(self, tmp_path, label, sep):
+        """The consequence that makes the above material, asserted directly."""
+        from manifest import build_manifest
+        root = tmp_path / ".claude"
+        d = root / "skills" / "off"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---{sep}name: off{sep}disable-model-invocation: true{sep}---{sep}body",
+            encoding="utf-8")
+        m = build_manifest(claude_dir=root)
+        assert [a.name for a in m.loaded] == [], (
+            f"separator {label!r}: a disabled skill was reported as LOADED because its "
+            f"frontmatter did not parse"
+        )
+        assert any(f.kind == "disabled" for f in m.findings), f"separator {label!r}"

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -164,7 +164,8 @@ class TestFrontmatterParseIsBoundedAndLinear:
         """A 4MB SKILL.md must not be pulled into memory to read its frontmatter.
 
         This asserts the READ, not just the result. A first version of this test only
-        checked that `_FM_READ_BYTES` was small and that parsing still worked — and it
+        checked that `_FM_READ_BYTES` (as it was then named) was small and that parsing
+        still worked — and it
         passed with the bounded read reverted to a full `read_text()`, because a full read
         produces the same mapping. A test that cannot fail on the defect it names is not a
         test. Found by mutation.
@@ -254,7 +255,7 @@ class TestFrontmatterParseIsBoundedAndLinear:
     def test_real_shapes_parse_unchanged(self, tmp_path, label, text, expected):
         from manifest import parse_frontmatter
         p = tmp_path / "SKILL.md"
-        p.write_text(text, encoding="utf-8")
+        p.write_bytes(text.encode("utf-8"))   # exact bytes, no platform translation
         assert parse_frontmatter(p) == expected, label
 
 
@@ -304,7 +305,9 @@ class TestFrontmatterWhitespaceClassIsNotNarrowed:
     def test_every_whitespace_separator_still_parses(self, tmp_path, label, sep):
         from manifest import parse_frontmatter
         p = tmp_path / "SKILL.md"
-        p.write_text(f"---{sep}name: a{sep}description: b{sep}---{sep}body", encoding="utf-8")
+        # write_bytes: on WRITE, newline=None maps '\n' to os.linesep, so write_text would
+        # put a platform-dependent separator on disk instead of the one named above.
+        p.write_bytes(f"---{sep}name: a{sep}description: b{sep}---{sep}body".encode("utf-8"))
         fm = parse_frontmatter(p)
         assert fm.get("name") == "a", (
             f"separator {label!r} no longer parses — the whitespace class was narrowed "
@@ -319,9 +322,9 @@ class TestFrontmatterWhitespaceClassIsNotNarrowed:
         root = tmp_path / ".claude"
         d = root / "skills" / "off"
         d.mkdir(parents=True)
-        (d / "SKILL.md").write_text(
-            f"---{sep}name: off{sep}disable-model-invocation: true{sep}---{sep}body",
-            encoding="utf-8")
+        (d / "SKILL.md").write_bytes(
+            f"---{sep}name: off{sep}disable-model-invocation: true{sep}---{sep}body"
+            .encode("utf-8"))
         m = build_manifest(claude_dir=root)
         assert [a.name for a in m.loaded] == [], (
             f"separator {label!r}: a disabled skill was reported as LOADED because its "
@@ -333,28 +336,50 @@ class TestFrontmatterWhitespaceClassIsNotNarrowed:
 class TestUniversalNewlineContract:
     """`parse_frontmatter` reads through `path.open("r")`, so CR never reaches the regex.
 
-    This is load-bearing and was invisible until a mutation test disagreed with a
-    hand-run enumeration: the enumeration used in-memory strings and reported six lost
-    shapes, the mutation reported four, and the read path was the difference. Pinned so
-    the next person does not have to rediscover it — and so switching to `newline=""`,
-    which would make CR reachable and change which separators are equivalent, fails here.
+    Load-bearing, and invisible until a mutation test disagreed with a hand-run
+    enumeration: the enumeration used in-memory strings and reported six lost shapes, the
+    mutation reported four, and the read path was the difference. Pinned so the next person
+    does not rediscover it, and so switching to `newline=""` — which would make CR
+    reachable and change which separators are equivalent — fails here.
     """
 
-    def test_carriage_returns_never_reach_the_regex(self, tmp_path):
+    def test_carriage_returns_never_reach_the_regex(self, tmp_path, monkeypatch):
+        """Asserts what PARSE_FRONTMATTER reads, not what this test reads.
+
+        The first version of this test opened the file itself and asserted no CR appeared
+        in its own buffer — a property of the test's read, not the production one. It
+        stayed GREEN when the production read was switched to `newline=""`, the exact
+        mutation it exists to catch. Third instance of that class this branch: an assertion
+        one layer away from the code proves nothing about the code.
+        """
+        import pathlib as _pathlib
+
         from manifest import parse_frontmatter
         p = tmp_path / "SKILL.md"
-        # Written as CRLF bytes on purpose — not via write_text, which would translate.
+        # write_bytes, not write_text: on WRITE, newline=None maps '\n' to os.linesep, so
+        # write_text would put a platform-dependent separator on disk rather than the one
+        # named here. Same substrate mistake as this class documents, one layer down.
         p.write_bytes(b"---\r\nname: a\r\ndescription: b\r\n---\r\nbody")
-        with p.open("r", encoding="utf-8", errors="replace") as fh:
-            seen = fh.read(4096)
-        assert "\r" not in seen, (
-            "a literal CR reached the reader — the file is no longer opened in universal-"
-            "newline mode, so the CR-bearing separators in "
-            "TestFrontmatterWhitespaceClassIsNotNarrowed are no longer equivalent to their "
-            "LF forms and need re-enumerating against this substrate"
+
+        opens: list = []
+        real_open = _pathlib.Path.open
+
+        def recording_open(self, *args, **kwargs):
+            opens.append(kwargs.get("newline", "__absent__"))
+            return real_open(self, *args, **kwargs)
+
+        monkeypatch.setattr(_pathlib.Path, "open", recording_open)
+        result = parse_frontmatter(p)
+
+        assert opens, "parse_frontmatter did not read through Path.open"
+        assert all(n == "__absent__" or n is None for n in opens), (
+            f"parse_frontmatter opened with newline={opens!r}. Universal-newline mode is "
+            f"off, so a literal CR now reaches the regex: the CR-bearing separators in "
+            f"TestFrontmatterWhitespaceClassIsNotNarrowed stop being equivalent to their "
+            f"LF forms and the enumeration needs re-running against this substrate."
         )
         # ...and the values still parse, through the translation.
-        assert parse_frontmatter(p) == {"name": "a", "description": "b"}
+        assert result == {"name": "a", "description": "b"}
 
     def test_lone_cr_line_endings_are_translated_not_dropped(self, tmp_path):
         """Classic-Mac CR-only endings become LF, so they parse rather than reading as

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -262,14 +262,25 @@ class TestFrontmatterWhitespaceClassIsNotNarrowed:
     """The ReDoS fix replaced `\\s*` with a class that cannot span the newline. That is a
     NARROWING of the whitespace class, and the first attempt narrowed too far.
 
-    `[ \\t]*\\r?` lost six shapes 8.8.2 parsed — form feed, vertical tab, `\\r\\r\\n`,
-    NBSP, em space, and a mixed run. Material, not cosmetic: `manifest` reports resolved
-    state, so frontmatter it fails to parse makes a `disable-model-invocation: true` skill
-    read as LOADED, and drops the description that carries the per-turn cost.
+    `[ \\t]*\\r?` lost FOUR shapes 8.8.2 parsed, measured through the real read path: form
+    feed, vertical tab, NBSP and em space. Material, not cosmetic: `manifest` reports
+    resolved state, so frontmatter it fails to parse makes a `disable-model-invocation:
+    true` skill read as LOADED, and drops the description that carries the per-turn cost.
 
     `[^\\S\\n]*` — whitespace except newline — is the class that keeps every shape and
-    still cannot restart the lazy body scan. This enumerates the dimension rather than
-    sampling it, which is the only way the six losses became visible.
+    still cannot restart the lazy body scan. Enumerating the dimension rather than sampling
+    it is the only way the losses became visible.
+
+    The first count published for this was SIX, and it was wrong. That enumeration ran
+    against in-memory strings while `parse_frontmatter` reads through `path.open("r")`,
+    i.e. universal newlines — which collapses every CR-based shape before the regex sees
+    it. A mutation test disagreed with the hand-run enumeration (four red, not six) and the
+    read path was the difference. A probe against a substrate the code does not use is not
+    a probe, and the error went in the direction that flattered the finding.
+
+    The CR-bearing separators below are kept deliberately: they pin the translated
+    behaviour, and `TestUniversalNewlineContract` pins the translation itself, because the
+    day someone opens the file with `newline=""` those shapes stop being equivalent.
     """
 
     SEPARATORS = [
@@ -317,3 +328,38 @@ class TestFrontmatterWhitespaceClassIsNotNarrowed:
             f"frontmatter did not parse"
         )
         assert any(f.kind == "disabled" for f in m.findings), f"separator {label!r}"
+
+
+class TestUniversalNewlineContract:
+    """`parse_frontmatter` reads through `path.open("r")`, so CR never reaches the regex.
+
+    This is load-bearing and was invisible until a mutation test disagreed with a
+    hand-run enumeration: the enumeration used in-memory strings and reported six lost
+    shapes, the mutation reported four, and the read path was the difference. Pinned so
+    the next person does not have to rediscover it — and so switching to `newline=""`,
+    which would make CR reachable and change which separators are equivalent, fails here.
+    """
+
+    def test_carriage_returns_never_reach_the_regex(self, tmp_path):
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        # Written as CRLF bytes on purpose — not via write_text, which would translate.
+        p.write_bytes(b"---\r\nname: a\r\ndescription: b\r\n---\r\nbody")
+        with p.open("r", encoding="utf-8", errors="replace") as fh:
+            seen = fh.read(4096)
+        assert "\r" not in seen, (
+            "a literal CR reached the reader — the file is no longer opened in universal-"
+            "newline mode, so the CR-bearing separators in "
+            "TestFrontmatterWhitespaceClassIsNotNarrowed are no longer equivalent to their "
+            "LF forms and need re-enumerating against this substrate"
+        )
+        # ...and the values still parse, through the translation.
+        assert parse_frontmatter(p) == {"name": "a", "description": "b"}
+
+    def test_lone_cr_line_endings_are_translated_not_dropped(self, tmp_path):
+        """Classic-Mac CR-only endings become LF, so they parse rather than reading as
+        one unterminated line."""
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        p.write_bytes(b"---\rname: a\r---\rbody")
+        assert parse_frontmatter(p) == {"name": "a"}

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -122,3 +122,136 @@ def test_output_is_renderable_and_serialisable(install: Path):
 def test_empty_install_says_so(tmp_path: Path):
     out = format_manifest(build_manifest(claude_dir=tmp_path))
     assert "0 artifacts loaded" in out
+
+
+class TestFrontmatterParseIsBoundedAndLinear:
+    """`schliff manifest` reads third-party content, so its parser is a trust boundary.
+
+    It walks every SKILL.md under `~/.claude/skills`, every `*.md` under
+    `~/.claude/commands`, the project's `.claude/`, and the payload of every enabled
+    plugin. Two defects from the 2026-07-30 audit met there:
+
+    1. `_FM = r"^---\\s*\\n(.*?)\\n---\\s*\\n"` is O(n^2) because `\\s*` may consume
+       newlines: every `\\s*` length restarts the lazy body scan. 25.6s at 64KB, 4.04x
+       per doubling; ~1.9h extrapolated at 1MB.
+    2. The read had no size cap at all — a raw `read_text()`, unlike every other reader
+       in the engine, which goes through `read_skill_safe` at MAX_SKILL_SIZE.
+
+    Both call sites do `fm, _ = parse_frontmatter(...)`: the body was never used. So the
+    fix reads a bounded HEAD rather than capping a full read nobody needed.
+    """
+
+    def test_unterminated_frontmatter_parses_in_linear_time(self, tmp_path):
+        import time
+
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        prev = None
+        for n in (16_000, 32_000, 64_000):
+            p.write_text("---" + "\n" * n, encoding="utf-8")
+            start = time.perf_counter()
+            parse_frontmatter(p)
+            elapsed = time.perf_counter() - start
+            if prev is not None:
+                assert elapsed / prev < 3.0, (
+                    f"parse_frontmatter is super-linear: {prev * 1000:.1f}ms -> "
+                    f"{elapsed * 1000:.1f}ms at n={n} ({elapsed / prev:.2f}x per doubling)"
+                )
+            prev = elapsed
+        assert prev < 1.0, f"parse_frontmatter took {prev:.2f}s on a 64KB file"
+
+    def test_oversized_file_is_not_read_whole(self, tmp_path, monkeypatch):
+        """A 4MB SKILL.md must not be pulled into memory to read its frontmatter.
+
+        This asserts the READ, not just the result. A first version of this test only
+        checked that `_FM_READ_BYTES` was small and that parsing still worked — and it
+        passed with the bounded read reverted to a full `read_text()`, because a full read
+        produces the same mapping. A test that cannot fail on the defect it names is not a
+        test. Found by mutation.
+        """
+        import pathlib as _pathlib
+
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        p.write_text("---\nname: big\ndescription: fine\n---\n" + "x" * (4 * 1024 * 1024),
+                     encoding="utf-8")
+
+        requested: list = []
+        real_open = _pathlib.Path.open
+
+        def recording_open(self, *args, **kwargs):
+            handle = real_open(self, *args, **kwargs)
+            real_read = handle.read
+
+            def read(n=-1):
+                requested.append(n)
+                return real_read(n)
+
+            handle.read = read
+            return handle
+
+        monkeypatch.setattr(_pathlib.Path, "open", recording_open)
+        fm = parse_frontmatter(p)
+
+        assert fm.get("name") == "big"
+        assert fm.get("description") == "fine"
+        assert requested, (
+            "parse_frontmatter did not go through Path.open — a full-file read path "
+            "(read_text, read_bytes) bypasses the bound entirely"
+        )
+        assert all(n is not None and n > 0 for n in requested), (
+            f"parse_frontmatter issued an unbounded read: read({requested}). "
+            f"read(-1) or read() pulls the whole 4MB file into memory."
+        )
+        assert max(requested) <= 64 * 1024, f"read too much at once: {max(requested)} bytes"
+
+    # Largest frontmatter block measured across 248 real skills, commands and plugin
+    # payloads (vercel's ai-sdk SKILL.md). The head read must stay above it or the
+    # frontmatter of a real artifact gets truncated and its description silently reads
+    # as empty — the same "calibrate the bound, do not guess it" rule as the pattern
+    # bounds in PR 1, and it needs its own assertion for the same reason.
+    CORPUS_MAX_FRONTMATTER_BYTES = 15_711
+
+    def test_head_read_stays_above_the_measured_frontmatter_maximum(self):
+        from manifest import _FM_READ_BYTES
+        assert _FM_READ_BYTES > self.CORPUS_MAX_FRONTMATTER_BYTES, (
+            f"head read {_FM_READ_BYTES} is not above the largest real frontmatter block "
+            f"({self.CORPUS_MAX_FRONTMATTER_BYTES}); a real artifact would parse as if it "
+            f"had no frontmatter. Re-measure before changing this."
+        )
+        assert _FM_READ_BYTES < 1024 * 1024, (
+            "the head read must stay well under MAX_SKILL_SIZE (1MB) or it is not a bound"
+        )
+
+    def test_returns_only_the_frontmatter_mapping(self, tmp_path):
+        """Both call sites discarded the body. Returning it invited a full read for
+        nothing, so the signature drops it."""
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        p.write_text("---\nname: x\ndescription: y\n---\n\nbody text\n", encoding="utf-8")
+        result = parse_frontmatter(p)
+        assert isinstance(result, dict), f"expected a mapping, got {type(result).__name__}"
+        assert result == {"name": "x", "description": "y"}
+
+    # Shapes that must keep parsing byte-identically after the anchor change.
+    EQUIVALENCE = [
+        ("plain", "---\nname: a\ndescription: b\n---\nbody", {"name": "a", "description": "b"}),
+        ("crlf", "---\r\nname: a\r\ndescription: b\r\n---\r\nbody",
+         {"name": "a", "description": "b"}),
+        ("trailing spaces on delimiters", "---  \nname: a\n---  \nbody", {"name": "a"}),
+        ("no frontmatter", "# just a heading\n", {}),
+        ("unterminated", "---\nname: a\n", {}),
+        ("block scalar", "---\nname: a\ndescription: >\n  one\n  two\n---\nbody",
+         {"name": "a", "description": "one two"}),
+        ("quoted value", '---\nname: "a b"\n---\nbody', {"name": "a b"}),
+        ("boolean", "---\nname: a\ndisable-model-invocation: true\n---\nbody",
+         {"name": "a", "disable-model-invocation": True}),
+    ]
+
+    @pytest.mark.parametrize("label,text,expected", EQUIVALENCE,
+                             ids=[c[0] for c in EQUIVALENCE])
+    def test_real_shapes_parse_unchanged(self, tmp_path, label, text, expected):
+        from manifest import parse_frontmatter
+        p = tmp_path / "SKILL.md"
+        p.write_text(text, encoding="utf-8")
+        assert parse_frontmatter(p) == expected, label

--- a/skills/schliff/tests/unit/test_manifest.py
+++ b/skills/schliff/tests/unit/test_manifest.py
@@ -349,9 +349,15 @@ class TestUniversalNewlineContract:
         The first version of this test opened the file itself and asserted no CR appeared
         in its own buffer — a property of the test's read, not the production one. It
         stayed GREEN when the production read was switched to `newline=""`, the exact
-        mutation it exists to catch. Third instance of that class this branch: an assertion
-        one layer away from the code proves nothing about the code.
+        mutation it exists to catch. An assertion one layer away from the code proves
+        nothing about the code.
+
+        It then stayed green a SECOND time, for the same mutation spelled positionally
+        (`open("r", -1, "utf-8", "replace", "")`), because the repair inspected `kwargs`
+        only. So the arguments are now normalised through the real signature instead of
+        being guessed at: an assertion a spelling can walk around is not an assertion.
         """
+        import inspect
         import pathlib as _pathlib
 
         from manifest import parse_frontmatter
@@ -361,19 +367,22 @@ class TestUniversalNewlineContract:
         # named here. Same substrate mistake as this class documents, one layer down.
         p.write_bytes(b"---\r\nname: a\r\ndescription: b\r\n---\r\nbody")
 
-        opens: list = []
         real_open = _pathlib.Path.open
+        signature = inspect.signature(real_open)
+        newlines: list = []
 
         def recording_open(self, *args, **kwargs):
-            opens.append(kwargs.get("newline", "__absent__"))
+            bound = signature.bind(self, *args, **kwargs)
+            bound.apply_defaults()
+            newlines.append(bound.arguments.get("newline"))
             return real_open(self, *args, **kwargs)
 
         monkeypatch.setattr(_pathlib.Path, "open", recording_open)
         result = parse_frontmatter(p)
 
-        assert opens, "parse_frontmatter did not read through Path.open"
-        assert all(n == "__absent__" or n is None for n in opens), (
-            f"parse_frontmatter opened with newline={opens!r}. Universal-newline mode is "
+        assert newlines, "parse_frontmatter did not read through Path.open"
+        assert all(n is None for n in newlines), (
+            f"parse_frontmatter opened with newline={newlines!r}. Universal-newline mode is "
             f"off, so a literal CR now reaches the regex: the CR-bearing separators in "
             f"TestFrontmatterWhitespaceClassIsNotNarrowed stop being equivalent to their "
             f"LF forms and the enumeration needs re-running against this substrate."

--- a/skills/schliff/tests/unit/test_patterns_scale_linearly.py
+++ b/skills/schliff/tests/unit/test_patterns_scale_linearly.py
@@ -12,11 +12,15 @@ the measured defects were 3.9x-4.1x. The threshold is 3.0x with an absolute floo
 a loaded CI runner cannot flake it while the 4.0x class is still caught with margin.
 
 Known limit, stated rather than glossed: this gate reaches exactly as far as its filler
-alphabet. `manifest._FM` is quadratic on a frontmatter-shaped input (`"---" + "\n" * n`,
-3.95x per doubling) and NONE of the generic fillers below trip it — they come in at
-1.85x, below the absolute floor. So a shape nobody thought of stays invisible here. The
-`_MIN_ABS_SECONDS` floor has the same character: it suppresses noise, and it would also
-suppress a quadratic with a very small constant at this input size.
+alphabet. That is not hypothetical — `manifest._FM` was quadratic on a frontmatter-shaped
+input at 3.95x per doubling while every generic filler came in at 1.85x, below the
+absolute floor, so the gate shipped blind to a live defect for one commit. The two
+`frontmatter_*` fillers close that specific shape; a shape nobody has thought of yet
+still stays invisible. The `_MIN_ABS_SECONDS` floor has the same character: it suppresses
+noise, and it would also suppress a quadratic with a very small constant at this size.
+
+The lesson generalises: when a defect is found by hand, add the filler that would have
+found it. The alphabet is the gate.
 
 Cost: ~10-25s. That is the price of the only gate here that does not depend on a
 heuristic being right. Its deterministic companion is `test_patterns_are_bounded.py`.
@@ -101,6 +105,11 @@ _FILLERS = {
     "the_file": lambda n: "the file " * (n // 9),
     "urlish": lambda n: "http://a/" * (n // 9),
     "md_link": lambda n: "- [x](y.md) " * (n // 12),
+    # Frontmatter-shaped. Added when the blind spot documented below turned out to hide a
+    # live quadratic: `manifest._FM` opens with `^---\s*\n`, so only an input that STARTS
+    # with the delimiter reaches its lazy body scan. None of the fillers above do.
+    "frontmatter_unterminated": lambda n: "---" + "\n" * (n - 3),
+    "frontmatter_open": lambda n: "---\n" + "\n" * (n - 4),
 }
 
 _N = 2000                 # base size; the comparison runs at 2*_N


### PR DESCRIPTION
**2 of 4 in a stack.** Base is #162, not `main` — GitHub retargets this to `main` once #162
merges. Review only the diff shown here.

`schliff manifest` walks third-party content: every SKILL.md under `~/.claude/skills`, every
command under `~/.claude/commands`, the project's `.claude/`, and the payload of every
enabled plugin. Two defects met there.

## 1. Quadratic frontmatter parse

`_FM = r"^---\s*\n(.*?)\n---\s*\n"` — `\s` matches the newline **itself**, so every possible
`\s*` length restarted the lazy body scan. O(n²) on a file that opens the delimiter and
never closes it: 25.6 s at 64 KB, 4.04× per doubling, ~1.9 h extrapolated at 1 MB.

Through the shipping CLI on one hostile 64 KB skill: **30.77 s → 0.22 s.**

Fixed with `[^\S\n]*` — whitespace except the newline. A class that cannot span the record
separator cannot restart that scan: 1.5 ms at 64 KB, linear.

## 2. No size cap at all

The read was a raw `read_text()` — the only reader in the engine without one, while every
other goes through `read_skill_safe` at `MAX_SKILL_SIZE`. Both call sites did
`fm, _ = parse_frontmatter(...)`, so **the body was the only reason a whole file had to be
in memory**. Reading a bounded 65,536-character head and dropping the body from the
signature removes the unbounded read, the quadratic trigger and a dead return value
together.

Calibrated: across 248 real skills, commands and plugin payloads the frontmatter block runs
a median of 694 characters, p95 4,476, max 15,711 (vercel's `ai-sdk`) — 100% carried with 4×
headroom, and a test pins the bound above that maximum. Characters, not bytes: `read(n)` on
a text handle counts code points, so the constant is `_FM_READ_CHARS` rather than promising
a byte guarantee the call does not make.

**Verified against the real install:** `manifest --json` output is byte-identical to `main`
— same sha256, 109 artifacts, 8,240 resident tokens, 19 findings.

## Review caught a real regression, and then a wrong number

- **The first fix narrowed too far.** `[ \t]*\r?` lost four shapes 8.8.2 parsed — form feed,
  vertical tab, NBSP, em space. Material rather than cosmetic: this tool reports *resolved
  state*, so frontmatter it fails to parse makes a `disable-model-invocation: true` skill
  read as **LOADED** and drops the description that carries the per-turn cost. `[^\S\n]*`
  keeps every shape: **0 divergences** across all 14 enumerated separators. Every code point
  the class admits was probed individually for a revived blowup (1.97–2.07× per doubling).
- **I first published that count as six.** The enumeration ran against in-memory strings
  while `parse_frontmatter` reads through `path.open("r")` — universal newlines, which
  collapses every CR-based shape before the regex sees it. A mutation test disagreed with the
  hand-run enumeration and the read path was the difference. A probe against a substrate the
  code does not use is not a probe. The translation is now pinned by a test, since `newline=""`
  would make CR reachable and change which separators are equivalent.

## Three of this PR's own tests were non-discriminating

Every one found by mutation, none by rereading, and one of them twice:

1. `test_oversized_file_is_not_read_whole` asserted the constant and the result, so it passed
   with the bounded read reverted to a full `read_text()` — a full read yields the same
   mapping. It now instruments `Path.open` and asserts the actual `read(n)`.
2. Nothing pinned the head against the corpus maximum, so shrinking it to 8 KB passed.
3. `test_carriage_returns_never_reach_the_regex` asserted its **own** read rather than the
   production one and stayed green on the exact mutation it exists to catch; the repair then
   inspected `kwargs` only and stayed green again for the same mutation spelled positionally.
   Arguments are now normalised through `inspect.signature(...).bind(...)`.

A test that cannot fail on the defect it names is not a test — and an assertion a spelling
can walk around is not an assertion.

The empirical ReDoS gate from #162 gained the two frontmatter-shaped fillers that were its
documented blind spot, so this defect is now caught by the gate (3.99×, 4.07× confirmed)
rather than by a hand-built payload.

## Gates run

1918 pytest · test-self 21/0 · integration 100/0 · proof 6/0 · ruff clean · markdownlint
0/67 · 0 dangling.

Spec: `docs/specs/2026-07-30-redos-audit-fixes.md` (D3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
