### PR TITLE
security(playground): a negative Content-Length bypassed the byte cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   gate gained the frontmatter-shaped fillers that were the documented blind spot, so this
   defect is now caught by the gate rather than by hand.
 
+- **The playground's byte cap was bypassable with a negative `Content-Length`.**
+  `read_len = min(content_length, MAX_CONTENT_SIZE)` is `-1` when the header is `-1`, and
+  `rfile.read(-1)` reads to EOF — so the cap that line's own comment promises did not hold.
+  Measured by driving `do_POST` with an instrumented socket: **3,145,832 bytes read against
+  a 512,000-byte cap.** The leaderboard's `submit.py` already had the `< 0` half of its
+  guard; the playground did not. Now rejected as `400 Invalid Content-Length header`, the
+  same reason the endpoint already gives for an unparseable one.
+
+  Honest scope: bounded in practice by Vercel's own body limit, and whether the edge
+  forwards a negative `Content-Length` at all is unverified — checking would mean probing
+  production. Defence in depth and a fixed asymmetry between two sibling endpoints, not a
+  demonstrated live exploit.
+
 - **`clarity`'s function docstring contradicted its own module docstring**, claiming a
   zero default weight and a `--clarity` opt-in. Both were stale — clarity runs in the
   default scorer set for every format — and that contradiction is exactly what made two

--- a/docs/specs/2026-07-30-redos-audit-fixes.md
+++ b/docs/specs/2026-07-30-redos-audit-fixes.md
@@ -1,6 +1,7 @@
 # Bounded quantifiers: closing the ReDoS class found by the 2026-07-30 audit
 
-Status: D1, D1a, D2, D5, D6 implemented (PR 1). D3 implemented (PR 2). D7, D8 pending.
+Status: D1, D1a, D2, D5, D6 implemented (PR 1). D3 implemented (PR 2).
+D9 implemented, D10 declined (PR 3). D7 pending, D8 declined.
 Date: 2026-07-30
 Baseline: `main` @ `ab41827`
 
@@ -294,6 +295,54 @@ absolute floor. The frontmatter filler therefore lands **with** the D3 fix, wher
 red-before-green rather than red-on-main. The `_MIN_ABS_SECONDS` floor has the same
 character: it suppresses noise, and would also suppress a quadratic with a very small
 constant at this input size.
+
+### D9 — `score.py`: a negative Content-Length is an invalid header, not a small one
+
+`read_len = min(content_length, MAX_CONTENT_SIZE)` evaluates to `-1` when the header is
+`-1`, and `rfile.read(-1)` reads to EOF — so the cap the line's own comment promises
+("Read at most MAX_CONTENT_SIZE bytes regardless of the declared Content-Length") is
+bypassed. Measured by driving `do_POST` with an instrumented `rfile`: **3,145,832 bytes
+read against a 512,000-byte cap.** `web/leaderboard/api/submit.py` already had the `< 0`
+half of its guard; this endpoint did not.
+
+Rejected as `400 Invalid Content-Length header` rather than folded into the `413` branch:
+the endpoint already has that exact 400 for an unparseable header, and a negative length
+is the same category of defect.
+
+Bounded in practice by Vercel's own body limit, and whether the edge forwards a negative
+Content-Length at all is **unverified** — establishing that would mean probing production.
+So this is defence in depth and an asymmetry between two sibling endpoints, not a
+demonstrated live exploit.
+
+Tests drive `do_POST` rather than grepping the source, and each asserts the **reason**, not
+just the status: before the guard a negative length already returned 400, from the
+truncated-JSON branch, so a status-only assertion would have passed on the unfixed code.
+An over-broad `<= 0` guard is caught too — it keeps every status identical and only steals
+the empty-body message, which a status-only assertion cannot see. Both were found by
+mutation.
+
+### D10 — F7 (badge cache-buster) DECLINED, with the measurement
+
+`badge.py` reads only `repo` from the query string; other parameters are ignored by the
+handler but are part of the CDN cache key, so `?repo=o/n&x=N` mints unlimited distinct keys
+that each re-run the scorer. The proposed fix was to reject unknown parameters.
+
+Declined, because the severity was derived from D1. Post-fix cost of the worst payload an
+attacker can put in an AGENTS.md at the 32 KB cap:
+
+| payload | before D1 | after D1 |
+| --- | --- | --- |
+| benign 32 KB | — | 87.9 ms |
+| the 4.75 s shape | 4,750 ms | 122.7 ms |
+| the 162 s shape | 162,600 ms | 96.0 ms |
+
+120 ms per request is ordinary request cost, not amplification. And the marginal harm over
+"attacker enumerates real public repos" is about zero: the CDN cache only ever protected a
+*single* repo key, and there is no shortage of repos. Changing public behaviour — a URL with
+a stray parameter would start returning a grey badge — is not worth that.
+
+Recorded rather than silently dropped, so the decline is auditable. Revisit if D1 is ever
+relaxed, since this finding's severity is a function of that one.
 
 ### D7 — `run-eval.sh`: make the missing guard visible, do not touch the matcher
 

--- a/playground/api/score.py
+++ b/playground/api/score.py
@@ -162,6 +162,17 @@ class handler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": "Invalid Content-Length header"})
             return
 
+        # A NEGATIVE Content-Length is an invalid header, not a small one. Without this
+        # branch it falls through both checks below and reaches
+        # `read_len = min(content_length, MAX_CONTENT_SIZE)`, which is -1 — and
+        # `rfile.read(-1)` reads to EOF, so the byte cap the next comment promises is
+        # bypassed entirely. Measured before the guard: a declared -1 read 3,145,832 bytes
+        # against a 512,000-byte cap. `web/leaderboard/api/submit.py` already had the
+        # `< 0` half of its guard; this endpoint did not.
+        if content_length < 0:
+            self._send_json(400, {"error": "Invalid Content-Length header"})
+            return
+
         if content_length > MAX_CONTENT_SIZE:
             self._send_json(413, {
                 "error": "Content too large",

--- a/skills/schliff/tests/unit/test_playground_score.py
+++ b/skills/schliff/tests/unit/test_playground_score.py
@@ -55,18 +55,26 @@ class TestContentLengthGuard:
     """
 
     @staticmethod
-    def _handler_class():
+    def _handler_class(monkeypatch):
+        """Load playground/api/score.py by path.
+
+        `monkeypatch.syspath_prepend`, not a bare `sys.path.insert`: the first version of
+        this helper inserted the repo root on EVERY call and never removed it, so a suite
+        run left five duplicate entries in a global. This file's sibling conftest isolates
+        cwd per test with automatic restore for the same reason — a test that mutates
+        process-wide state and does not undo it can change the behaviour of tests that run
+        after it.
+        """
         import importlib.util
-        import sys
-        sys.path.insert(0, str(_ROOT))
+        monkeypatch.syspath_prepend(str(_ROOT))
         spec = importlib.util.spec_from_file_location("_pg_score", _SCORE_PY)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         return mod
 
-    def _drive(self, content_length: str, body: bytes):
+    def _drive(self, monkeypatch, content_length: str, body: bytes):
         import io
-        mod = self._handler_class()
+        mod = self._handler_class(monkeypatch)
 
         class RecordingBytesIO(io.BytesIO):
             def __init__(self, data):
@@ -102,46 +110,46 @@ class TestContentLengthGuard:
     # A body far past the cap, so an unbounded read is unmistakable.
     BODY = json.dumps({"content": "x" * 64, "filename": "SKILL.md"}).encode() + b"\n" + b"P" * (3 * 1024 * 1024)
 
-    def test_negative_content_length_does_not_bypass_the_cap(self):
-        h, cap = self._drive("-1", self.BODY)
+    def test_negative_content_length_does_not_bypass_the_cap(self, monkeypatch):
+        h, cap = self._drive(monkeypatch, "-1", self.BODY)
         requested, returned = h.rfile.reads[0] if h.rfile.reads else (None, 0)
         assert returned <= cap, (
             f"Content-Length: -1 read {returned:,} bytes past the {cap:,}-byte cap "
             f"(rfile.read({requested}) reads to EOF)"
         )
 
-    def test_negative_content_length_is_reported_as_an_invalid_header(self):
+    def test_negative_content_length_is_reported_as_an_invalid_header(self, monkeypatch):
         """Discriminating on the REASON, not just the status.
 
         Before the guard this already returned 400 — from the truncated-JSON branch, not
         from any Content-Length check. Asserting the status alone would have passed on the
         unfixed code, so it asserts the error string that only the guard produces.
         """
-        h, _ = self._drive("-1", self.BODY)
+        h, _ = self._drive(monkeypatch, "-1", self.BODY)
         assert h.status == 400, f"expected 400 for an invalid Content-Length, got {h.status}"
         assert h.body.get("error") == "Invalid Content-Length header", (
             f"400 came from the wrong branch: {h.body!r}. A negative Content-Length must be "
             f"rejected as an invalid header, not incidentally as unparseable JSON."
         )
 
-    def test_honest_oversize_still_gets_413(self):
-        h, _ = self._drive(str(3 * 1024 * 1024), self.BODY)
+    def test_honest_oversize_still_gets_413(self, monkeypatch):
+        h, _ = self._drive(monkeypatch, str(3 * 1024 * 1024), self.BODY)
         assert h.status == 413, f"expected 413 for an honest oversize, got {h.status}"
 
-    def test_lying_small_content_length_still_reads_only_what_it_declared(self):
-        h, _ = self._drive("10", self.BODY)
+    def test_lying_small_content_length_still_reads_only_what_it_declared(self, monkeypatch):
+        h, _ = self._drive(monkeypatch, "10", self.BODY)
         requested, returned = h.rfile.reads[0]
         assert returned == 10, f"read {returned} bytes for a declared 10"
         assert h.status == 400  # truncated JSON
 
-    def test_zero_content_length_still_rejected_as_an_empty_body(self):
+    def test_zero_content_length_still_rejected_as_an_empty_body(self, monkeypatch):
         """Also discriminating on the reason, for the opposite direction.
 
         An over-broad guard (`<= 0` instead of `< 0`) keeps every status identical and only
         changes which message an empty body gets — invisible to a status-only assertion.
         Found by mutation, like every other instance of this on the branch.
         """
-        h, _ = self._drive("0", b"")
+        h, _ = self._drive(monkeypatch, "0", b"")
         assert h.status == 400
         assert h.body.get("error") == "Empty request body", (
             f"an empty body must keep its own reason, not be absorbed by the "

--- a/skills/schliff/tests/unit/test_playground_score.py
+++ b/skills/schliff/tests/unit/test_playground_score.py
@@ -40,3 +40,110 @@ def test_json_parse_except_catches_recursionerror(path):
         assert "RecursionError" in ln, (
             f"{path.name} parse except must catch RecursionError (PG-1): {ln.strip()}"
         )
+
+
+class TestContentLengthGuard:
+    """A negative Content-Length must not turn the byte cap into an unbounded read.
+
+    `read_len = min(content_length, MAX_CONTENT_SIZE)` is -1 when the header is -1, and
+    `rfile.read(-1)` reads to EOF — so the declared cap is bypassed entirely. The
+    leaderboard's `submit.py` has the `< 0` guard; the playground's `score.py` did not.
+
+    Driven through `do_POST` with an instrumented `rfile`, not asserted against the source
+    text: the guard is a behaviour, and this file's other tests read the source only because
+    they pin an `except` clause, which has no observable behaviour to drive.
+    """
+
+    @staticmethod
+    def _handler_class():
+        import importlib.util
+        import sys
+        sys.path.insert(0, str(_ROOT))
+        spec = importlib.util.spec_from_file_location("_pg_score", _SCORE_PY)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _drive(self, content_length: str, body: bytes):
+        import io
+        mod = self._handler_class()
+
+        class RecordingBytesIO(io.BytesIO):
+            def __init__(self, data):
+                super().__init__(data)
+                self.reads: list = []
+
+            def read(self, n=-1):
+                data = super().read(n)
+                self.reads.append((n, len(data)))
+                return data
+
+        class H(mod.handler):
+            def __init__(self):
+                self.headers = {"Content-Length": content_length}
+                self.rfile = RecordingBytesIO(body)
+                self.wfile = io.BytesIO()
+                self.status = None
+
+            def send_response(self, status):
+                self.status = status
+
+            def send_header(self, *a):
+                pass
+
+            def end_headers(self):
+                pass
+
+        h = H()
+        h.do_POST()
+        h.body = json.loads(h.wfile.getvalue().decode("utf-8")) if h.wfile.getvalue() else {}
+        return h, mod.MAX_CONTENT_SIZE
+
+    # A body far past the cap, so an unbounded read is unmistakable.
+    BODY = json.dumps({"content": "x" * 64, "filename": "SKILL.md"}).encode() + b"\n" + b"P" * (3 * 1024 * 1024)
+
+    def test_negative_content_length_does_not_bypass_the_cap(self):
+        h, cap = self._drive("-1", self.BODY)
+        requested, returned = h.rfile.reads[0] if h.rfile.reads else (None, 0)
+        assert returned <= cap, (
+            f"Content-Length: -1 read {returned:,} bytes past the {cap:,}-byte cap "
+            f"(rfile.read({requested}) reads to EOF)"
+        )
+
+    def test_negative_content_length_is_reported_as_an_invalid_header(self):
+        """Discriminating on the REASON, not just the status.
+
+        Before the guard this already returned 400 — from the truncated-JSON branch, not
+        from any Content-Length check. Asserting the status alone would have passed on the
+        unfixed code, so it asserts the error string that only the guard produces.
+        """
+        h, _ = self._drive("-1", self.BODY)
+        assert h.status == 400, f"expected 400 for an invalid Content-Length, got {h.status}"
+        assert h.body.get("error") == "Invalid Content-Length header", (
+            f"400 came from the wrong branch: {h.body!r}. A negative Content-Length must be "
+            f"rejected as an invalid header, not incidentally as unparseable JSON."
+        )
+
+    def test_honest_oversize_still_gets_413(self):
+        h, _ = self._drive(str(3 * 1024 * 1024), self.BODY)
+        assert h.status == 413, f"expected 413 for an honest oversize, got {h.status}"
+
+    def test_lying_small_content_length_still_reads_only_what_it_declared(self):
+        h, _ = self._drive("10", self.BODY)
+        requested, returned = h.rfile.reads[0]
+        assert returned == 10, f"read {returned} bytes for a declared 10"
+        assert h.status == 400  # truncated JSON
+
+    def test_zero_content_length_still_rejected_as_an_empty_body(self):
+        """Also discriminating on the reason, for the opposite direction.
+
+        An over-broad guard (`<= 0` instead of `< 0`) keeps every status identical and only
+        changes which message an empty body gets — invisible to a status-only assertion.
+        Found by mutation, like every other instance of this on the branch.
+        """
+        h, _ = self._drive("0", b"")
+        assert h.status == 400
+        assert h.body.get("error") == "Empty request body", (
+            f"an empty body must keep its own reason, not be absorbed by the "
+            f"Content-Length guard: {h.body!r}"
+        )


### PR DESCRIPTION
**3 of 4 in a stack.** Base is #163. Review only the diff shown here.

⚠️ **This one needs a deploy to take effect** — `vercel --cwd playground deploy --prod`
after merge. Until then the fix is in the repo and not in production.

## The defect

`read_len = min(content_length, MAX_CONTENT_SIZE)` evaluates to `-1` when the header is
`-1`, and `rfile.read(-1)` reads to EOF — so the cap that line's own comment promises
("Read at most MAX_CONTENT_SIZE bytes regardless of the declared Content-Length") did not
hold.

Measured by driving `do_POST` with an instrumented socket:

```
honest 3MB    Content-Length=3145728  status=413  read(None) ->         0 bytes
lying small   Content-Length=     10  status=400  read(10)   ->        10 bytes
NEGATIVE -1   Content-Length=     -1  status=400  read(-1)   -> 3,145,832 bytes  <== CAP BYPASSED
```

`web/leaderboard/api/submit.py` already had the `< 0` half of its guard; this endpoint did
not. Now rejected as `400 Invalid Content-Length header` — the same reason the endpoint
already gives for an unparseable one, rather than folding a negative length into the 413
branch.

## Honest scope

Bounded in practice by Vercel's own body limit, and **whether the edge forwards a negative
`Content-Length` at all is unverified** — establishing that would mean probing production.
This is defence in depth plus a fixed asymmetry between two sibling endpoints, not a
demonstrated live exploit. Stated the same way in the spec and CHANGELOG.

## F7 declined, with the measurement

`badge.py` reads only `repo`; other query parameters are ignored by the handler but are part
of the CDN cache key, so `?repo=o/n&x=N` mints unlimited distinct keys that each re-run the
scorer. The proposed fix was to reject unknown parameters. **Declined**, because the severity
was derived from #162:

| payload at the 32 KB cap | before #162 | after |
| --- | --- | --- |
| benign | — | 87.9 ms |
| the 4.75 s shape | 4,750 ms | 122.7 ms |
| the 162 s shape | 162,600 ms | 96.0 ms |

120 ms per request is ordinary request cost, not amplification — and the marginal harm over
"attacker enumerates real public repos" is about zero, since the CDN cache only ever
protected a *single* repo key. Changing public behaviour so a URL with a stray parameter
returns a grey badge is not worth that. Recorded as D10 so the decline is auditable; revisit
only if #162's bound is relaxed. F6 stays declined on the same grounds (D8).

## Tests

Driven through `do_POST`, not grepped from the source — this file's older tests read source
text only because they pin an `except` clause, which has no behaviour to drive. Each asserts
the **reason**, not just the status, and that mattered twice:

- Before the guard, a negative length already returned 400 from the truncated-JSON branch. A
  status-only assertion would have passed on the unfixed code.
- An over-broad `<= 0` guard keeps every status identical and only steals the empty-body
  message. My first version of that test asserted the status alone and stayed green under
  exactly that mutation.

Four mutations caught: guard removed (2 red), guard on the wrong branch (1), guard over-broad
(1), guard moved below the read (1).

Review also found the test harness inserting the repo root into `sys.path` on every call
without cleanup — five duplicates in a process-global after five calls. Now
`monkeypatch.syspath_prepend`; verified with a session-finish probe, one entry after the
suite instead of five.

## Gates run

1923 pytest · test-self 21/0 · integration 100/0 · proof 6/0 · ruff clean · markdownlint
0/67 · 0 dangling.

Spec: `docs/specs/2026-07-30-redos-audit-fixes.md` (D9, D10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
