### PR TITLE
chore(release): v8.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.8.2",
+  "version": "8.9.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.9.0] - 2026-07-30
+
 ### Security
 
 - **Five scoring regexes were quadratic on untrusted input; the worst cost 162 seconds
@@ -1212,6 +1214,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
 [Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.2...HEAD
+[8.9.0]: https://github.com/Zandereins/schliff/compare/v8.8.2...v8.9.0
 [8.8.2]: https://github.com/Zandereins/schliff/compare/v8.8.1...v8.8.2
 [8.8.1]: https://github.com/Zandereins/schliff/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Zandereins/schliff/compare/v8.7.0...v8.8.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.8.2)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.9.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -33,7 +33,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.8.2
+schliff v8.9.0
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -49,7 +49,7 @@ schliff v8.8.2
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.8.2` (`pip install schliff==8.8.2` or `uvx schliff@8.8.2`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.9.0` (`pip install schliff==8.9.0` or `uvx schliff@8.9.0`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -242,7 +242,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.8.2'` in the
+lead an older pinned install; pin it with `schliff-version: '8.9.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -278,7 +278,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.8.2
+    rev: v8.9.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.8.2.**
+**Current version: 8.9.0.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.8.2"
+version = "8.9.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.8.2"
+__version__ = "8.9.0"


### PR DESCRIPTION
Ships the four audit follow-ups merged as #162–#165.

| PR | Fix |
| --- | --- |
| #162 | Five quadratic scoring regexes bounded; two regression gates added |
| #163 | `manifest`'s frontmatter parse and the unbounded read behind it |
| #164 | Playground's negative-`Content-Length` cap bypass |
| #165 | `run-eval.sh`'s timeout guard announces when it is inactive |

**Minor, not patch.** No public score moves, but the runtime behaviour of a gate changes — a
build that used to hang now completes — and the GitHub Action installs `schliff` latest,
which is the fork-PR path carrying the worst blast radius.

## Version surfaces

Three lockstep sources (`pyproject.toml`, `.claude-plugin/plugin.json`,
`skills/schliff/__init__.py`), gated by `test_version_consistency`. Eight secondary
references in `README.md` / `docs/README.md`, including the `&v=` badge cache-bust and the
pre-commit `rev`.

The **playground pin is deliberately not bumped here** — it follows in its own PR once PyPI
has resolved, so `uv.lock` can be relocked against a version that exists.

## Reproducibility re-measured before the bump

The README now claims these reproduce from `schliff==8.9.0`, so every one was re-measured
against this branch rather than assumed:

| claim | measured |
| --- | --- |
| hero AGENTS.md | **95.6**, 1,065 tokens |
| shieldclaw, isolated | **28.7** (4/7 dims) |
| shieldclaw, with eval suite | **84.5** |
| shieldclaw, after fixes | **94.6** |

None moved.

## Gates

1927 pytest · test-self 21/0 · integration 100/0 · proof 6/0 · ruff clean · markdownlint
0/67 · 0 dangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)