### PR TITLE
fix(scoring): --format system-prompt dropped the security dimension

### DIFF
--- a/docs/specs/2026-07-31-format-alias-drops-security.md
+++ b/docs/specs/2026-07-31-format-alias-drops-security.md
@@ -7,8 +7,8 @@
 The same file scores differently depending on whether its format is *detected* or *stated*:
 
 ```
-$ schliff score fp.txt --json                         → composite 49.4 · 7 dims · security 100
-$ schliff score fp.txt --format system-prompt --json  → composite 36.8 · 6 dims · security absent
+schliff score fp.txt --json                         → composite 49.4 · 7 dims · security 100
+schliff score fp.txt --format system-prompt --json  → composite 36.8 · 6 dims · security absent
 ```
 
 Measured spread across five files: **5.9 to 15.0 composite points**. The user who pins the

--- a/docs/specs/2026-07-31-format-alias-drops-security.md
+++ b/docs/specs/2026-07-31-format-alias-drops-security.md
@@ -1,0 +1,81 @@
+# `--format system-prompt` silently drops the security dimension
+
+**Status:** fixed · **Branch:** `fix/format-alias-drops-security` · **Found:** 2026-07-31, on shipped v8.9.0
+
+## Symptom
+
+The same file scores differently depending on whether its format is *detected* or *stated*:
+
+```
+$ schliff score fp.txt --json                         → composite 49.4 · 7 dims · security 100
+$ schliff score fp.txt --format system-prompt --json  → composite 36.8 · 6 dims · security absent
+```
+
+Measured spread across five files: **5.9 to 15.0 composite points**. The user who pins the
+format explicitly — the more careful thing to do in CI — gets the wrong number.
+
+## Cause
+
+`--format` accepts aliases (`registry.FORMAT_ALIASES`), including `system-prompt` → `system_prompt`.
+Every *lookup* in `registry.py` resolved them; the *branch* in `shared.build_scores` did not:
+
+```python
+if fmt == "system_prompt":      # raw compare — False for "system-prompt"
+```
+
+For the alias the compare fails, the dedicated early return is skipped, and the file falls through
+to the instruction-file branch — where `if dim == "security" and not include_security: continue`
+removes the dimension. For `system_prompt`, `security` is a **core headline dimension**
+(weight 0.15, `registry.HEADLINE_EXCLUDED` excludes only `runtime`), so the composite moves.
+
+`system-prompt` is the only affected alias, because `system_prompt` is the only format with a
+dedicated branch. `skill`/`claude`/`cursor`/`agents` all reach the generic branch, where
+`get_scorers()` resolves them correctly — verified, not assumed (60-cell matrix below).
+
+## Fix
+
+`registry.resolve_format()` becomes the single canonicalizer (the four inline
+`FORMAT_ALIASES.get(fmt, fmt)` copies now call it — that duplication is what let one caller forget).
+`shared.build_scores` dispatches on the resolved name:
+
+```python
+if resolve_format(fmt) == "system_prompt":
+```
+
+**Deliberately NOT canonicalizing `fmt` itself.** The second compare four lines down
+(`if fmt != "skill.md"`) drives normalization, and resolving `fmt` globally would flip it too:
+`--format skill` would stop being laundered through a `.md` temp file and its score would move
+(**measured: 30.8 → 26.1** on a `.txt`). That is a real inconsistency, but it is a different
+defect with different semantics, and it was not what the measurement accused. It is recorded
+below rather than smuggled into this fix.
+
+## Acceptance gate — two-sided
+
+Not "the new case works" alone; also "no already-correct score moved" (the one-sided gate is what
+let #149 through).
+
+| | Result |
+| --- | --- |
+| 5 files × 12 format values (incl. `None` and every alias), shipped 8.9.0 vs fixed | **55/60 byte-identical** |
+| The 5 that changed | all `--format system-prompt`, each now **equal to its canonical `system_prompt` twin** (71.9 = 71.9, 67.8 = 67.8) |
+| Unit tests | 3 new, red before / green after; **1930 passed** |
+| ruff 0.15.8 (CI pin) over `scripts/` | clean |
+
+The first run of this gate **caught the over-broad first draft** of the fix (the `--format skill`
+regression above) before it reached a commit. That is the gate doing its job, and the reason it is
+two-sided.
+
+## Left open — separate decisions, not fixed here
+
+1. **`--format skill` normalizes a file that needs no normalization**, routing it through a `.md`
+   temp file and shifting its score by ~4.7 points versus the un-normalized path. Which of the two
+   is *correct* is a semantics question, not a bug fix.
+2. **The reported format echoes the alias**, not its canonical name: `"format": "skill"` in JSON,
+   and `cli.py:288` prints `Format: skill (normalized)` for a plain SKILL.md — a false statement,
+   since nothing was normalized. Cosmetic; no score impact (measured).
+
+## Reachability note
+
+This lands on the path F3 identified in the 2026-07-30 audit: `security` is dead for the skill.md
+family and **live and load-bearing for `system_prompt`**. The deletion-list entry for `security.py`
+must stay split — fix candidate here, deletion candidate there.

--- a/skills/schliff/scripts/scoring/registry.py
+++ b/skills/schliff/scripts/scoring/registry.py
@@ -98,13 +98,25 @@ HEADLINE_EXCLUDED: dict[str, frozenset] = {
 }
 
 
+def resolve_format(fmt: str) -> str:
+    """Canonicalize a format name, mapping any `--format` alias to its real name.
+
+    Every lookup below resolves aliases individually. Callers that BRANCH on the
+    format string must resolve it first — a raw `fmt == "system_prompt"` compare
+    silently takes the wrong path for the public `system-prompt` alias, which is
+    how `security` (a core system_prompt dimension) went missing from an explicitly
+    formatted score while detection kept it. Unknown names pass through unchanged
+    so the existing per-format fallbacks still apply.
+    """
+    return FORMAT_ALIASES.get(fmt, fmt)
+
+
 def get_headline_excluded(fmt: str) -> frozenset:
     """Return the dims excluded from the headline composite for a format (resolves aliases).
 
     Falls back to the instruction-file exclusion set for unknown formats.
     """
-    resolved = FORMAT_ALIASES.get(fmt, fmt)
-    return HEADLINE_EXCLUDED.get(resolved, _HEADLINE_EXCLUDED_INSTRUCTION)
+    return HEADLINE_EXCLUDED.get(resolve_format(fmt), _HEADLINE_EXCLUDED_INSTRUCTION)
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +128,7 @@ def get_scorers(fmt: str) -> list[str]:
 
     Falls back to skill.md scorers for unknown formats.
     """
-    resolved = FORMAT_ALIASES.get(fmt, fmt)
-    return list(SCORER_REGISTRY.get(resolved, SCORER_REGISTRY["skill.md"]))
+    return list(SCORER_REGISTRY.get(resolve_format(fmt), SCORER_REGISTRY["skill.md"]))
 
 
 def get_weights(fmt: str) -> dict[str, float]:
@@ -125,8 +136,7 @@ def get_weights(fmt: str) -> dict[str, float]:
 
     Falls back to skill.md weights for unknown formats (forward compat).
     """
-    resolved = FORMAT_ALIASES.get(fmt, fmt)
-    return dict(WEIGHT_PROFILES.get(resolved, WEIGHT_PROFILES["skill.md"]))
+    return dict(WEIGHT_PROFILES.get(resolve_format(fmt), WEIGHT_PROFILES["skill.md"]))
 
 
 def get_all_formats() -> list[str]:

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -204,13 +204,22 @@ def build_scores(skill_path: str, eval_suite: Optional[dict] = None,
     import tempfile
 
     from scoring.formats import detect_format, normalize_content
-    from scoring.registry import get_scorers
+    from scoring.registry import get_scorers, resolve_format
 
     if fmt is None:
         fmt = detect_format(skill_path)
 
+    # DISPATCH on the canonical name, NORMALIZE on the raw one. `fmt` may be a
+    # public `--format` alias (`system-prompt`, `skill`, ...) and both compares
+    # below are raw string compares, but only this one may be widened: resolving
+    # `fmt` itself would also flip the `!= "skill.md"` compare underneath, so
+    # `--format skill` would stop being normalized through a temp file and its
+    # score would move (measured: 30.8 -> 26.1 on a .txt). That normalization
+    # asymmetry is a separate, unaccused defect — see the branch note in the spec.
+    # detect_format already returns canonical names, so this is a no-op on the
+    # detected path.
     # System prompts: no normalization, no temp file, dedicated scorer set
-    if fmt == "system_prompt":
+    if resolve_format(fmt) == "system_prompt":
         scores = {}
         for dim in get_scorers("system_prompt"):
             scores[dim] = _call_scorer(dim, skill_path, None)

--- a/skills/schliff/tests/unit/test_system_prompt_scoring.py
+++ b/skills/schliff/tests/unit/test_system_prompt_scoring.py
@@ -830,3 +830,47 @@ class TestAntiGaming:
             assert result["score"] <= 60
         finally:
             os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Format alias must not change the scored dimension set
+# ---------------------------------------------------------------------------
+
+class TestFormatAliasDoesNotDropSecurity:
+    """`--format system-prompt` must score the same dimensions as detection.
+
+    `shared.build_scores` branches on a RAW string compare (`fmt == "system_prompt"`).
+    The public `--format` flag also accepts the hyphenated alias `system-prompt`
+    (`registry.FORMAT_ALIASES`), which fails that compare, falls through to the
+    instruction-file branch, and there loses `security` to the `include_security`
+    gate — even though `security` is a CORE headline dimension for system_prompt
+    (weight 0.15, `registry.HEADLINE_EXCLUDED`). Measured on the shipped 8.9.0:
+    the same file scored 49.4 detected vs 36.8 with the alias.
+    """
+
+    def test_alias_scores_the_same_dimensions_as_canonical(self):
+        from shared import build_scores
+        path = _fixture_path("good_api_assistant.txt")
+        canonical = build_scores(path, fmt="system_prompt")
+        aliased = build_scores(path, fmt="system-prompt")
+        assert set(aliased) == set(canonical), (
+            "the hyphenated alias scored a different dimension set: "
+            f"missing={set(canonical) - set(aliased)}, extra={set(aliased) - set(canonical)}"
+        )
+
+    def test_alias_keeps_the_core_security_dimension(self):
+        from shared import build_scores
+        path = _fixture_path("good_api_assistant.txt")
+        assert "security" in build_scores(path, fmt="system-prompt")
+
+    def test_alias_and_detection_agree_on_every_dimension_score(self):
+        """Not just the key set — the values must be identical too."""
+        from scoring.formats import detect_format
+        from shared import build_scores
+        path = _fixture_path("good_api_assistant.txt")
+        assert detect_format(path) == "system_prompt"
+        detected = build_scores(path)
+        aliased = build_scores(path, fmt="system-prompt")
+        assert {k: v["score"] for k, v in aliased.items()} == {
+            k: v["score"] for k, v in detected.items()
+        }


### PR DESCRIPTION
`--format` accepts aliases, but `shared.build_scores` dispatched on a raw string
compare (`fmt == "system_prompt"`). The public `system-prompt` alias failed it,
skipped the dedicated early return, and fell through to the instruction-file
branch — where the `include_security` gate removed a dimension that is CORE for
system_prompt (weight 0.15, `registry.HEADLINE_EXCLUDED` excludes only `runtime`).

Same file, same version:

```
score fp.txt --json                        → composite 49.4 · 7 dims · security 100
score fp.txt --format system-prompt --json → composite 36.8 · 6 dims · security absent
```

Spread across five files: **5.9 to 15.0 composite points**. The user who pins the
format explicitly — the more careful thing to do in CI — gets the wrong number.

`system-prompt` is the only affected alias, because `system_prompt` is the only
format with a dedicated branch. Verified against a 60-cell matrix, not assumed.

## Fix

`registry.resolve_format()` becomes the single canonicalizer; the four inline
`FORMAT_ALIASES.get(fmt, fmt)` copies now call it — that duplication is why one
caller could forget it. Dispatch resolves the alias.

`fmt` itself is deliberately NOT canonicalized: the normalization compare four
lines down (`fmt != "skill.md"`) would flip too, and `--format skill` would stop
being routed through a temp file (**measured 30.8 → 26.1**). Separate defect with
different semantics, recorded in the spec rather than smuggled in here.

## Two-sided acceptance gate

| | Result |
| --- | --- |
| 5 files × 12 format values (incl. `None` and every alias), 8.9.0 vs this branch | **55/60 byte-identical** |
| The 5 that changed | all `--format system-prompt`, each now **equal to its canonical twin** (71.9 = 71.9, 67.8 = 67.8) |
| Unit tests | 3 new, red before / green after; **1930 passed** |
| ruff 0.15.8 (CI pin) over `scripts/` | clean |

The first run of this gate **caught an over-broad first draft** of the fix (the
`--format skill` regression above) before it reached a commit.

Spec: `docs/specs/2026-07-31-format-alias-drops-security.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)