### PR TITLE
fix(doctor): a named directory that does not exist is now an error

### DIFF
--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -420,6 +420,21 @@ def cmd_doctor(args: argparse.Namespace) -> None:
               "not both", file=sys.stderr)
         raise SystemExit(2)
 
+    # A directory the user NAMED must exist; the built-in defaults must not be
+    # validated, because `.claude/skills` legitimately does not exist in most
+    # repos and the no-arg scan is the common invocation. Without this, a typo'd
+    # path renders as "No skills found" + exit 0 — indistinguishable from an
+    # empty directory, so no CI gate can catch it — and the report then lists the
+    # default dirs it did not scan. `verify` already errors on a missing file.
+    named = flagged or positional
+    if named:
+        bad = [d for d in named if not os.path.isdir(d)]
+        if bad:
+            for d in bad:
+                kind = "not a directory" if os.path.exists(d) else "no such directory"
+                print(f"schliff doctor: {kind}: {d}", file=sys.stderr)
+            raise SystemExit(2)
+
     report = doctor_mod.run_doctor(
         skill_dirs=flagged or positional,
         verbose=verbose,

--- a/skills/schliff/tests/unit/test_doctor_positional_dirs.py
+++ b/skills/schliff/tests/unit/test_doctor_positional_dirs.py
@@ -60,3 +60,51 @@ def test_both_forms_at_once_is_refused(skill_dir: Path):
 def test_bare_doctor_still_scans_installed_skills():
     """No argument keeps its original meaning."""
     assert _run().returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# A directory the user NAMED must exist. Defaults must stay optional.
+# ---------------------------------------------------------------------------
+
+def test_missing_named_dir_is_an_error():
+    """A typo'd path currently reports "No skills found" and exits 0.
+
+    Indistinguishable from an empty directory, so a CI gate cannot catch the
+    typo — and the report then lists the DEFAULT scan dirs it did not use.
+    `verify` already errors on a missing file; `doctor` must not disagree.
+    """
+    proc = _run("/nope/definitely/not/here")
+    assert proc.returncode != 0, (
+        "a non-existent directory exited 0 — a typo is silently a clean run"
+    )
+    assert "not/here" in (proc.stderr + proc.stdout)
+
+
+def test_named_path_that_is_a_file_is_an_error(tmp_path: Path):
+    proc = _run(str(tmp_path / "notadir.md"))
+    assert proc.returncode != 0
+
+
+def test_existing_file_passed_as_dir_is_an_error(tmp_path: Path):
+    f = tmp_path / "SKILL.md"
+    f.write_text("# hi\n", encoding="utf-8")
+    proc = _run(str(f))
+    assert proc.returncode != 0, "a regular file was accepted as a scan directory"
+
+
+def test_flag_form_is_validated_too(tmp_path: Path):
+    proc = _run("--skill-dirs", str(tmp_path / "gone"))
+    assert proc.returncode != 0
+
+
+def test_default_dirs_are_NOT_validated():
+    """Counter-test — the half that must not change.
+
+    With no argument, doctor scans built-in defaults; `.claude/skills` legitimately
+    does not exist in most repos. Validating those would break the no-arg case,
+    which is the most common invocation.
+    """
+    proc = _run()
+    assert proc.returncode == 0, (
+        f"no-arg doctor regressed to exit {proc.returncode}: {proc.stderr.strip()[:300]}"
+    )


### PR DESCRIPTION
`schliff doctor /typo/d/path` rendered "No skills found. Check skill directories."
and exited 0 — indistinguishable from an empty directory, so no CI gate could
catch the typo. The report then listed the DEFAULT scan dirs, which it had not
scanned, as if they were the ones that came up empty. `verify` already errors on
a missing file (`Error: file not found`); doctor disagreed with it.

A silent exit-0 on a bad path is a false-green: in a CI step it reports success
for work that never ran.

## Scope

Validation sits at the **CLI boundary**, not in `run_doctor()`, so library callers
are untouched. Only paths the user NAMED are checked — the built-in defaults stay
optional, because `.claude/skills` legitimately does not exist in most repos and
the no-arg scan is the common invocation. A path that exists but is a regular
file is rejected too; it previously scanned to zero in silence.

## Gate

Counter-test included and green **before and after**: no-arg doctor still exits 0.
That is the half that must not change.

End-to-end through the CLI:

```
doctor <typo>                  exit=2  schliff doctor: no such directory: /nope/not/here
doctor <file, not a dir>       exit=2  schliff doctor: not a directory: ../SKILL.md
doctor --skill-dirs <gone>     exit=2  schliff doctor: no such directory: /nope/gone
doctor <real dir>              exit=0  7 skills scanned
doctor            (no args)    exit=0  2 skills scanned
```

**1932 tests pass**, ruff 0.15.8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)