### PR TITLE
chore: ignore llm-council session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ uv.lock
 
 # Playwright MCP session artifacts
 .playwright-mcp/
+
+# LLM-council session artifacts (verdict + full transcript). These carry
+# adoption numbers, private decision context and advisor reasoning — they are
+# working notes, not repo content.
+council-report-*.html
+council-transcript-*.md


### PR DESCRIPTION
The council writes `council-report-*.html` and `council-transcript-*.md` into the
repo root. They carry adoption numbers, private decision context and advisor
reasoning — working notes, not repo content. Keep them out of history by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)