### PR TITLE
fix(cli): report the version of the loaded code, not the installed dist

### DIFF
--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -38,19 +38,34 @@ _PATH_HELP = "Path to instruction file (SKILL.md/CLAUDE.md/AGENTS.md/.cursorrule
 def _resolve_version() -> str:
     """Single source of truth for the runtime version string.
 
-    Reads from installed package metadata (importlib.metadata) so the CLI,
-    the score-display header, and the --version flag can never drift from
-    pyproject.toml. Falls back to "dev" when the package is not installed
-    (e.g. running cli.py straight from a source checkout).
+    Reads `__version__` from the package `__init__.py` next to this module, so the
+    reported version always describes the code that is actually loaded. That
+    constant is gated against pyproject.toml and .claude-plugin/plugin.json by
+    test_version_consistency.py, so it cannot drift from the release either.
+
+    Deliberately NOT importlib.metadata: that reads the *installed* dist-info,
+    which in a source or editable checkout describes a different — often older —
+    copy of schliff than the one executing. This value is stamped into the score
+    JSON (see cmd_score) and propagates into benchmark JSONL and leaderboard
+    entries, so a stale read misattributes measurements to an engine version that
+    never produced them. Resolving by path rather than by import also keeps the
+    answer independent of how the CLI was invoked (console script, -m, or
+    straight from a checkout), which sys.path-based lookups are not.
+
+    Falls back to "dev" when the constant cannot be read.
     """
+    import re
+
+    init_path = os.path.join(os.path.dirname(_SCRIPTS_DIR), "__init__.py")
     try:
-        from importlib.metadata import PackageNotFoundError, version
-        try:
-            return version("schliff")
-        except PackageNotFoundError:
-            return "dev"
-    except ImportError:  # importlib.metadata absent (pathological env)
-        return "dev"
+        with open(init_path, encoding="utf-8") as handle:
+            for line in handle:
+                match = re.match(r"""^__version__\s*=\s*["']([^"']+)["']""", line)
+                if match:
+                    return match.group(1)
+    except OSError:
+        pass
+    return "dev"
 
 
 def _ensure_skill_path_exists(skill_path: str, exit_code: int = 1) -> None:

--- a/skills/schliff/tests/unit/test_version_consistency.py
+++ b/skills/schliff/tests/unit/test_version_consistency.py
@@ -22,8 +22,33 @@ def _package_version() -> str:
     return schliff.__version__
 
 
+def _cli_reported_version() -> str:
+    import cli  # scripts/ is on sys.path via conftest
+    return cli._resolve_version()
+
+
 def test_all_versions_match():
     assert _pyproject_version() == _plugin_version() == _package_version(), (
         f"version drift: pyproject={_pyproject_version()} "
         f"plugin={_plugin_version()} package={_package_version()}"
     )
+
+
+def test_reported_version_describes_the_loaded_code_not_the_installed_dist(monkeypatch):
+    """The version stamped into a score must describe the engine that produced it.
+
+    `_resolve_version()` used to read `importlib.metadata`, i.e. the *installed*
+    dist-info. In a source or editable checkout that describes a different — often
+    older — copy of schliff than the one actually executing, and the value is not
+    cosmetic: `cli.py` stamps it into the score JSON, so it propagates into
+    benchmark JSONL and leaderboard entries, attributing measurements to an engine
+    version that never produced them.
+
+    The stale metadata is injected here rather than assumed, so this discriminates
+    in CI too — where the installed dist legitimately matches the tree and a plain
+    equality check would pass either way.
+    """
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.0.1-stale")
+    assert _cli_reported_version() == _package_version()


### PR DESCRIPTION
## Problem

`_resolve_version()` read `importlib.metadata.version("schliff")` — the **installed** dist-info — while its docstring promised the value "can never drift from pyproject.toml". In a source or editable checkout those are different things, and the docstring was part of the defect.

Measured on this repo before the fix:

| Source | Value |
|---|---|
| `pyproject.toml`, `plugin.json`, `__init__.py` | 8.9.0 |
| `schliff version` | **8.1.0** |
| module the venv console script actually loads | `/Users/franzpaul/schliff/skills/schliff/__init__.py` |

The venv is an editable install, so it was executing 8.9.0 code while reporting a stale 8.1.0 dist-info left over from an earlier install.

**Not cosmetic:** `cmd_score` stamps this value into the score JSON as `version`, so it propagates into benchmark JSONL and leaderboard entries — attributing measurements to an engine version that never produced them. Blast radius is bounded to source/editable installs; a `pip install schliff` user's metadata matches their code.

## Fix

Read `__version__` from the package `__init__.py` next to the module. That constant is already gated against `pyproject.toml` and `.claude-plugin/plugin.json` by `test_version_consistency.py`, so it cannot drift from the release either. Resolving by path rather than by import keeps the answer independent of how the CLI was invoked (console script, `-m`, or straight from a checkout) — which sys.path-based lookups are not. The `"dev"` fallback is retained for an unreadable constant.

## Verification

The test injects stale metadata rather than assuming it, so it discriminates in CI too — where the installed dist legitimately matches the tree and a plain equality assertion would pass with or without the fix.

- Red before the fix: `AssertionError: assert '0.0.1-stale' == '8.9.0'`
- Green after; `schliff version` and the JSON `version` field both report 8.9.0
- 1936 tests pass (1935 + the new one), `ruff==0.15.8` clean

No score value changes.