### PR TITLE
fix(scoring): --format skill scored differently than --format skill.md

### DIFF
--- a/docs/specs/2026-08-04-format-alias-normalization-asymmetry.md
+++ b/docs/specs/2026-08-04-format-alias-normalization-asymmetry.md
@@ -1,0 +1,135 @@
+# `--format skill` and `--format skill.md` score the same file differently
+
+**Status:** fixed · **Branch:** `fix/format-alias-normalization` · **Found:** 2026-08-04, on `main` at 8cb3158
+
+Closes the two items [2026-07-31](2026-07-31-format-alias-drops-security.md) left open. They are
+not two semantics questions — they are the last two branch sites of the defect #168 fixed at the
+first one.
+
+## Symptom
+
+Two spellings of the same `--format` value disagree:
+
+```
+schliff score AGENTS.md --format skill     → composite 39.3
+schliff score AGENTS.md --format skill.md  → composite 34.5
+```
+
+Across the 29 tracked instruction files in this repo, **exactly the 8 that have no YAML
+frontmatter** diverge, by **4.7 to 5.5 composite points**:
+
+| File | `--format skill` | `--format skill.md` | Δ |
+| --- | --- | --- | --- |
+| `AGENTS.md` | 39.3 | 34.5 | 4.8 |
+| `benchmarks/corpus/v1/phase0-snapshot/09-algorithms.SKILL.md` | 23.7 | 18.2 | 5.5 |
+| `benchmarks/corpus/v1/phase0-snapshot/10-GAP-Design-System.SKILL.md` | 22.1 | 17.4 | 4.7 |
+| `demo/sample-cursorrules/.cursorrules` | 29.7 | 25.0 | 4.7 |
+| `demo/sync-conflict/.cursorrules` | 29.7 | 25.0 | 4.7 |
+| `demo/sync-conflict/CLAUDE.md` | 29.7 | 25.0 | 4.7 |
+| `skills/schliff/tests/fixtures/dangling-repo/AGENTS.md` | 29.6 | 24.8 | 4.8 |
+| `skills/schliff/tests/proof/bad-skill.md` | 20.7 | 16.0 | 4.7 |
+
+Two of those are real files in the project's own benchmark corpus, so this is not a synthetic
+edge case. `skill`/`skill.md` is the **only** alias pair that diverges — `claude`/`claude.md`,
+`cursor`/`cursorrules`, `agents`/`agents.md` and `system-prompt`/`system_prompt` are byte-identical
+across all 29 files (measured, not reasoned: #168 closed the last of those).
+
+A second, non-scoring symptom: a genuine SKILL.md **with** frontmatter, scored with `--format skill`,
+prints
+
+```
+  Format: skill (normalized)
+```
+
+Both halves are false. `skill` is not the format's name, and nothing was normalized — for content
+that already has frontmatter `normalize_content` returns it unchanged.
+
+## Cause
+
+Three raw string compares branch on a value that may be a public `--format` alias:
+
+| Site | Compare | Consequence |
+| --- | --- | --- |
+| `shared.py:230` | `fmt != "skill.md"` | the alias enters the normalization branch its canonical twin skips |
+| `formats.py:77` | `fmt == FORMAT_SKILL_MD` | the inner early return misses the alias too, so wrapping proceeds |
+| `cli.py:288` | `detected_fmt != "skill.md"` | display name and the "(normalized)" claim |
+
+For a file without frontmatter the normalization branch invents synthetic frontmatter
+(`_extract_name` / `_extract_description` from the body) and scores the wrapped copy. The structure
+dimension then sees a name and a description that the file does not have — worth the 4.7–5.5 points.
+For a file that already has frontmatter the branch is a no-op on content, which is why only 8 of 29
+files move.
+
+`resolve_format()` was introduced by #168 and every *lookup* in `registry.py` uses it. These three
+are *branches*, and the docstring of `resolve_format` already warns that branches must resolve
+first. #168 fixed one of four; these are the remaining three.
+
+## Decision: converge on NOT normalizing
+
+The two spellings must agree — that is not a judgment call for a deterministic scorer. Which side
+they agree on is, and it is the un-normalized one (the lower number):
+
+- Normalization exists so formats that *legitimately* carry no frontmatter (CLAUDE.md, AGENTS.md,
+  `.cursorrules`) are scorable at all. A SKILL.md is **defined** by its frontmatter.
+- Inventing a name and description for a SKILL.md that lacks them hides exactly the structural
+  defect the structure dimension exists to report. 39.3 is the flattered number; 34.5 is the
+  measurement.
+- Auto-detection is not the tie-breaker some might expect: a frontmatter-less `.txt` detects as
+  `unknown`, not `skill.md`, so AUTO normalizes because of the *detected* format. Nothing about the
+  detected path argues for laundering a stated `skill.md`.
+
+So `--format skill` drops to its canonical twin's score. **This lowers scores** for the stated-format
+path on files without frontmatter, which is why it ships as a minor, not a patch.
+
+## Fix
+
+Canonicalize once at the top of `build_scores`, then branch only on the canonical name — `fmt`
+carries a canonical value from that line down, so both compares underneath are correct without
+being touched individually. `normalize_content` receives the canonical name and its own early
+return starts working. `detect_format` already returns canonical names, so the detected path — and
+with it the playground, which only ever calls `detect_format` — is a strict no-op.
+
+`cli.py` resolves `detected_fmt` for display and for the JSON `format` field, which fixes the name
+and retires the false "(normalized)" line in one move: once `--format skill` resolves to `skill.md`,
+the `!= "skill.md"` guard is correctly False and prints nothing.
+
+The JSON `format` field now reports canonical names for every alias (`--format claude` reports
+`claude.md`). No consumer breaks: the leaderboard validates against its own display vocabulary
+(`VALID_FORMATS = {"SKILL.md", ".cursorrules", "CLAUDE.md", "AGENTS.md"}`), which never accepted
+engine names in the first place, and the playground emits `detect_format()` output.
+
+## Acceptance gate — two-sided
+
+Same shape as #168's, widened from 60 cells to 348: **29 tracked instruction files × 12 format
+values** (`None`, the 10 registry/alias choices, and `unknown` — mirroring `cli.py:1067`, which
+appends it). Both the composite and every per-dimension score are compared.
+
+| | Result |
+| --- | --- |
+| 348 cells, `main` at 8cb3158 vs fixed | **340/348 byte-identical** |
+| The 8 that changed | all `--format skill` on a frontmatter-less file, each now **equal to its canonical `skill.md` twin** |
+| Cells that raise | 0 before, 0 after |
+| Unit tests | red before / green after |
+| ruff 0.15.8 (CI pin) over `scripts/` | clean |
+
+The 8 changed cells are exactly the set the symptom table accuses — no third cell moved. That is the
+property #149 lacked and the reason this gate is two-sided rather than "the new case works".
+
+## Reachability note
+
+A stated format reaches the engine from exactly one place: `cmd_score`
+(`getattr(args, "format")`, `cli.py:175`). `verify`, `badge`, `doctor`, `diff`, `compare`, `report`
+and `suggest` all call `detect_format` and cannot receive an alias — so **no CI gate can change
+verdict from this fix**, only an explicit `schliff score --format skill` on a file without
+frontmatter. `evolve --format` is free-form but routes through `text_gradient`, which resolves.
+
+## Left open
+
+Nothing from #168's list remains. `_resolve_version()` — the third item raised on 2026-08-04 —
+shipped separately in #172, since it shares no code with this.
+
+One inaccuracy in #168's write-up, recorded rather than fixed: it states the four inline
+`FORMAT_ALIASES.get(fmt, fmt)` copies were all replaced by `resolve_format()`. One survives, at
+`text_gradient.py:594`. It resolves correctly, so it is not a defect and is deliberately left
+untouched here — but it is the same duplication #168 named as the reason a caller could forget,
+so it is worth collapsing the next time that file is opened for a real change.

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -177,9 +177,15 @@ def cmd_score(args: argparse.Namespace) -> None:
         effective_fmt = fmt_override or url_fmt
         scores = build_scores(skill_path, eval_suite, include_runtime=True, fmt=effective_fmt)
 
-        # Determine the effective format for display
+        # Determine the effective format for display. Canonicalize a stated format:
+        # `--format` accepts aliases, and echoing the alias made the report state a
+        # name that is not the format's ("Format: skill") and, because the
+        # "(normalized)" guard below compares against the canonical name, claim a
+        # normalization that never happened. detect_format already returns canonical
+        # names, so this only affects the stated path.
         if effective_fmt:
-            detected_fmt = effective_fmt
+            from scoring.registry import resolve_format
+            detected_fmt = resolve_format(effective_fmt)
         else:
             from scoring.formats import detect_format
             detected_fmt = detect_format(skill_path)

--- a/skills/schliff/scripts/scoring/formats.py
+++ b/skills/schliff/scripts/scoring/formats.py
@@ -73,6 +73,11 @@ def normalize_content(content: str, fmt: str) -> str:
     If the content already has YAML frontmatter (starts with "---") or
     fmt is "skill.md", return content unchanged. Otherwise wrap the content
     in synthetic YAML frontmatter so the scoring engine can process it.
+
+    `fmt` must be a CANONICAL format name, not a `--format` alias: the early
+    return below is a raw compare, so passing "skill" instead of "skill.md"
+    wraps a SKILL.md in invented frontmatter and inflates its structure score.
+    `shared.build_scores` — the only production caller — resolves before calling.
     """
     if fmt == FORMAT_SKILL_MD:
         return content

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -209,17 +209,19 @@ def build_scores(skill_path: str, eval_suite: Optional[dict] = None,
     if fmt is None:
         fmt = detect_format(skill_path)
 
-    # DISPATCH on the canonical name, NORMALIZE on the raw one. `fmt` may be a
-    # public `--format` alias (`system-prompt`, `skill`, ...) and both compares
-    # below are raw string compares, but only this one may be widened: resolving
-    # `fmt` itself would also flip the `!= "skill.md"` compare underneath, so
-    # `--format skill` would stop being normalized through a temp file and its
-    # score would move (measured: 30.8 -> 26.1 on a .txt). That normalization
-    # asymmetry is a separate, unaccused defect — see the branch note in the spec.
-    # detect_format already returns canonical names, so this is a no-op on the
-    # detected path.
+    # Canonicalize ONCE, then branch only on the canonical name. `fmt` may be a
+    # public `--format` alias (`skill`, `system-prompt`, ...), and every branch
+    # below used to compare the raw string — so an alias took a different path
+    # than its canonical twin. That cost `system-prompt` the security dimension
+    # (#168) and sent `skill` through a normalization branch that `skill.md`
+    # skips, inventing synthetic frontmatter and inflating a frontmatter-less
+    # file by 4.7-5.5 composite points. `detect_format` already returns canonical
+    # names, so this is a strict no-op on the detected path — including the
+    # playground, which only ever passes detected formats.
+    fmt = resolve_format(fmt)
+
     # System prompts: no normalization, no temp file, dedicated scorer set
-    if resolve_format(fmt) == "system_prompt":
+    if fmt == "system_prompt":
         scores = {}
         for dim in get_scorers("system_prompt"):
             scores[dim] = _call_scorer(dim, skill_path, None)

--- a/skills/schliff/tests/unit/test_formats.py
+++ b/skills/schliff/tests/unit/test_formats.py
@@ -88,3 +88,78 @@ def test_format_alias_resolves_to_correct_token_budget():
             assert check_token_budget(content, alias)["budget"] != FORMAT_TOKEN_BUDGETS["unknown"]
     # unknown/garbage still falls back safely
     assert check_token_budget(content, "totally-bogus")["budget"] == FORMAT_TOKEN_BUDGETS["unknown"]
+
+
+# --- Alias and canonical name must score identically (2026-08-04) ---
+
+_NO_FRONTMATTER = """\
+# Deploy Helper
+
+Helps deploy things to production safely.
+
+## Usage
+
+Run the deploy command.
+
+## When to Use
+
+Use when deploying a service.
+"""
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def test_skill_alias_scores_identically_to_canonical_name(tmp_path):
+    """`--format skill` and `--format skill.md` must agree on a frontmatter-less file.
+
+    `shared.build_scores` branched on a RAW compare (`fmt != "skill.md"`). The public
+    `skill` alias failed it, entered the normalization branch its canonical twin skips,
+    and was scored as a copy wrapped in synthetic frontmatter that the file does not
+    have — inflating it by 4.7-5.5 composite points across the 8 tracked instruction
+    files without frontmatter (two of them in the benchmark corpus).
+
+    The fixture deliberately has NO frontmatter: with frontmatter present
+    `normalize_content` returns the content unchanged, so the bug is invisible.
+    """
+    from shared import build_scores
+    path = _write(tmp_path, "SKILL.md", _NO_FRONTMATTER)
+    assert build_scores(path, None, fmt="skill") == build_scores(path, None, fmt="skill.md")
+
+
+def test_stating_skill_format_does_not_invent_frontmatter(tmp_path):
+    """The structure score must report missing frontmatter, not have it papered over.
+
+    This is the direction the fix converges on, pinned separately from the equality
+    above: equality alone would also be satisfied by making BOTH spellings normalize,
+    which would hide the defect the structure dimension exists to report.
+    """
+    from shared import build_scores
+    no_fm = _write(tmp_path, "SKILL.md", _NO_FRONTMATTER)
+    with_fm = _write(
+        tmp_path,
+        "WITH.md",
+        "---\nname: deploy-helper\ndescription: Use when deploying.\n---\n\n" + _NO_FRONTMATTER,
+    )
+    stated = build_scores(no_fm, None, fmt="skill")["structure"]["score"]
+    assert stated < build_scores(with_fm, None, fmt="skill.md")["structure"]["score"]
+
+
+def test_every_format_alias_scores_identically_to_its_canonical_name(tmp_path):
+    """Generalized over the alias table, so a newly added alias cannot reopen this.
+
+    Two of the four branch sites that compared a raw format string have now been fixed
+    one incident at a time (#168 for `system-prompt`, this one for `skill`). Deriving
+    the pairs from FORMAT_ALIASES instead of listing them is what makes the next alias
+    covered on the day it is added.
+    """
+    from scoring.registry import FORMAT_ALIASES
+    from shared import build_scores
+    path = _write(tmp_path, "SKILL.md", _NO_FRONTMATTER)
+    for alias, canonical in sorted(FORMAT_ALIASES.items()):
+        assert build_scores(path, None, fmt=alias) == build_scores(path, None, fmt=canonical), (
+            f"alias {alias!r} scored differently than canonical {canonical!r}"
+        )


### PR DESCRIPTION
Closes the two items [`2026-07-31-format-alias-drops-security.md`](docs/specs/2026-07-31-format-alias-drops-security.md) left open. Recorded there as separate semantics questions — they are the last two branch sites of the defect #168 fixed at the first one.

## Symptom

```
schliff score AGENTS.md --format skill     → composite 39.3
schliff score AGENTS.md --format skill.md  → composite 34.5
```

Across the 29 tracked instruction files, **exactly the 8 without YAML frontmatter** diverge, by **4.7–5.5 composite points** — including two real files in the project's own benchmark corpus. `skill`/`skill.md` is the only affected alias pair; `claude`, `cursor`, `agents` and `system-prompt` are byte-identical across all 29 files (measured, not reasoned — #168 closed the last of those).

A genuine SKILL.md **with** frontmatter, scored with `--format skill`, also printed `Format: skill (normalized)`. Neither half is true: `skill` is not the format's name, and content that already has frontmatter is returned unchanged.

## Cause

`shared.build_scores` branched on a raw compare (`fmt != "skill.md"`), so the alias entered the normalization branch its canonical twin skips. For a frontmatter-less file that branch invents a name and description from the body and scores the wrapped copy:

```
--format skill     structure 80, issues: [no_real_examples]
--format skill.md  structure 50, issues: [no_frontmatter, no_real_examples]
```

The alias was hiding the exact defect the structure dimension exists to report.

## Decision: converge on NOT normalizing

The two spellings must agree — that is not a judgment call for a deterministic scorer. Which side is:

- Normalization exists so formats that *legitimately* carry no frontmatter (CLAUDE.md, AGENTS.md, `.cursorrules`) are scorable at all. A SKILL.md is **defined** by its frontmatter.
- 34.5 is the measurement; 39.3 was the flattered number.

**This lowers scores** for `score --format skill` on files without frontmatter — hence a minor, not a patch.

## Fix

Canonicalize once at the top of `build_scores`, so every branch below is correct without being widened individually, and `normalize_content` receives a canonical name so its own early return starts working. `detect_format` already returns canonical names, so the detected path — and the playground, which only calls `detect_format` — is a **strict no-op**.

`cli.py` resolves the reported format, which fixes the display name and retires the false "(normalized)" line in one move. The JSON `format` field now reports canonical names for every alias. No consumer breaks: the leaderboard validates against its own display vocabulary (`{"SKILL.md", ".cursorrules", "CLAUDE.md", "AGENTS.md"}`), which never accepted engine names, and the playground emits `detect_format` output.

**No CI gate can change verdict.** A stated format reaches the engine only via `cmd_score`; `verify`, `badge`, `doctor`, `diff`, `compare`, `report` and `suggest` all use `detect_format`.

## Two-sided gate

29 tracked instruction files × 12 format values (`None`, all 10 registry/alias choices, and `unknown` — mirroring `cli.py:1067`). Composite **and** every per-dimension score compared.

| | Result |
| --- | --- |
| 348 cells, `main` vs fixed | **340/348 byte-identical** |
| The 8 that changed | all `--format skill` on a frontmatter-less file, each now **equal to its canonical `skill.md` twin** |
| Cells that raise | 0 before, 0 after |
| Unit tests | 3 red before / green after; one derived from `FORMAT_ALIASES` so the next alias is covered on day one |
| Suite | 1939 pass |
| ruff 0.15.8 (CI pin) | clean |

The 8 changed cells are exactly the set the symptom table accuses — no third cell moved.