### PR TITLE
chore(release): v8.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.9.0",
+  "version": "8.10.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,93 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.10.0] - 2026-08-04
+
+Four correctness fixes, all in the same place: a value that describes *how* a file was
+measured, reported wrongly. Three of them were found by verifying the fourth.
+
+### Changed
+
+- **`--format skill` and `--format skill.md` scored the same file differently — the alias
+  is now the canonical name, which LOWERS the score for files without frontmatter.**
+  Measured on `AGENTS.md`: 39.3 via the alias, 34.5 via the canonical spelling. Across the
+  29 tracked instruction files in this repo, exactly the 8 that carry no YAML frontmatter
+  diverged, by 4.7–5.5 composite points — two of them real files in the project's own
+  benchmark corpus, so this was not an edge case nobody met.
+
+  `shared.build_scores` branched on a raw string compare (`fmt != "skill.md"`), so the
+  public `skill` alias entered a normalization branch that its canonical twin skips. For a
+  file without frontmatter that branch invents a name and description from the body and
+  scores the wrapped copy — `structure` went 50 → 80 and the `no_frontmatter` issue
+  disappeared. **The alias was hiding the exact defect the dimension exists to report.**
+
+  The two spellings agreeing is not a judgment call for a deterministic scorer; which side
+  they agree on is. Normalization exists so formats that *legitimately* carry no
+  frontmatter (CLAUDE.md, AGENTS.md, `.cursorrules`) are scorable at all, and a SKILL.md is
+  defined by its frontmatter — so the un-normalized, lower number is the measurement and
+  39.3 was the flattered one. This is why the release is a minor and not a patch.
+
+  Only the stated-format path moves. `detect_format` already returned canonical names, so
+  auto-detection, every other command, and the playground are strict no-ops — verified
+  cell by cell. Nothing that pins a format in CI can change verdict either: a stated format
+  reaches the engine only through `score`, never through `verify`.
+
+  Gate: 29 files × 12 format values (`None`, all 10 registry/alias choices, and `unknown`),
+  comparing the composite *and* every per-dimension score — **340/348 cells byte-identical**,
+  and the 8 that moved are exactly the accused set, each now equal to its canonical twin.
+  ([#173](https://github.com/Zandereins/schliff/pull/173))
+
+- **The reported format echoed the `--format` alias instead of the format's name.** A
+  genuine SKILL.md scored with `--format skill` printed `Format: skill (normalized)`, where
+  neither half was true — `skill` is not the format's name, and content that already has
+  frontmatter is returned unchanged. The JSON `format` field now reports canonical names
+  for every alias (`--format claude` → `claude.md`). No consumer breaks: the leaderboard
+  validates against its own display vocabulary, which never accepted engine names.
+  ([#173](https://github.com/Zandereins/schliff/pull/173))
+
+### Fixed
+
+- **`--format system-prompt` silently dropped the security dimension, worth up to 15
+  composite points.** The same file, the same version: `49.4` with 7 dimensions when the
+  format was detected, `36.8` with 6 and no `security` when it was stated through the
+  public hyphenated alias. Spread across five files: 5.9 to 15.0 points. The user who pins
+  the format explicitly — the more careful thing to do in CI — got the wrong number.
+
+  `shared.build_scores` dispatched on a raw `fmt == "system_prompt"`, which the
+  `system-prompt` alias fails; the file then fell through to the instruction-file branch,
+  where the `include_security` gate removes a dimension that is CORE for `system_prompt`
+  (weight 0.15). Dispatch now resolves through a single `registry.resolve_format()`, which
+  also replaced the inline copies of that lookup — the duplication is why one caller could
+  forget it. ([#168](https://github.com/Zandereins/schliff/pull/168))
+
+- **`schliff doctor <typo>` exited 0.** A named directory that does not exist rendered
+  "No skills found. Check skill directories." and exited successfully — indistinguishable
+  from an empty directory, so no CI gate could catch the typo. The report then listed the
+  DEFAULT scan directories, which it had not scanned, as if those were the ones that came
+  up empty. `verify` had always errored on a missing file; `doctor` disagreed with it.
+
+  Validation sits at the CLI boundary, so library callers are untouched, and only paths the
+  user NAMED are checked — the built-in defaults stay optional, because `.claude/skills`
+  legitimately does not exist in most repos and the no-arg scan is the common invocation. A
+  path that exists but is a regular file is rejected too; it previously scanned to zero in
+  silence. ([#169](https://github.com/Zandereins/schliff/pull/169))
+
+- **The version stamped into every score described the installed package, not the engine
+  that produced the score.** `_resolve_version()` read `importlib.metadata`, i.e. the
+  installed dist-info, while its docstring promised the value "can never drift from
+  pyproject.toml" — in a source or editable checkout those are different things, and the
+  docstring was part of the defect. Measured in this repo: all three gated version sources
+  said 8.9.0, `schliff version` said 8.1.0, and the console script was loading the 8.9.0
+  working tree the whole time.
+
+  Not cosmetic — `score --json` stamps this value as `version`, so it propagated into
+  benchmark JSONL and leaderboard entries, attributing measurements to an engine version
+  that never produced them. Now read from the package `__init__.py` next to the module,
+  which is already gated against `pyproject.toml`, and resolved by path rather than by
+  import so the answer does not depend on how the CLI was invoked. A `pip install` user was
+  never affected; their metadata matches their code.
+  ([#172](https://github.com/Zandereins/schliff/pull/172))
+
 ## [8.9.0] - 2026-07-30
 
 ### Security
@@ -1213,7 +1300,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.8.2...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.10.0...HEAD
+[8.10.0]: https://github.com/Zandereins/schliff/compare/v8.9.0...v8.10.0
 [8.9.0]: https://github.com/Zandereins/schliff/compare/v8.8.2...v8.9.0
 [8.8.2]: https://github.com/Zandereins/schliff/compare/v8.8.1...v8.8.2
 [8.8.1]: https://github.com/Zandereins/schliff/compare/v8.8.0...v8.8.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.9.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.10.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -33,7 +33,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.9.0
+schliff v8.10.0
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -49,7 +49,7 @@ schliff v8.9.0
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.9.0` (`pip install schliff==8.9.0` or `uvx schliff@8.9.0`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.0` (`pip install schliff==8.10.0` or `uvx schliff@8.10.0`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
 
 ---
 
@@ -242,7 +242,7 @@ jobs:
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.9.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.10.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -278,7 +278,7 @@ repos only.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.9.0
+    rev: v8.10.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.9.0.**
+**Current version: 8.10.0.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.9.0"
+version = "8.10.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.9.0"
+__version__ = "8.10.0"


### PR DESCRIPTION
Ships four correctness fixes: two merged on 2026-07-31 but never released (#168, #169) and two found while verifying those (#172, #173).

**Minor, not patch.** #173 lowers the score of `schliff score --format skill` on a file without frontmatter, converging the alias onto its canonical twin. Auto-detection, every other command, and the playground are unaffected.

## What ships

| PR | Fix |
| --- | --- |
| #168 | `--format system-prompt` silently dropped the security dimension — up to 15 composite points |
| #169 | `schliff doctor <typo>` exited 0, indistinguishable from an empty directory |
| #172 | the version stamped into every score described the installed dist, not the running engine |
| #173 | `--format skill` and `--format skill.md` scored the same file 4.7–5.5 points apart |

## Version surfaces

Three gated sources (`pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`) plus every secondary reference: README PyPI badge cache-bust, hero example banner, the reproducibility note (pip/uvx pins), the GitHub Action `schliff-version` example, the pre-commit `rev:` example, `docs/README.md`.

`install.sh` reads `pyproject.toml` dynamically and reports `Schliff v8.10.0` (RELEASING.md step 2, verified).

Also repairs a **stale CHANGELOG footer**: `[Unreleased]` still compared against `v8.8.2`, skipping `v8.9.0` — the same drift the checklist caught once before.

**The playground pin stays on 8.9.0 deliberately.** It installs from PyPI, so it can only move once 8.10.0 is published, and `playground-pin-drift.yml` asserts the *live deployed* engine equals the committed pin — bumping it before the prod redeploy would turn that gate red at the next 07:00 UTC run.

## Verification

- 1939 tests pass; markdownlint clean over all 69 tracked `.md` files
- `python -m build` + `twine check`: both artifacts PASSED
- the built wheel installed into a **clean non-editable 3.12 venv** reports `schliff 8.10.0`, and all four fixes hold in the shipped artifact:
  - `--format skill` and `--format skill.md` both 25.4, `format: skill.md`
  - both `system-prompt` spellings keep 7 dimensions including `security`
  - `doctor /nope/not/here` exits 2
- README hero output reproduces byte-for-byte against the real CLI

## Remaining steps (human-gated, not in this PR)

1. `gh release create v8.10.0` — `publish.yml` fires on `release: published` and pushes to PyPI via OIDC. **Irreversible.**
2. Bump `playground/pyproject.toml` pin + `uv lock --upgrade-package schliff`, then `vercel --prod` from a clean tree, then dispatch `playground-pin-drift.yml`
3. `vercel --prod` from `web/leaderboard/`
4. Re-point the `v1` float tag to the release commit