### PR TITLE
chore: retire the hosted surfaces, fix the Action's CI recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![AGENTS.md quality](https://img.shields.io/endpoint?url=https%3A%2F%2Fschliff-playground.vercel.app%2Fapi%2Fbadge%3Frepo%3DZandereins%2Fschliff)](https://schliff-playground.vercel.app)
-
-*That last badge is Schliff scoring this repo's own `AGENTS.md` — live, and reproducible from your own checkout.*
 
 **Your AI instruction files silently degrade — and nothing catches it.** `AGENTS.md` is read by Cursor, Codex, Copilot, and Claude Code — one rotting file now quietly degrades four tools. A trigger phrase rots, an edge case slips, the file balloons past its token budget. No error, no red test — just agents that quietly get worse.
 
@@ -47,9 +44,9 @@ schliff v8.10.0
   Format: agents.md (normalized)
 ```
 
-No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#10](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
+No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#129](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.0` (`pip install schliff==8.10.0` or `uvx schliff@8.10.0`); the hydra field run below is dated to the version it was measured on. Prefer the browser? Paste your file into the [playground](https://schliff-playground.vercel.app) — same engine, with AGENTS.md and SKILL.md tabs.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.0` (`pip install schliff==8.10.0` or `uvx schliff@8.10.0`); the hydra field run below is dated to the version it was measured on.*
 
 ---
 
@@ -77,7 +74,7 @@ Deterministic means reproducible and auditable — it does not automatically mea
 
 Config linters tell you whether the file is *valid* — a list of pass/fail rules. Schliff tells you how *good* it is — one graded 0–100 score you can gate, diff across commits, and rank.
 
-- **Reproducible.** The headline composite is computed from a canonical, versioned weight registry. Calibration is **off by default**, so `verify`, `badge`, and the leaderboard return the same score on your laptop and in CI.
+- **Reproducible.** The headline composite is computed from a canonical, versioned weight registry. Calibration is **off by default**, so `verify` and `badge` return the same score on your laptop and in CI.
 - **Auditable.** Every dimension is a readable scorer in [`scripts/scoring/`](skills/schliff/scripts/scoring/). The weights are a dict you can open. There is no hidden judge prompt.
 - **Anti-gaming, precisely scoped.** A dedicated guard layer ([`guards.py`](skills/schliff/scripts/scoring/guards.py)) detects and floors padding, junk fences, platitude farms, and keyword stuffing — worthless text cannot outrank operational text. A *plausible lie* about your repo is out of reach of any static scorer (see [What the score does not measure](#what-the-score-does-not-measure)).
 - **Zero core dependencies.** Core Schliff is stdlib-only and runs on **Python ≥ 3.10**. (Optional `[evolve]` / `[judge]` extras pull in LLM clients for an opt-in smoke-test only — never for scoring.)
@@ -229,15 +226,30 @@ repo-root `AGENTS.md` and posts a scored comment on every PR:
 # .github/workflows/agents-lint.yml
 name: AGENTS.md Lint
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write   # the comment step needs this; omit it and set comment-on-pr: false
 jobs:
   score:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Zandereins/schliff@v1
         with:
           minimum-score: '75'   # optional: fail the PR below this score
 ```
+
+`comment-on-pr` defaults to `true`, and posting a comment needs
+`pull-requests: write` — without the `permissions:` block above you inherit the
+repository default, which in many repos is read-only, and the comment step then
+fails while the score still gates the PR.
+
+> **Never switch this to `pull_request_target` to get comments on fork PRs.**
+> That trigger runs with a write-scoped token in the base repository while
+> checking out untrusted code, which is the standard way CI secrets get stolen.
+> On a fork PR the token is read-only by design: the score and the exit code
+> still work, only the comment is skipped. That degradation is the intended
+> behaviour, not a problem to route around.
 
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
@@ -259,18 +271,6 @@ supported format — the minimum is scaled by measurement coverage, so `SKILL.md
 files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
 `AGENTS.md`: older engines scored it under the SKILL profile
 ([#101](https://github.com/Zandereins/schliff/issues/101)).
-
-### README badge
-
-Show your repo's AGENTS.md quality — no setup, no CI, no account:
-
-```markdown
-![AGENTS.md quality](https://img.shields.io/endpoint?url=https%3A%2F%2Fschliff-playground.vercel.app%2Fapi%2Fbadge%3Frepo%3DOWNER%2FREPO)
-```
-
-Replace `OWNER/REPO` with your repository. The badge is scored live from your
-`AGENTS.md` at `HEAD`; GitHub's image cache (camo) may delay refreshes. Public
-repos only.
 
 ### pre-commit
 
@@ -360,8 +360,7 @@ scripts/
 ## Links & docs
 
 - **Docs:** [`docs/SCORING.md`](docs/SCORING.md)
-- **Playground:** [schliff-playground.vercel.app](https://schliff-playground.vercel.app) — paste a SKILL.md or AGENTS.md, get a live score (or `schliff demo` in the CLI). The playground reports the structural score for SKILL.md — the CLI's full 7-dim composite can differ; AGENTS.md has no such gap.
-- **Leaderboard:** [schliff-leaderboard.vercel.app](https://schliff-leaderboard.vercel.app)
+- **Try it without installing:** `uvx schliff@latest demo` scores a built-in bad skill; `schliff score <file>` scores your own.
 - **Case studies:** [`docs/case-studies/`](docs/case-studies/)
 
 ## License

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,11 +13,12 @@ Run through this list before creating a new tag. Skipping a step has burned us b
 7. **Commit on a release branch** (`chore/release-X.Y.Z`), open PR, merge to `main`.
 8. **Create the GitHub Release** (tag `vX.Y.Z`, e.g. `gh release create vX.Y.Z`) — `publish.yml` fires on `release: published`, NOT on a bare tag push.
 9. **Verify PyPI release** — check `pip install schliff==X.Y.Z` works.
-10. **Redeploy the web surfaces** — their bundles carry engine/seed state:
-    playground (bump `playground/pyproject.toml` pin + `uv lock --upgrade-package schliff`,
-    then `vercel --prod` + dispatch `playground-pin-drift.yml`) AND leaderboard
-    (`vercel --prod` from `web/leaderboard/` — its bundled seed shows the
-    self-entry version; skipping this left the live row on 8.1.0 until 2026-07-07).
+10. **No web surfaces to redeploy.** The playground, the leaderboard and the hosted
+    badge endpoint were retired on 2026-08-04 (see `docs/adr/0008-retire-hosted-surfaces.md`).
+    Their code and tests stay in the tree, but nothing is deployed and no engine pin
+    needs to move with a release. There are **six** version surfaces, not eight:
+    `pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`,
+    the README references, `docs/README.md`, and the git tag.
 11. **Re-point the `v1` float tag** to the release commit (`git tag -f v1 <sha> && git push origin v1 --force`).
 12. **Post-release:** close milestone, update memory entries that reference version.
 

--- a/action.yml
+++ b/action.yml
@@ -315,7 +315,7 @@ runs:
             }
           }
 
-          body += `\n---\n<sub>Scored by [Schliff](https://github.com/Zandereins/schliff) — the deterministic AGENTS.md quality gate · [Try the playground](https://schliff-playground.vercel.app)</sub>`;
+          body += `\n---\n<sub>Scored by [Schliff](https://github.com/Zandereins/schliff) — the deterministic AGENTS.md quality gate</sub>`;
 
           // Update existing comment or create new one
           const marker = '<!-- schliff-score-comment -->';

--- a/docs/adr/0008-retire-hosted-surfaces.md
+++ b/docs/adr/0008-retire-hosted-surfaces.md
@@ -1,0 +1,107 @@
+# ADR 0008: Retire the hosted playground, leaderboard and badge endpoint
+
+- Status: accepted
+- Date: 2026-08-04
+
+## Context
+
+schliff shipped three publicly reachable surfaces alongside the CLI: a playground
+(`POST /api/score`), a leaderboard (`POST /api/submit`, `GET /api/query`) and a badge
+endpoint (`GET /api/badge?repo=`). All three ran as Vercel serverless functions in region
+`iad1`, and the leaderboard's rate limiter stored visitor-IP-derived keys in an Upstash
+Redis instance.
+
+The trigger was an operator constraint: the maintainer is a private individual in Germany
+and will not publish a home address, which the provider-identification duty for publicly
+provided telemedia requires. But a council review found that framing was the weaker half
+of the problem. The **data-protection information duty** does not attach to how an operator
+presents themselves — it attaches to **processing**. Visitor IPs used as rate-limit keys
+are processing, and no service address, no lawyer's opinion and no wording change removes
+that duty. It is a permanent operating obligation for as long as the surfaces run.
+
+Against that stood the measured value of the surfaces:
+
+- **Web Analytics was never enabled** on either project (`404 Web Analytics not found`),
+  so no usage data exists and none can be recovered retroactively.
+- A GitHub code search for `schliff-playground.vercel.app` and
+  `schliff-leaderboard.vercel.app` returned references in **three repositories, all owned
+  by the maintainer** — zero third-party consumers. The search is not exhaustive, so the
+  honest claim is *no demonstrable demand*, not *zero demand*.
+- A pre-registered demand bet on badge adoption had a baseline of **0 badges in the wild**.
+
+## Decision
+
+Take all three surfaces offline. Both Vercel projects are **kept and emptied**, not
+deleted: every function and environment variable is removed and each project serves a
+static retirement notice. The playground additionally serves a static shields-endpoint
+JSON at `/api/badge` reporting `retired` in grey, so any badge already embedded in a
+README degrades to an honest label instead of a broken image.
+
+The Upstash `rl:*` keys are deleted explicitly over the REST API and the result recorded
+before the integration is removed, rather than trusting the integration teardown to erase
+them.
+
+The application code and its 95 tests stay in the repository. Exactly one file is removed:
+`.github/workflows/playground-pin-drift.yml`, which asserted that the live deployed engine
+matched the committed pin and would otherwise fail daily against a service that no longer
+exists.
+
+## Why
+
+Retirement is the only option that discharges every obligation at once. A service address
+(~10–20 €/month, the alternative four of six advisors reached for) would settle the
+*disputed* provider-identification question and leave the *established* processing duty and
+the third-country transfer untouched. Buying a permanent operating obligation for surfaces
+with no demonstrable demand is the worse trade regardless of who is right about the
+provider-identification threshold — which is why this decision does not depend on
+resolving it.
+
+**The projects are kept rather than deleted** because releasing a `*.vercel.app` subdomain
+makes it re-registrable, and the playground URL was already written into third-party pull
+requests by the action's comment footer. Emptying removes the processing just as
+completely; deleting additionally hands a schliff-branded address to whoever claims it
+next.
+
+**The code is kept** because deleting it discharges no obligation that taking the surfaces
+offline does not already discharge. It was the only irreversible step in the original plan
+and the only one with no stated benefit, and it would have forced the deletion of four test
+files carrying 95 collected tests. The drift risk it was meant to remove — stale entries in
+the release checklist — costs one paragraph in `RELEASING.md`.
+
+## Rejected
+
+- **Publish a service address and keep operating.** Settles the disputed duty only. Leaves
+  the processing duty and the `iad1` transfer, i.e. a permanent obligation, in exchange for
+  surfaces with no measured users.
+- **Rebuild the playground as a static client-side page (Pyodide/WASM).** Technically
+  attractive — the scoring core is deterministic and dependency-free — but a static page is
+  just as much a publicly provided telemedium, so it does not answer the address question.
+  It was advanced and then withdrawn by its own proposer as "a data-protection improvement
+  in provider-identification costume".
+- **Gate the surfaces behind authentication.** Same practical effect as retirement for any
+  outside user, while keeping the projects, the processing and the obligations alive.
+- **Wait until the demand bet's 2026-09-29 deadline.** The bet's instrument was never
+  instrumented — analytics did not exist — so waiting produces no new evidence. Enabling
+  analytics now and waiting 30–60 days *would* produce some, and that option is recorded in
+  the kill criteria below rather than pretended away.
+- **Delete the Vercel projects.** See above: subdomain re-registration, no compensating
+  benefit.
+
+## What would reverse this
+
+1. The Vercel usage dashboard shows more than roughly 200 requests per month to either
+   project after retirement, with the maintainer's own checks subtracted. That would mean
+   demand existed and was merely never measured; an EU region plus a published privacy
+   notice would then beat retirement.
+2. A third-party repository turns up embedding the badge. Code search is not exhaustive; a
+   real consumer makes the static retirement JSON a duty rather than a courtesy and means
+   the subdomains must be held indefinitely.
+
+## Note on scope
+
+This ADR records an engineering and operating decision and the reasoning behind it. It is
+**not legal advice and not a legal assessment** — no lawyer was consulted, the
+provider-identification threshold for a non-monetised open-source demo is genuinely
+disputed, and the processing analysis above is a considered reading rather than a finding.
+It is written down so the decision is not re-litigated from memory, not so it can be cited
+as authority.

--- a/docs/ops/vercel-deploy-runbook.md
+++ b/docs/ops/vercel-deploy-runbook.md
@@ -1,5 +1,15 @@
 # Vercel Deploy + Firewall Runbook (playground & leaderboard)
 
+> **RETIRED 2026-08-04 — do not follow this to bring the services back up.**
+> The playground, leaderboard and hosted badge endpoint were taken offline; both
+> Vercel projects now serve a static retirement notice and hold no functions and
+> no environment variables. The rationale, including the data-protection reasoning
+> that drove it, is in `docs/adr/0008-retire-hosted-surfaces.md`.
+>
+> This document is kept because the code it describes is still in the tree (95
+> tests load it) and because the firewall and KV sections record what *was*
+> configured. Reviving any of it is a new decision, not a redeploy.
+
 > Status as of 2026-06-03: **DEPLOYED**. Both projects are live and public in
 > team `zaneins-projects`:
 >


### PR DESCRIPTION
Takes the playground, leaderboard and hosted badge endpoint out of the docs and out of the Action's output, and closes the four findings that survive the retirement. Rationale: [`docs/adr/0008-retire-hosted-surfaces.md`](docs/adr/0008-retire-hosted-surfaces.md).

## The reason changed during review

The trigger was the provider-identification duty — the **disputed** half. The load-bearing half is the **data-protection information duty**, which attaches to *processing*, not to how an operator presents themselves. Visitor IPs used as rate-limit keys are processing, so no service address and no wording change discharges it: it is a permanent operating obligation.

Measured against that:

| | |
|---|---|
| Web Analytics, both projects | never enabled — `404 Web Analytics not found`, no data, not recoverable |
| Code search, both URLs | references in **3 repositories, all maintainer-owned** — no third-party consumers |
| Pre-registered badge-adoption bet | baseline **0 badges in the wild** |

No demonstrable demand, permanent obligation. (Code search is not exhaustive, so the honest claim is *no demonstrable demand*, not *zero demand* — recorded that way in the ADR.)

## Deliberately NOT done, against the original plan

- **The application code stays.** Deleting it discharges nothing that taking the surfaces offline does not already discharge, it was the only irreversible step with no stated benefit, and it would force deleting four test files carrying **95 collected tests** (`test_leaderboard_storage.py`, `test_leaderboard_kv.py`, `test_leaderboard_versioning.py`, `test_playground_score.py` all load modules by path from `web/leaderboard/api` and `playground/`). The drift risk it was meant to remove costs one paragraph in `RELEASING.md`, which is in this PR.
- **The Vercel projects are kept and emptied, not deleted.** A released `*.vercel.app` subdomain is re-registrable, and this action's comment footer has already written the playground URL into third-party pull requests.

## Findings closed

- **F1** — the README CI recipe had no `permissions:` block while `comment-on-pr` defaults to `true` and the comment step needs `pull-requests: write`. Read-only-default repos: documented feature fails silently. Read-write-default repos: over-privileged workflow. The example now carries the minimal set that `action-selftest.yml` already uses.
- **F2** — added the `pull_request_target` warning this project's own spec demanded and a plan checkbox still lists as open. It is exactly the trigger a user reaches for when F1 makes fork-PR comments fail, and it pairs a write-scoped token with untrusted code. The read-only fork token is the *intended* degradation; the docs now say so.
- **F5** — the example pinned `actions/checkout@v4` while this repo pins 100 % by SHA. Now uses the same SHA the workflows here already trust rather than introducing a new one.
- **F6** — a link rendered `#10` and pointed at `pull/129`.

**F3** (Google Fonts), **F4** (publicly served config files) and **F7** (`style-src 'unsafe-inline'`) are not fixed but moot — their subject goes offline. The static retirement pages carry `default-src 'none'` and make no third-party requests.

## Verification

1939 tests pass · `ruff==0.15.8` clean · markdownlint clean over all tracked `.md` including the new ADR · no `schliff-playground.vercel.app` / `schliff-leaderboard.vercel.app` references left in `README.md`, `action.yml` or `docs/README.md`.

The AI-transparency README section ships separately, as its own PR — it is an unrelated decision that was bundled in by accident.