### PR TITLE
docs: say where AI is involved, and where it is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Because the number is stable, it does real work: gate pull requests on it [in CI
 
 An optional LLM judge exists for exploratory work, but it is never part of the deterministic score. The number you gate on is rule-based, end to end.
 
+**Where AI is and is not involved.** Scoring calls no model: install core Schliff and nothing
+leaves your machine. Two opt-in extras do call one — `[evolve]` for the improvement loop and
+`[judge]` for an exploratory smoke-test — and when they do, the request runs **from your machine
+with your own API key, to the provider you configure**. This project operates no inference
+service, holds no key of yours, and receives nothing you score. Without the extra installed the
+LLM paths refuse to run rather than degrading silently, and `schliff evolve --budget 0` stays
+deterministic even with it installed.
+
 ---
 
 ## The scoring model
@@ -332,8 +340,8 @@ LLM extras power this optional layer only; they are never used for scoring.
 | Install | Pulls in | When you need it |
 | --- | --- | --- |
 | `schliff` | stdlib only | Scoring, verify, badge, CI — everything that gates a release |
-| `schliff[judge]` | LLM client | Opt-in exploratory LLM-judge smoke-test (never scoring) |
-| `schliff[evolve]` | LLM client | Opt-in autonomous-improvement extras |
+| `schliff[judge]` | `anthropic`, `pydantic` | Opt-in exploratory LLM-judge smoke-test (never scoring) |
+| `schliff[evolve]` | `litellm` | Opt-in autonomous-improvement extras |
 
 ---
 


### PR DESCRIPTION
Requested as AI-use transparency with the EU AI Act in mind. **Reading the README first changed the shape of the answer.**

It already disclosed most of this: the zero-core-dependency bullet, "never part of the deterministic score", and the install table all state that scoring calls no model. A separate "AI use in schliff" section would have been mostly duplication. So this closes the two things that were genuinely absent.

## What was missing

**1. Where the model runs, and whose credentials.** Nothing said that the opt-in LLM paths execute on *your* machine with *your* key, that this project operates no inference service, holds no key of yours, and receives nothing you score. For a transparency statement that is exactly the part a reader wants — and it was the part not there.

**2. Which packages the extras actually pull.** The table said "LLM client" twice. It now names them: `[judge]` → `anthropic`, `pydantic`; `[evolve]` → `litellm`. A named dependency is checkable; "LLM client" is not.

## Every claim verified against the code, not asserted

| Claim | Verified at |
|---|---|
| core is literally zero-dependency | no `dependencies` field in `pyproject.toml` |
| `[judge]` = `anthropic` + `pydantic`, `[evolve]` = `litellm` | `[project.optional-dependencies]` |
| refuses rather than degrading silently | `evolve/llm.py` `_check_litellm_available()` exits non-zero with an install hint |
| `--budget 0` stays deterministic even with the extra installed | `budget.py:49` (`is_deterministic_only` is `budget == 0`) → `engine.py:247`, where that branch short-circuits **before** the else-branch that imports and calls `call_llm` — the path is not merely skipped, it is never imported |

## Deliberately not added

**A published legal self-classification under the AI Act.** The council's risk seat warned that a wrong published self-assessment becomes evidence against its author — and that warning argues against publishing one at all, not just against publishing a sloppy one. The repo states verifiable facts about what calls a model and what does not; the regulatory reading stays internal reasoning rather than a public assertion.

1939 tests pass · markdownlint clean.
