### PR TITLE
chore(release): v8.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.10.1] - 2026-08-04
+
+**The hosted playground, leaderboard and badge endpoint have been retired.** The CLI, the
+GitHub Action, the pre-commit hook and the Claude Code skill are unaffected and continue to
+be maintained — this release exists so the published package stops pointing at services
+that no longer answer.
+
+### Removed
+
+- **The hosted surfaces are offline.** `schliff-playground.vercel.app` and
+  `schliff-leaderboard.vercel.app` now serve a static retirement notice and hold no
+  functions and no environment variables. The Redis instance behind the leaderboard's rate
+  limiter has been deleted.
+
+  The reason is not the one this started as. The trigger was a provider-identification duty,
+  which for a non-monetised open-source demo is genuinely disputed. The load-bearing reason
+  is the data-protection information duty, which attaches to **processing** rather than to
+  how an operator presents themselves — visitor IPs used as rate-limit keys are processing,
+  and no address, wording change or legal opinion discharges that. It is a permanent
+  operating obligation, and it was being paid for surfaces with **no demonstrable demand**:
+  web analytics was never enabled on either project, and a code search for both URLs found
+  references in three repositories, all owned by the maintainer.
+
+  **Badges already embedded in a README do not break.** `/api/badge` still answers, as a
+  static shields endpoint reporting `retired` in grey. Both Vercel projects are kept rather
+  than deleted, deliberately: a released `*.vercel.app` subdomain is re-registrable, and
+  this project's own Action had already written the playground URL into third-party pull
+  requests.
+
+  The application code and its tests stay in the repository. Full rationale and the
+  rejected alternatives — including a service address and a static client-side rebuild —
+  are in [`docs/adr/0008-retire-hosted-surfaces.md`](docs/adr/0008-retire-hosted-surfaces.md).
+  ([#176](https://github.com/Zandereins/schliff/pull/176),
+  [#177](https://github.com/Zandereins/schliff/pull/177))
+
+### Fixed
+
+- **The documented CI recipe granted no permissions while the feature it documents needs
+  one.** `comment-on-pr` defaults to `true` and the comment step needs `pull-requests:
+  write`, but the README workflow carried no `permissions:` block. In repositories whose
+  default token is read-only the documented feature failed silently; in repositories with a
+  read-write default the workflow ran with more privilege than it needed. The example now
+  carries the minimal set that this project's own self-test workflow already used.
+  ([#177](https://github.com/Zandereins/schliff/pull/177))
+
+- **Added the warning against `pull_request_target` that was missing.** It is exactly the
+  trigger a user reaches for when fork-PR comments fail, and it pairs a write-scoped token
+  with a checkout of untrusted code. On a fork PR the read-only token is the *intended*
+  degradation — the score and the exit code still work, only the comment is skipped — and
+  the docs now say so instead of leaving the reader to discover it.
+  ([#177](https://github.com/Zandereins/schliff/pull/177))
+
+- **The CI example pinned `actions/checkout@v4`** while every workflow in this repository
+  pins by commit SHA. For a tool that argues for supply-chain care, teaching the unpinned
+  form was the wrong signal. It now uses the same SHA the workflows here already trust.
+  ([#177](https://github.com/Zandereins/schliff/pull/177))
+
+- A README link rendered as `#10` while pointing at pull request 129.
+  ([#177](https://github.com/Zandereins/schliff/pull/177))
+
+### Changed
+
+- **The README now says where a model is involved and where it is not.** Scoring calls no
+  model and core Schliff is literally zero-dependency — `pyproject.toml` declares no
+  `dependencies` at all. The two opt-in extras that do call one run **from the user's own
+  machine with the user's own API key**; this project operates no inference service, holds
+  no key, and receives nothing that is scored. Without the extra installed those paths
+  refuse to run rather than degrading silently, and `schliff evolve --budget 0` never
+  imports the LLM path at all. The install table now names the actual packages
+  (`anthropic`, `pydantic`, `litellm`) instead of saying "LLM client".
+  ([#178](https://github.com/Zandereins/schliff/pull/178))
+
+- `RELEASING.md` drops the web-redeploy step and the playground engine pin: there are now
+  **six** version surfaces, not eight. ([#177](https://github.com/Zandereins/schliff/pull/177))
+
 ## [8.10.0] - 2026-08-04
 
 Four correctness fixes, all in the same place: a value that describes *how* a file was
@@ -1300,7 +1375,8 @@ measured, reported wrongly. Three of them were found by verifying the fourth.
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.10.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.10.1...HEAD
+[8.10.1]: https://github.com/Zandereins/schliff/compare/v8.10.0...v8.10.1
 [8.10.0]: https://github.com/Zandereins/schliff/compare/v8.9.0...v8.10.0
 [8.9.0]: https://github.com/Zandereins/schliff/compare/v8.8.2...v8.9.0
 [8.8.2]: https://github.com/Zandereins/schliff/compare/v8.8.1...v8.8.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.10.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.10.1)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -30,7 +30,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.10.0
+schliff v8.10.1
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -46,7 +46,7 @@ schliff v8.10.0
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#129](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.0` (`pip install schliff==8.10.0` or `uvx schliff@8.10.0`); the hydra field run below is dated to the version it was measured on.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.1` (`pip install schliff==8.10.1` or `uvx schliff@8.10.1`); the hydra field run below is dated to the version it was measured on.*
 
 ---
 
@@ -262,7 +262,7 @@ fails while the score still gates the PR.
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.10.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.10.1'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -286,7 +286,7 @@ files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.10.0
+    rev: v8.10.1
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.10.0.**
+**Current version: 8.10.1.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.10.0"
+version = "8.10.1"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.10.0"
+__version__ = "8.10.1"


### PR DESCRIPTION
Ships the retirement of the hosted surfaces to the published package.

**Why a release at all:** the wheel is functionally unchanged. But `pyproject.toml` sets `readme = "README.md"`, so the **PyPI project page** keeps advertising a playground and a badge endpoint that no longer answer until a release carries the new README. That is the whole reason this exists.

**Patch, not minor:** no package API moves. What was removed are hosted services, not anything importable or callable. The CHANGELOG says so in its first paragraph rather than hiding it behind a version number.

## Version surfaces

Six bumped, not eight: `pyproject.toml`, `.claude-plugin/plugin.json`, `skills/schliff/__init__.py`, the README references (badge cache-bust, hero banner, reproducibility pins, the `schliff-version` and pre-commit examples), and `docs/README.md`.

The playground engine pin and its `uv.lock` **stay on 8.10.0 deliberately** — they describe a deployment that no longer happens, which is exactly what the `RELEASING.md` change in #177 recorded when it dropped the count from eight to six.

## Verification

| Check | Result |
|---|---|
| `install.sh --help` | `Schliff v8.10.1` (reads `pyproject.toml` dynamically — RELEASING.md step 2) |
| version-consistency gate | green |
| Test suite | 1939 pass |
| `ruff==0.15.8` / markdownlint | clean |
| README hero block | reproduces byte-for-byte against the real CLI |
| `python -m build` + `twine check` | both artifacts PASSED |
| wheel in a clean non-editable 3.12 venv | loads from `site-packages` (verified, not assumed) and reports `8.10.1` |

All four fixes from 8.10.0 re-verified **in the built artifact**, not just on `main`:

- `--format skill` and `--format skill.md` both `25.4` with `format: skill.md`
- both `system-prompt` spellings keep 7 dimensions including `security`
- `doctor /nope/not/here` exits 2

## After merge

Tag and publish `v8.10.1`, then re-point the `v1` float tag so Action consumers get the cleaned-up PR-comment footer from #177.
