### PR TITLE
docs(adr): assess the AI Act, and correct 0008's stated trigger

### DIFF
--- a/docs/adr/0008-retire-hosted-surfaces.md
+++ b/docs/adr/0008-retire-hosted-surfaces.md
@@ -105,3 +105,25 @@ provider-identification threshold for a non-monetised open-source demo is genuin
 disputed, and the processing analysis above is a considered reading rather than a finding.
 It is written down so the decision is not re-litigated from memory, not so it can be cited
 as authority.
+
+## Correction, 2026-08-04 (same day, after acceptance)
+
+The Context section above states the trigger as "the maintainer … will not publish a home
+address". **That was too broad and is corrected here rather than rewritten** — an accepted
+ADR records what was decided and on what basis, including where the basis turned out to be
+stated wrongly.
+
+The accurate position: publishing provider-identification data was never the blocker it was
+written up as, and the maintainer does publish it where it is owed. What a published address
+cannot do is discharge the **data-protection information duty**, because that duty attaches
+to processing rather than to how an operator presents themselves — which is exactly the
+reasoning already given under *Why*, and which the retirement was actually built on.
+
+**The decision is unchanged and the load-bearing argument is untouched.** The two reasons that
+carry it — a permanent processing obligation, and no demonstrable demand for the surfaces
+paying for it — were independent of the trigger from the start. Only the framing of the
+trigger was wrong, and a public record that says something inaccurate about its own author is
+worth correcting even when the outcome does not move.
+
+See `docs/adr/0009-ai-act-assessment.md` for the regulatory assessment that was deliberately
+left out of this ADR at the time.

--- a/docs/adr/0009-ai-act-assessment.md
+++ b/docs/adr/0009-ai-act-assessment.md
@@ -1,0 +1,116 @@
+# ADR 0009: EU AI Act — schliff imposes no transparency obligation on itself, and why
+
+- Status: accepted
+- Date: 2026-08-04
+
+## Context
+
+Article 50 of the EU AI Act became applicable on **2026-08-02**. The Digital Omnibus on AI
+(in force 2026-07-27) postponed the high-risk timelines — Annex III to 2027-12-02, Annex I to
+2028-08-02 — but **did not postpone Article 50**. The only grace period it granted there is for
+the Art. 50(2) machine-readable marking of systems already on the market at 2026-08-02, which
+runs to 2026-12-02. Article 4 (AI literacy) survived as an obligation of effort rather than of
+result and carries no fine, being absent from the Art. 99 ceilings.
+
+schliff is affected by none of it, and this ADR records *why* — because "it does not apply" is
+a claim that decays. Two days after Art. 50 started applying, a reader is entitled to ask, and
+the answer should not have to be reconstructed from the source tree.
+
+What schliff actually is, verified against the tree on 2026-08-04:
+
+- **The score is rule-based.** `pyproject.toml` declares no `dependencies` at all. Every
+  dimension is a readable scorer under `skills/schliff/scripts/scoring/`; the weights are a
+  dict. Nothing infers, nothing learns, nothing is trained.
+- **Two optional extras call a model**: `[evolve]` pulls `litellm`, `[judge]` pulls
+  `anthropic`. Both are opt-in installs. Without them the paths exit non-zero with an install
+  hint rather than degrading, and `schliff evolve --budget 0` never imports the LLM path at all
+  (`budget.py:49` → `engine.py:247`).
+- **Where they do run, they run on the user's machine with the user's own credentials**,
+  against a provider the user configures. This project ships no model, hosts no inference,
+  holds no key, and receives nothing that is scored.
+- **schliff publishes no text.** Its output is a score, and — for `evolve` — an edited file on
+  the user's own disk. Since 2026-08-04 it also operates no public service at all
+  (see ADR 0008).
+
+## Decision
+
+Record that no Article 50 obligation attaches to schliff, on the reasoning below, and state
+the AI-use facts in the README so a reader does not have to take that on trust. Do **not**
+add a disclosure banner, a machine-readable marking, or an AI-transparency page.
+
+## Why
+
+**Primary reason: the scored artefact is not produced by an AI system.** Art. 3(1) requires a
+machine-based system that infers. A regex-and-arithmetic scorer with a published weight dict
+does not, so the Regulation does not reach the part of schliff that everything else depends on.
+This is the strongest available argument and it is deliberately placed first — "Art. 50 barely
+applies" would have been the weaker claim, because it concedes the framework applies at all.
+
+**Art. 50(4) subpara. 2 cannot bite, on its own terms.** That clause — the one that does reach
+a blog, and the reason fpaul.dev is getting a transparency page — obliges deployers to disclose
+AI-generated or manipulated **text published to inform the public on matters of public
+interest**, unless the content had human review and a named person holds editorial
+responsibility (Recital 134 uses the same wording). schliff publishes no text to anyone. The
+`evolve` output is a file edit delivered to the person who invoked it, which is neither
+publication nor an address to the public.
+
+**Art. 50(1) does not apply.** It covers systems intended to interact directly with natural
+persons, which must disclose that the interaction is with an AI. A CLI that prints a number is
+not that, and on the one path where a model *is* involved the user installed an extra named
+`[evolve]` and configured a provider to get there. The README states it regardless, which is
+the cheap and honest thing to do whether or not it is owed.
+
+**Neither provider nor deployer for the optional paths.** schliff places no model on the market
+and operates none. `litellm` is a client library; the model, the endpoint and the credentials
+are the user's. On the reading taken here the user is the deployer of whatever they configure,
+and this project is a caller. This is the least settled point in the assessment and is named as
+such below rather than buried.
+
+**Chapter III and Chapter V are not in scope.** schliff is not an Annex III use case — it
+scores text files, not people — and its high-risk timelines moved to 2027-12-02 in any event.
+Chapter V concerns general-purpose model providers; schliff trains and ships no model.
+
+**Art. 4 is satisfied by the same README text.** If it applies at all it is now an obligation
+of effort and not fineable, and naming which paths call a model and which do not is that effort.
+
+## Where this is least certain
+
+Two points, named so they are not mistaken for settled:
+
+1. **Whether distributing software that calls a third-party model makes the distributor a
+   provider.** Taken here as no. It is the point on which the optional-path reasoning would
+   turn if a supervisory authority read the roles more broadly.
+2. **Art. 50(2) machine-readable marking of synthetic output.** Taken here as an obligation of
+   the generating system's provider rather than of a client that requests a completion. If that
+   is wrong, `evolve` output would be in scope — and the grace period for systems already on the
+   market ran to 2026-12-02.
+
+Neither changes the primary reason: the deterministic score, which is the product, involves no
+AI system at all.
+
+## Rejected
+
+- **Publishing nothing at all.** The position taken in the earlier work on this: a wrong
+  published self-classification becomes evidence against its author, so publish only verifiable
+  facts. That argument stands against a *guessed* classification, not against a sourced one —
+  and leaving the question unanswered while Art. 50 is live invites the reader to assume the
+  worse answer.
+- **A disclosure banner or an AI-transparency page.** Both would assert an obligation that does
+  not exist here and imply the score is model-derived, which is the exact misunderstanding
+  the project exists to avoid.
+- **Machine-readable marking of `evolve` output.** Not owed on this reading, and marking a file
+  the user asked to have edited on their own disk communicates nothing to anyone.
+
+## Sources and scope
+
+The regulatory facts above — the 2026-08-02 Art. 50 date, the Digital Omnibus outcome and what
+it did and did not postpone, the Art. 50(4) subpara. 2 wording, the Art. 4 downgrade, the Art.
+99(4)(g) and 99(6) penalty structure, and the KI-MIG assigning central market surveillance in
+Germany to the Bundesnetzagentur — come from a primary-source verification dated 2026-08-04
+against `artificialintelligenceact.eu` (Art. 50, Recital 134, Art. 99) and the Bundestag
+record, and were not re-derived here.
+
+**This is an assessment by the maintainer, not legal advice and not a legal opinion.** No
+lawyer was consulted. It states a reading, names where that reading is weakest, and is dated so
+a later reader can see what it was based on. If something after August 2026 is at stake,
+re-check the sources rather than citing this document.


### PR DESCRIPTION
Two things, both about the public record being accurate rather than convenient.

## ADR 0009 — the AI Act assessment that 0008 left out

Article 50 became applicable **2026-08-02**. The Digital Omnibus on AI (in force 2026-07-27) moved the high-risk timelines — Annex III to 2027-12-02, Annex I to 2028-08-02 — but **not that one**. "It does not apply to us" is a claim that decays, so the reasoning is written down instead of left to be reconstructed from the source tree.

**The primary argument is that the scored artefact is not produced by an AI system at all.** Art. 3(1) requires a machine-based system that *infers*; a regex-and-arithmetic scorer with a published weight dict does not. That is deliberately placed ahead of "Art. 50 barely applies", which is the weaker claim because it concedes the framework reaches us.

| Provision | Why it does not attach |
|---|---|
| Art. 50(4) subpara. 2 | needs **text published to inform the public** on matters of public interest — schliff publishes none; `evolve` edits a file on the caller's own disk |
| Art. 50(1) | needs direct interaction with natural persons; a CLI printing a number is not that, and the README discloses the model paths anyway |
| Chapter III (high-risk) | not an Annex III use case — it scores text files, not people |
| Chapter V (GPAI) | trains and ships no model |
| Art. 4 (AI literacy) | obligation of effort since the Omnibus, not fineable; the README text *is* the effort |

**Two points named as least certain** rather than buried: whether distributing software that calls a third-party model makes the distributor a *provider*, and whether Art. 50(2) marking falls on the generating system's provider or on a client requesting a completion. Neither disturbs the primary reason.

**The regulatory facts are not re-derived here.** They come from a primary-source verification dated 2026-08-04 against `artificialintelligenceact.eu` (Art. 50, Recital 134, Art. 99) and the Bundestag record. All ten load-bearing values were cross-checked against that source before this was written. The document is labelled a maintainer assessment — not legal advice — and dated so a later reader can see its basis.

**This reverses a call made earlier today.** That call — publish only verifiable facts, never a self-classification, because a wrong published classification becomes evidence against its author — was right against a *guessed* classification. With sourced facts it stops applying, and leaving the question unanswered while Art. 50 is live invites the reader to assume the worse answer.

## ADR 0008 — corrected, not rewritten

Its Context stated the trigger as *"the maintainer … will not publish a home address"*. That was too broad: publishing provider-identification data was never the blocker it was written up as.

What an address **cannot** do is discharge the data-protection information duty, because that duty attaches to **processing** rather than to how an operator presents themselves — which is the reasoning 0008 already gave under *Why* and actually rested on.

**The decision and its load-bearing argument are unchanged.** The two reasons that carry it — a permanent processing obligation, and no demonstrable demand for the surfaces paying for it — were independent of the trigger from the start. Only the framing was wrong, and a public record that says something inaccurate about its own author is worth correcting even when the outcome does not move. It is added as a dated correction rather than an edit, because an accepted ADR records what was decided and on what basis, including where the basis was stated wrongly.

## Verification

1939 tests pass · markdownlint clean over all 71 tracked `.md` files · every regulatory value in 0009 diffed against the verified source before commit.
