### PR TITLE
fix(ci): never cancel a Tests run on the default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,13 @@ permissions:
 
 concurrency:
   group: test-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on PR branches, but NEVER on the default branch. A cancelled
+  # run on main leaves the branch with no completed test result — GitHub renders that as
+  # a red mark next to the commit, indistinguishable from a real failure, while proving
+  # nothing either way. It happened on 42cf108: `lint` finished green, every test job was
+  # cancelled mid-flight, zero jobs failed. Same reasoning as the `cancel-in-progress:
+  # false` on publish.yml — some runs are worth more than the minutes they cost.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Lint gate for the project's own Python (dogfoods "the Ruff for SKILL.md").


### PR DESCRIPTION
The concurrency rule cancelled in-progress runs on **every** ref, `main` included. On a PR branch that is correct and saves minutes. On `main` it destroys the only evidence the branch has.

What happened on `42cf108`:

| Job | Result |
|---|---|
| `lint` | finished, green |
| `test (3.10–3.13)`, `test-macos`, `test-report` | **cancelled mid-flight** |
| any `failure` | **none** |

GitHub renders a cancelled run as a red mark next to the commit — indistinguishable from a real failure, while proving nothing either way. Re-running produced 7/7 green on unchanged code, so nothing was ever broken; the result had simply been thrown away.

## The fix

`cancel-in-progress` now takes an expression: still `true` for PR branches, always `false` for `refs/heads/main`.

This is the same trade `publish.yml` already makes — `cancel-in-progress: false  # don't kill in-flight publishes`. Some runs are worth more than the minutes they cost, and a default branch with no test verdict is the expensive kind of cheap.

## Diagnosis note, for the next red mark

- `gh run list` first: **`cancelled` is not `failure`.**
- Only `gh run view <id> --json jobs` says which job actually failed.
- `gh api .../commits/<sha>/status` reports `state: pending` with `total_count: 0` on this repo, because it uses check-runs and no legacy commit statuses at all. The same `pending` appears on fully green commits, so it is not a signal.

## Verification

The workflow still parses and its four jobs (`lint`, `test`, `test-macos`, `test-report`) are unchanged.
