### PR TITLE
SkillOpt import: gradient target guard, redaction patterns, and a credential report that does not gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.10.1",
+  "version": "8.11.0",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### BREAKING BEHAVIOUR
+
+- **`schliff verify` and the GitHub Action now fail on a detected credential, at any
+  `--min-score`.** A pipeline that is green today turns red if the instruction file contains
+  a structurally valid vendor token — an AWS access key, a GitHub token, an Anthropic or
+  OpenAI key, a Slack or Google key, or a JWT. This is filed here rather than under *Added*
+  because a build that used to pass can now fail without the workflow changing, and the
+  Action's `schliff-version` input defaults to the latest release.
+
+  **No score changes.** The composite, every dimension, badges, `compare`, and every pinned
+  `--min-score` threshold behave exactly as before. A leak is not a quality deduction that
+  competes with a threshold; it is a categorical failure, so it is modelled as one. That is
+  also why no `--allow-secrets` escape ships: an opt-out on a security gate becomes the
+  default copy-paste line, and a legitimate value that trips the detector is a pattern bug
+  to fix in the pattern.
+
+  **Placeholders never fire.** A finding requires the vendor prefix *and* the exact shape
+  that vendor issues, and any token announcing itself as a stand-in is ignored — including
+  AWS's own documentation key `AKIAIOSFODNN7EXAMPLE`, `sk-ant-REPLACE_ME…`, `<your-key>`
+  and `${VAR}`.
+
+### Added
+
+- **Credential findings in `score`, `score --json` and `doctor`.** Reporting surfaces display
+  the finding and never change their exit code; only `verify` and the Action gate on it.
+  A finding carries the **vendor and the line number, never the value** — the Action hands
+  the whole score object to its PR-comment step, so output sites cannot be enumerated and
+  the value must not be in the object to begin with.
+
+### Security
+
+- **The Action now refuses paths that resolve outside the workspace.** Both `skill-path` and
+  `eval-suite` are checked before schliff reads anything. A pull request from a fork controls
+  its own checkout and could previously plant a symlink pointing elsewhere on the runner;
+  schliff's messages report existence and exact byte size, which made an unguarded read an
+  out-of-repo oracle. A pinned pre-8.11 engine degrades to "no findings" rather than failing
+  the parse.
+
 ## [8.10.1] - 2026-08-04
 
 **The hosted playground, leaderboard and badge endpoint have been retired.** The CLI, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,37 +5,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-### BREAKING BEHAVIOUR
-
-- **`schliff verify` and the GitHub Action now fail on a detected credential, at any
-  `--min-score`.** A pipeline that is green today turns red if the instruction file contains
-  a structurally valid vendor token — an AWS access key, a GitHub token, an Anthropic or
-  OpenAI key, a Slack token or a Google key. **JWTs are deliberately not detected**: the
-  jwt.io sample and Supabase's `anon` key are public by design, and nothing in a JWT's shape
-  separates them from a service key. Use a dedicated secret scanner if you need that class.
-  This is filed here rather than under *Added*
-  because a build that used to pass can now fail without the workflow changing, and the
-  Action's `schliff-version` input defaults to the latest release.
-
-  **No score changes.** The composite, every dimension, badges, `compare`, and every pinned
-  `--min-score` threshold behave exactly as before. A leak is not a quality deduction that
-  competes with a threshold; it is a categorical failure, so it is modelled as one. That is
-  also why no `--allow-secrets` escape ships: an opt-out on a security gate becomes the
-  default copy-paste line, and a legitimate value that trips the detector is a pattern bug
-  to fix in the pattern.
-
-  **Placeholders never fire.** A finding requires the vendor prefix *and* the exact shape
-  that vendor issues, and any token announcing itself as a stand-in is ignored — including
-  AWS's own documentation key `AKIAIOSFODNN7EXAMPLE`, `sk-ant-REPLACE_ME…`, `<your-key>`
-  and `${VAR}`.
-
 ### Added
 
-- **Credential findings in `score`, `score --json` and `doctor`.** Reporting surfaces display
-  the finding and never change their exit code; only `verify` and the Action gate on it.
-  A finding carries the **vendor and the line number, never the value** — the Action hands
-  the whole score object to its PR-comment step, so output sites cannot be enumerated and
-  the value must not be in the object to begin with.
+- **Credential findings in `score`, `score --json`, `doctor`, `verify` and the GitHub Action.**
+  Schliff points out strings shaped like an AWS access key, a GitHub token, an Anthropic or
+  OpenAI key, a Slack token or a Google key. A finding carries the **vendor and the line
+  number, never the value** — the Action hands the whole score object to its PR-comment step,
+  so output sites cannot be enumerated and the value must not be in the object to begin with.
+
+  **Nothing gates on it, and no exit code changes anywhere.** A green pipeline stays green:
+  `verify` still exits on `--min-score` and `--regression` alone, and the Action annotates
+  with a warning without failing the job. No score changes either — the composite, every
+  dimension, badges, `compare` and every pinned threshold are bit-identical to before.
+
+  **The limitation, stated plainly:** a token's shape does not tell a live key from a
+  documentation example. Placeholders that name themselves are excluded — AWS's own
+  `AKIAIOSFODNN7EXAMPLE`, `sk-ant-REPLACE_ME…`, `<your-key>`, `${VAR}` — but a placeholder
+  that merely looks real will be reported, and a real key in a shape schliff does not know
+  will not be. Measured over ~740 real files on the author's machine, every finding the scan
+  produced was documentation *about* credentials. JWTs are deliberately not detected at all:
+  the jwt.io sample and Supabase's `anon` key are public by design and structurally identical
+  to a service key. **This is a report, not a secret scanner** — if you need enforcement, run
+  a dedicated one, and read the `credentials` field of `schliff score --json` if you want to
+  fail your own build on it.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **`schliff verify` and the GitHub Action now fail on a detected credential, at any
   `--min-score`.** A pipeline that is green today turns red if the instruction file contains
   a structurally valid vendor token — an AWS access key, a GitHub token, an Anthropic or
-  OpenAI key, a Slack or Google key, or a JWT. This is filed here rather than under *Added*
+  OpenAI key, a Slack token or a Google key. **JWTs are deliberately not detected**: the
+  jwt.io sample and Supabase's `anon` key are public by design, and nothing in a JWT's shape
+  separates them from a service key. Use a dedicated secret scanner if you need that class.
+  This is filed here rather than under *Added*
   because a build that used to pass can now fail without the workflow changing, and the
   Action's `schliff-version` input defaults to the latest release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.11.0] - 2026-08-10
+
 ### Added
 
 - **Credential findings in `score`, `score --json`, `doctor`, `verify` and the GitHub Action.**
@@ -1408,7 +1410,8 @@ measured, reported wrongly. Three of them were found by verifying the fourth.
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.10.1...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.11.0...HEAD
+[8.11.0]: https://github.com/Zandereins/schliff/compare/v8.10.1...v8.11.0
 [8.10.1]: https://github.com/Zandereins/schliff/compare/v8.10.0...v8.10.1
 [8.10.0]: https://github.com/Zandereins/schliff/compare/v8.9.0...v8.10.0
 [8.9.0]: https://github.com/Zandereins/schliff/compare/v8.8.2...v8.9.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.10.1)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.11.0)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -30,7 +30,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.10.1
+schliff v8.11.0
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -46,7 +46,7 @@ schliff v8.10.1
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#129](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.10.1` (`pip install schliff==8.10.1` or `uvx schliff@8.10.1`); the hydra field run below is dated to the version it was measured on.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.11.0` (`pip install schliff==8.11.0` or `uvx schliff@8.11.0`); the hydra field run below is dated to the version it was measured on.*
 
 ---
 
@@ -262,7 +262,7 @@ fails while the score still gates the PR.
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.10.1'` in the
+lead an older pinned install; pin it with `schliff-version: '8.11.0'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -286,7 +286,7 @@ files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.10.1
+    rev: v8.11.0
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/action.yml
+++ b/action.yml
@@ -390,28 +390,30 @@ runs:
             core.warning(`Could not post the Schliff comment (likely a fork PR with a read-only token): ${e.message}`);
           }
 
-    - name: Fail on detected credentials
+    - name: Report detected credentials
       shell: bash
       env:
         CREDENTIALS: ${{ steps.score.outputs.credentials }}
       run: |
-        # Categorical and unconditional: a leak does not compete with a score
-        # threshold, so this step carries no `if:` on minimum-score and cannot
-        # be tuned away (ADR 0011, ADR 0014).
+        # Reports, never gates (ADR 0019). A token's shape does not separate a
+        # live key from a documentation example (ADR 0020), so this check must
+        # not decide anyone's build: the person a false positive hits does not
+        # control schliff's release cycle, and `schliff-version` defaults to
+        # latest. `warning` rather than `error` is the honest severity for a
+        # finding that is right some of the time.
         #
-        # Placed AFTER "Comment on PR" deliberately. Inner steps of a composite
-        # action cannot carry continue-on-error, so the first non-zero exit stops
-        # the rest: gating earlier meant the contributor got a red check with no
-        # score comment at all - no dimensions, no dangling summary - on exactly
-        # the pull request that most needs reviewing.
+        # Annotations do not fail a job on their own, so no `exit 1` belongs
+        # here. The step stays after "Comment on PR" regardless: inner steps of
+        # a composite action cannot carry continue-on-error, so anything that
+        # started exiting non-zero here would again cost the contributor the
+        # score comment on exactly the pull request that most needs reviewing.
         if [ "${CREDENTIALS}" = "MISSING" ]; then
-          echo "::notice::The pinned schliff engine predates the credential gate; no scan was performed."
+          echo "::notice::The pinned schliff engine predates the credential scan; no scan was performed."
         elif [ -n "${CREDENTIALS}" ]; then
           for finding in ${CREDENTIALS}; do
-            echo "::error::Credential detected: ${finding%%:*} at line ${finding##*:}"
+            echo "::warning::Possible credential: ${finding%%:*} at line ${finding##*:}"
           done
-          echo "::error::Remove it from the instruction file and rotate the key."
-          exit 1
+          echo "::warning::If it is real, remove it from the instruction file and rotate the key."
         fi
 
     - name: Check minimum score

--- a/action.yml
+++ b/action.yml
@@ -73,9 +73,33 @@ runs:
         # Default to AGENTS.md at the repo root when no path is given (the
         # AGENTS.md-first entry point). Fail clearly if the file is missing,
         # with a message tailored to whether the path was explicit or defaulted.
+        # Containment. Every path handed to schliff must resolve inside the
+        # workspace. A fork PR controls its own checkout, so it can plant a
+        # symlink pointing anywhere on the runner — and schliff's reads report
+        # existence, byte size and (for the credential scan) whether a key is
+        # present, which turns an unguarded read into an out-of-repo oracle.
+        # This is the same guard `command_resolution._contained` applies to
+        # manifest reads. It runs BEFORE the `-f` test below, because `-f`
+        # dereferences symlinks and is itself an existence probe (ADR 0016).
+        contained() {
+        CONTAIN_ROOT="$GITHUB_WORKSPACE" CONTAIN_TARGET="$1" python3 -P -c "
+        import os, sys
+        try:
+            root = os.path.realpath(os.environ['CONTAIN_ROOT'])
+            target = os.path.realpath(os.environ['CONTAIN_TARGET'])
+            sys.exit(0 if os.path.commonpath([root, target]) == root else 1)
+        except (OSError, ValueError):
+            sys.exit(1)
+        "
+        }
+
         EXPLICIT_PATH="${INPUT_SKILL_PATH}"
         INPUT_SKILL_PATH="${INPUT_SKILL_PATH:-AGENTS.md}"
         SKILL_FULL="${GITHUB_WORKSPACE}/${INPUT_SKILL_PATH}"
+        if ! contained "$SKILL_FULL"; then
+          echo "::error::'skill-path' resolves outside the workspace. Refusing to read it."
+          exit 1
+        fi
         if [ ! -f "$SKILL_FULL" ]; then
           if [ -n "$EXPLICIT_PATH" ]; then
             echo "::error::Instruction file not found: ${INPUT_SKILL_PATH} (from the 'skill-path' input)."
@@ -88,6 +112,13 @@ runs:
         if [ -n "${INPUT_EVAL_SUITE}" ]; then
           EVAL_FLAG="--eval-suite"
           EVAL_PATH="${GITHUB_WORKSPACE}/${INPUT_EVAL_SUITE}"
+          # Second path on the same command line, and previously unguarded:
+          # schliff reports the eval suite's existence and exact byte size on
+          # stderr, which this action echoes into a public ::error:: annotation.
+          if ! contained "$EVAL_PATH"; then
+            echo "::error::'eval-suite' resolves outside the workspace. Refusing to read it."
+            exit 1
+          fi
         fi
         if [ -n "$EVAL_FLAG" ]; then
           RESULT=$(schliff score "$SKILL_FULL" "$EVAL_FLAG" "$EVAL_PATH" --json 2>/tmp/schliff_stderr) || true
@@ -132,6 +163,19 @@ runs:
         # KeyError (schliff 6.3.0 emits no `format`).
         FORMAT=$(echo "$RESULT" | python3 -P -c "import sys,json; print(json.load(sys.stdin).get('format',''))" 2>/dev/null) || true
         echo "format=$FORMAT" >> "$GITHUB_OUTPUT"
+
+        # Credential findings, rendered as "vendor:line" pairs. `.get` with a
+        # default so a pinned pre-8.11 engine degrades to "no findings" instead
+        # of failing the parse — the same graceful-degradation contract the
+        # `format` line above follows and the `old-engine` self-test asserts.
+        # Only vendor and line cross this boundary; the value never entered the
+        # JSON in the first place (ADR 0014).
+        CREDENTIALS=$(echo "$RESULT" | python3 -P -c "
+        import sys, json
+        found = json.load(sys.stdin).get('credentials', []) or []
+        print(' '.join(f\"{c['vendor']}:{c['line']}\" for c in found))
+        " 2>/dev/null) || true
+        echo "credentials=$CREDENTIALS" >> "$GITHUB_OUTPUT"
         # The already-resolved absolute path — single source of truth so the
         # dangling step does not re-derive the default-to-AGENTS.md logic.
         echo "skill_full=$SKILL_FULL" >> "$GITHUB_OUTPUT"
@@ -178,6 +222,24 @@ runs:
           " 2>/dev/null || true
         else
           echo "No dangling commands."
+        fi
+
+    - name: Fail on detected credentials
+      shell: bash
+      env:
+        CREDENTIALS: ${{ steps.score.outputs.credentials }}
+      run: |
+        # Categorical and unconditional: a leak does not compete with a score
+        # threshold, so this step carries no `if:` on minimum-score and cannot
+        # be tuned away (ADR 0011, ADR 0014). It runs before the threshold gate
+        # so the credential is the reported reason, not a score that happens to
+        # be low as well.
+        if [ -n "${CREDENTIALS}" ]; then
+          for finding in ${CREDENTIALS}; do
+            echo "::error::Credential detected: ${finding%%:*} at line ${finding##*:}"
+          done
+          echo "::error::Remove it from the instruction file and rotate the key."
+          exit 1
         fi
 
     - name: Check minimum score

--- a/action.yml
+++ b/action.yml
@@ -237,23 +237,6 @@ runs:
           echo "No dangling commands."
         fi
 
-    - name: Check minimum score
-      if: inputs.minimum-score != '0'
-      shell: bash
-      env:
-        COMPOSITE: ${{ steps.score.outputs.composite }}
-        MINIMUM: ${{ inputs.minimum-score }}
-      run: |
-        python3 -P -c "
-        import sys, os
-        score = float(os.environ['COMPOSITE'])
-        minimum = float(os.environ['MINIMUM'])
-        if score < minimum:
-            print(f'::error::Score {score} is below minimum {minimum}')
-            sys.exit(1)
-        print(f'Score {score} passes minimum {minimum}')
-        "
-
     - name: Comment on PR
       if: inputs.comment-on-pr == 'true' && github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -430,6 +413,23 @@ runs:
           echo "::error::Remove it from the instruction file and rotate the key."
           exit 1
         fi
+
+    - name: Check minimum score
+      if: inputs.minimum-score != '0'
+      shell: bash
+      env:
+        COMPOSITE: ${{ steps.score.outputs.composite }}
+        MINIMUM: ${{ inputs.minimum-score }}
+      run: |
+        python3 -P -c "
+        import sys, os
+        score = float(os.environ['COMPOSITE'])
+        minimum = float(os.environ['MINIMUM'])
+        if score < minimum:
+            print(f'::error::Score {score} is below minimum {minimum}')
+            sys.exit(1)
+        print(f'Score {score} passes minimum {minimum}')
+        "
 
     - name: Enforce dangling gate
       # Opt-in, and LAST: the comment above always posts first, then (only if the

--- a/action.yml
+++ b/action.yml
@@ -170,11 +170,24 @@ runs:
         # `format` line above follows and the `old-engine` self-test asserts.
         # Only vendor and line cross this boundary; the value never entered the
         # JSON in the first place (ADR 0014).
-        CREDENTIALS=$(echo "$RESULT" | python3 -P -c "
+        # Three states, never two. `MISSING` = a pinned pre-8.11 engine that
+        # never scanned (documented degradation, same contract the old-engine
+        # self-test asserts for check-commands). Empty = scanned, nothing found.
+        # A non-zero exit = could not evaluate, and that must fail the build:
+        # the previous `2>/dev/null || true` turned a malformed entry into an
+        # empty string, so a gate that could not run reported "all clear".
+        if ! CREDENTIALS=$(echo "$RESULT" | python3 -P -c "
         import sys, json
-        found = json.load(sys.stdin).get('credentials', []) or []
-        print(' '.join(f\"{c['vendor']}:{c['line']}\" for c in found))
-        " 2>/dev/null) || true
+        data = json.load(sys.stdin)
+        if 'credentials' not in data:
+            print('MISSING')
+        else:
+            found = data['credentials'] or []
+            print(' '.join('{}:{}'.format(c['vendor'], c['line']) for c in found))
+        "); then
+          echo "::error::Could not evaluate credential findings from the scorer output. Refusing to report a clean result."
+          exit 1
+        fi
         echo "credentials=$CREDENTIALS" >> "$GITHUB_OUTPUT"
         # The already-resolved absolute path — single source of truth so the
         # dangling step does not re-derive the default-to-AGENTS.md logic.
@@ -222,24 +235,6 @@ runs:
           " 2>/dev/null || true
         else
           echo "No dangling commands."
-        fi
-
-    - name: Fail on detected credentials
-      shell: bash
-      env:
-        CREDENTIALS: ${{ steps.score.outputs.credentials }}
-      run: |
-        # Categorical and unconditional: a leak does not compete with a score
-        # threshold, so this step carries no `if:` on minimum-score and cannot
-        # be tuned away (ADR 0011, ADR 0014). It runs before the threshold gate
-        # so the credential is the reported reason, not a score that happens to
-        # be low as well.
-        if [ -n "${CREDENTIALS}" ]; then
-          for finding in ${CREDENTIALS}; do
-            echo "::error::Credential detected: ${finding%%:*} at line ${finding##*:}"
-          done
-          echo "::error::Remove it from the instruction file and rotate the key."
-          exit 1
         fi
 
     - name: Check minimum score
@@ -411,6 +406,30 @@ runs:
           } catch (e) {
             core.warning(`Could not post the Schliff comment (likely a fork PR with a read-only token): ${e.message}`);
           }
+
+    - name: Fail on detected credentials
+      shell: bash
+      env:
+        CREDENTIALS: ${{ steps.score.outputs.credentials }}
+      run: |
+        # Categorical and unconditional: a leak does not compete with a score
+        # threshold, so this step carries no `if:` on minimum-score and cannot
+        # be tuned away (ADR 0011, ADR 0014).
+        #
+        # Placed AFTER "Comment on PR" deliberately. Inner steps of a composite
+        # action cannot carry continue-on-error, so the first non-zero exit stops
+        # the rest: gating earlier meant the contributor got a red check with no
+        # score comment at all - no dimensions, no dangling summary - on exactly
+        # the pull request that most needs reviewing.
+        if [ "${CREDENTIALS}" = "MISSING" ]; then
+          echo "::notice::The pinned schliff engine predates the credential gate; no scan was performed."
+        elif [ -n "${CREDENTIALS}" ]; then
+          for finding in ${CREDENTIALS}; do
+            echo "::error::Credential detected: ${finding%%:*} at line ${finding##*:}"
+          done
+          echo "::error::Remove it from the instruction file and rotate the key."
+          exit 1
+        fi
 
     - name: Enforce dangling gate
       # Opt-in, and LAST: the comment above always posts first, then (only if the

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.10.1.**
+**Current version: 8.11.0.**
 
 ## Understand the tool
 

--- a/docs/adr/0010-skillopt-import-scope.md
+++ b/docs/adr/0010-skillopt-import-scope.md
@@ -1,0 +1,62 @@
+# ADR 0010: Import three items from SkillOpt; reject the activation harness
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+`microsoft/SkillOpt` (MIT, audited 2026-08-06 at `9639719`) trains a skill document as the
+state of a frozen agent. A full read of the tree produced four candidate imports:
+
+- **F1** — the keep/revert gate in `auto-improve.py` accepts an edit when schliff's own
+  composite rises, the same rubric `text_gradient.py` inverted to generate that edit.
+- **F2** — `runtime-evaluator.py:54-69` embeds the skill as untrusted text inside a prompt.
+  There is no `--plugin-dir` and no skills-dir install anywhere under
+  `skills/schliff/scripts/`, so the skill is force-fed and selection never happens.
+  SkillOpt's `adapters/superpowers.py` instead clones a host at a pinned SHA, overlays the
+  candidate, and loads it through the real plugin bootstrap.
+- **F3** — `scoring/security.py` has negation- and code-block-awareness but zero credential
+  patterns. An instruction file with a live API key scores silently.
+- **F4** — `evolve/sanitize.py` bounds its GitHub token patterns at exactly 36 characters and
+  covers only `ghp_` (`:19`) and `gho_` (`:20`); SkillOpt uses `gh[pousr]_[A-Za-z0-9]{20,}`.
+  The ODBC `Pwd=` spelling is absent. *(Two earlier drafts overstated this gap. `AIza` and
+  `gho_` are already present at `sanitize.py:25` and `:20`; `Password=` is already redacted by
+  the generic assignment catcher at `:41`, which lists `password`/`passwd` in its name
+  alternation — executing the shipped `redact_secrets` on a connection string confirms it. The
+  verified residual delta is exactly: the `ghu_`/`ghs_`/`ghr_` prefixes, the exact-36 length
+  bound, and `Pwd=`.)*
+
+Three further candidates were checked and **refuted**: schliff's `command_resolution.py` is
+stricter than SkillOpt's `skill_resolver.py` (it refuses to claim absence without proof),
+`auto-improve.py:435` already handles the unmatched-edit case that SkillOpt needed two test
+files to fix, and `evolve/sanitize.py` already carries `sk-ant-`, which SkillOpt lacks.
+
+The standing constraint is Route B: schliff is maintained-but-parked, the demand bet was
+cashed RED on 2026-08-04, and no active user drives any of these requirements.
+
+## Decision
+
+Build F3, F1 and F4, in that order. Do not build F2.
+
+## Why
+
+The three survivors each have a justification that does not depend on user count. F3 protects
+against a harm that does not scale with adoption — a committed credential damages the one
+person who has it, immediately and irreversibly. F1 repairs a measurement that reports false
+wins, which is a defect in the core promise regardless of who is watching. F4 is a narrow
+correctness fix to patterns that already exist.
+
+F3 leads rather than F1 because `auto-improve` is not a subcommand of the shipped CLI — there
+is no hit in `cli.py` — and `/schliff:auto` is barred from unattended use until PR-B lands.
+The lying gate sits on a path nobody currently runs unsupervised, so its damage is
+hypothetical today. F3 sits on `score` and `verify`, which are the surfaces actually in use.
+
+## Rejected
+
+**F2, the activation harness.** It is not an import but a new subsystem: clone, pin, bootstrap,
+rule-based judges, evidence collection. It is the most expensive item, it introduces new attack
+surface (the evaluated agent gets Bash as the same OS user, so evidence is tamper-*evident*,
+not tamper-proof), and it introduces permanent maintenance load through a pinned host that
+goes stale. Under Route B none of that is honestly justifiable. The finding it rests on stands
+and is recorded — schliff's runtime evaluator measures a fragment, not the substrate — but
+recording a finding is not the same as funding its fix.

--- a/docs/adr/0011-credential-gate-is-score-neutral.md
+++ b/docs/adr/0011-credential-gate-is-score-neutral.md
@@ -2,6 +2,9 @@
 
 - Status: accepted
 - Date: 2026-08-06
+- Superseded in part by ADR 0019 on 2026-08-10: the gate-effective half is withdrawn — no
+  credential finding changes an exit code. Score-neutrality and its operative constraint (the
+  detector stays out of `scoring.security._CATEGORIES`) remain in force.
 
 ## Context
 

--- a/docs/adr/0011-credential-gate-is-score-neutral.md
+++ b/docs/adr/0011-credential-gate-is-score-neutral.md
@@ -1,0 +1,56 @@
+# ADR 0011: Credential detection is score-neutral and gate-effective
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+Adding credential detection to schliff raised an apparent binary: fold it into the security
+dimension so it affects the composite and therefore CI gates, or keep it purely informational
+so nothing breaks.
+
+Both branches are bad. schliff has **no rubric-versioning mechanism** — no `RUBRIC_VERSION`,
+nothing — so a score-affecting change has nothing to soften its landing. And the README
+publicly recommends pinning an absolute threshold in two places (`--min-score 75` in the CI
+recipe and the pre-commit hook), so a composite shift breaks advice schliff itself published.
+
+The purely informational branch is worse in a different way: `schliff verify AGENTS.md
+--min-score 75` would print the finding and **exit 0**. Detecting a credential and then
+waving it through the gate is the exact state the work was meant to end.
+
+## Decision
+
+Credential detection changes no score and no threshold. The composite is bit-identical before
+and after. `verify` exits non-zero when a credential is found, independently of `--min-score`.
+
+**The operative constraint:** the detector must stay out of `scoring/security.py`'s
+`_CATEGORIES`. A category there carries a penalty, and for `system_prompt` the security
+dimension is always-on and weighted 0.15 in the composite (`shared.py:224-228` skips the
+`include_security` gate for that format; `registry.py:29`). A `_CATEGORIES` entry would
+therefore move the system-prompt composite and break this ADR silently, on the one format
+where nobody would look for it.
+
+No opt-out flag ships.
+
+## Why
+
+The false binary dissolved once "score-affecting" and "gate-effective" were separated. A leak
+is not a quality deduction that belongs on the same scale as three missing trigger phrases —
+it is a categorical failure. Modelling it as a hard fail rather than a penalty gives the full
+protective effect at zero compatibility cost: badges, comparisons, the leaderboard shape and
+every pinned threshold behave exactly as before, so no rubric versioning is needed.
+
+The change is still breaking in behaviour — a green CI can turn red — but it fires only where
+a structurally valid vendor token is actually present, which is the correct build failure.
+
+## Rejected
+
+**Score-affecting.** Shifts every composite, invalidates pinned thresholds, and needs a
+versioning mechanism that does not exist. Buys nothing the hard fail does not already buy.
+
+**Purely informational.** Leaves the credential passing the gate. Detecting and permitting is
+worse than either extreme, because it produces the appearance of protection.
+
+**An `--allow-secrets` opt-out.** An escape hatch on a security gate becomes the default
+copy-paste line within a release or two. If a legitimate value trips the detector, that is a
+pattern bug to fix in the pattern, not a switch to hand the user.

--- a/docs/adr/0012-credential-discriminator-is-value-not-location.md
+++ b/docs/adr/0012-credential-discriminator-is-value-not-location.md
@@ -1,0 +1,68 @@
+# ADR 0012: A credential is identified by its value, not by where it sits
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+`scoring/security.py` carries two false-positive mitigations, and they work in **opposite
+directions** — a distinction an earlier draft of this ADR got wrong.
+
+The **code-block rule is opt-out**: `security.py:215` reads
+`if cat_name != "obfuscation" and _in_code_block(...)`, so every category is suppressed inside
+a fenced block and `obfuscation` alone is exempt.
+
+The **negation rule is opt-in**: `security.py:220` reads
+`if cat_name in _NEGATION_ELIGIBLE and _preceded_by_negation(...)`, and `:48` defines that set
+as `{"dangerous_cmd", "overpermission", "boundaries"}` — three of the six categories at
+`:29-36`. `injection`, `exfil` and `obfuscation` are all already negation-exempt, by absence
+from the set rather than by special case.
+
+The consequence for a new `credential` category: it inherits the code-block suppression
+automatically and would be blind exactly where keys live — `export ANTHROPIC_API_KEY=sk-ant-…`
+inside a setup snippet. It inherits **no** negation suppression, because it would not be in
+`_NEGATION_ELIGIBLE`. So the concern that *"**never** commit your `sk-ant-abc123…` key"*
+would be swallowed is unfounded; only the code-block rule needs an explicit exemption.
+
+## Decision
+
+Credential patterns are exempt from the code-block suppression, as `obfuscation` already is,
+and are kept out of `_NEGATION_ELIGIBLE` so no negation suppression applies. The detector
+scans the whole document.
+
+A finding carries the **vendor and the line number, never any character of the matched
+value** — see ADR 0014 for why that rule has to hold at the data-structure level rather than
+at each output site.
+
+A finding requires a **structurally valid vendor token**: the vendor prefix plus the exact
+shape that vendor issues — `AKIA` followed by 16 base32 characters, `gh[pousr]_` followed by
+at least 20, `sk-ant-` followed by at least 20, and so on. Placeholder shapes never fire:
+`sk-...`, `sk-xxx`, `<your-key>`, `${VAR}`, `sk-REPLACE_ME`, and anything already carrying a
+`[REDACTED…]` marker.
+
+## Why
+
+Location carries no information about whether a token is real; shape carries all of it. Moving
+the discriminator from position to value turns the false-positive question from a judgment
+call — "is this documentation or a leak?" — into a deterministic one — "is this a placeholder
+or a valid token?". Determinism is the property schliff sells, so this is the only form of the
+check that belongs in it.
+
+The base rate makes it safe: `AKIA` followed by exactly 16 base32 characters does not occur by
+accident in prose. SkillOpt's own patterns have the same property, and additionally carry
+`(?!\[REDACTED…\])` lookaheads — the same idea of excluding known-fake values.
+
+## Rejected
+
+**Inherit the code-block suppression.** Systematically skips the most likely location. The
+detector would be loudest where risk is lowest.
+
+**Add `credential` to `_NEGATION_ELIGIBLE`.** Would introduce a suppression that does not
+apply today, so that *"never commit your `sk-ant-…` key"* stops firing. The key is still in
+the file; the sentence around it does not change that.
+
+**Exempt from suppression with no value test.** Every document showing an example goes red.
+
+**Two severities, one for in-block and one for out-of-block matches.** Two severities mean two
+gate thresholds and an argument about which one turns the build red. Under a hard-fail gate
+(ADR 0011) exactly one class is wanted.

--- a/docs/adr/0012-credential-discriminator-is-value-not-location.md
+++ b/docs/adr/0012-credential-discriminator-is-value-not-location.md
@@ -2,6 +2,8 @@
 
 - Status: accepted
 - Date: 2026-08-06
+- Superseded by ADR 0020 on 2026-08-10: the premise below — *"shape carries all of it"* — is
+  refuted by measurement. The decisions in this ADR stand; only their stated reason does not.
 
 ## Context
 

--- a/docs/adr/0013-separate-pattern-sets-for-detection-and-redaction.md
+++ b/docs/adr/0013-separate-pattern-sets-for-detection-and-redaction.md
@@ -1,0 +1,77 @@
+# ADR 0013: Detection and redaction keep separate pattern sets
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+Two places in schliff match secret-shaped strings, and the obvious economy is to share one
+pattern set between them. They have opposite error costs:
+
+| | False positive | False negative |
+| --- | --- | --- |
+| **Redaction** (`evolve/sanitize.py`, before an outbound LLM call) | harmless — something that was not a secret gets masked in a prompt | the secret reaches the provider |
+| **Detection** (the credential gate) | breaks a third party's CI | a leak is missed |
+
+Redaction wants to be aggressive. Detection wants to be precise. One shared set can only be
+one of the two.
+
+The corpus decides the rest. schliff scores **instruction files**, not source trees, and
+instruction files legitimately carry git SHAs, UUIDs, base64 fragments and hashes. A generic
+"name looks secret-ish and value has high entropy" rule over that corpus is a false-positive
+machine, and under ADR 0011 a false positive turns somebody's build red.
+
+## Decision
+
+Two sets, in two files, each with a docstring naming its error-cost direction.
+
+Detection carries vendor prefixes with structural validation only. Redaction additionally
+carries the generic rules — the assignment-name heuristic at `sanitize.py:41`, which already
+subsumes `Password=` via its `password`/`passwd` alternation, plus the ODBC `Pwd=` spelling it
+does not yet cover.
+
+`Password=` and `Pwd=` belong to redaction alone. The audit spec had assigned them to
+detection; that was wrong. A later draft then listed `Password=` as something redaction still
+had to gain, which was also wrong — it is already there.
+
+## Why
+
+The asymmetry is not a detail to be smoothed over — it is the whole reason the two call sites
+exist. Encoding it as two files with two stated purposes makes the next pattern addition
+self-directing: whoever adds a rule reads the docstring and knows which side it belongs on.
+
+If `Pwd=` is adopted for redaction, carry SkillOpt's distinction with it: their pattern
+separates the ODBC `Pwd=` from the conventional all-caps `PWD` working-directory variable
+(`staging.py:144-150`).
+
+**ReDoS safety is proven by timing, not by the static heuristic.** An earlier draft required
+every adopted pattern to pass `validate_regex_complexity` (`shared.py:308`). That rule was
+wrong twice over. The validator's only production call sites are
+`runtime-evaluator.py:123` and `scoring/runtime.py:164`, both on assertion patterns supplied
+by an eval suite — it is a guard against *untrusted* regexes, not an authoring standard for
+first-party ones. And run over the 16 live `_SECRET_PATTERNS`, it fails one that already
+ships: `sanitize.py:24` (the private-key pattern) trips the nested-quantifier heuristic on
+`\s+(RSA\s+)?`. A rule that bars working production code to satisfy a heuristic has the
+causality backwards.
+
+First-party patterns in either set are therefore guarded by a **ReDoS timing test in the
+suite**: a pathological input of defined length must complete within a wall-clock bound. That
+measures the property that matters — catastrophic backtracking — instead of a textual
+resemblance to it, and it cannot produce a heuristic false positive. See
+`feedback_redos_untrusted_regex`: verify with a warm, equal-size timing discriminator.
+
+`validate_regex_complexity` keeps its existing job on eval-suite regexes, unchanged.
+
+SkillOpt's `_SECRET_VALUE` is a concatenated alternation; it is a reference, not something to
+paste, and would have to earn its place through the timing test like anything else.
+
+## Rejected
+
+**One aggressive shared set.** Detection inherits the generic rules and the false positives
+with them.
+
+**One precise shared set.** Redaction loses generic coverage and starts leaking values it used
+to mask — a regression in the direction where the cost is highest.
+
+**One set with a "high-precision" subset marker.** A convention inside a shared file drifts on
+the first addition by someone who did not read it. Two files with two docstrings hold longer.

--- a/docs/adr/0014-gate-surfaces-versus-reporting-surfaces.md
+++ b/docs/adr/0014-gate-surfaces-versus-reporting-surfaces.md
@@ -1,0 +1,74 @@
+# ADR 0014: Only gate surfaces change exit codes; reporting surfaces never do
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+ADR 0011 makes credential detection gate-effective. That raised the question of which commands
+the gate applies to, and the answer was not the obvious one.
+
+The GitHub Action **does not call `verify`**. It calls `schliff score --json` and implements
+its own threshold logic (`action.yml:93-95`), swallowing the exit code with `|| true`; a
+comment at `:115` notes only that its bands "stay aligned with `schliff verify`". A hard fail
+added to `verify` alone would therefore bypass the most-used CI surface entirely, and the
+Action would keep passing files containing live credentials.
+
+`action.yml:22-25` also shows `schliff-version` defaulting to `''` — latest. Action users
+receive new behaviour on their next run without changing anything. Pre-commit users are pinned
+by `rev:` and are not affected until they bump.
+
+## Decision
+
+Two gate surfaces: `verify` and the GitHub Action. Both exit non-zero on a credential finding.
+
+`score --json` carries the finding as a data field — it is the Action's only data source.
+
+`score`, `doctor`, `compare` and `report` display the finding and **never** change their exit
+code.
+
+**The finding carries the vendor and the line number. The matched value never enters the data
+structure at all.** Not truncated, not prefixed, not masked at the output site — absent. The
+transport is the reason: `action.yml:210` hands the entire score JSON to the comment step as
+`RESULT_B64`, so anything in that structure is already in the workflow's step outputs before
+any renderer decides what to print. Base64 there is shell safety, not secrecy, and the Action
+uses no `::add-mask::` anywhere. Enumerating output sites cannot work when the transport
+carries the whole object; keeping the value out of the object binds every site at once,
+including CI logs and the PR comment, with no list to maintain.
+
+## Why
+
+The split follows purpose, not convenience. `verify` and the Action exist to gate; changing
+their exit code is what they are for. The others exist to report, and a reporting command that
+starts exiting non-zero breaks every pipeline that legitimately just wants the number —
+including, concretely, `RESULT=$(schliff score …)` inside the very Action being protected.
+
+`doctor` deserves a note: it scans directories of skills that are usually not yours. Turning
+red on somebody else's file helps nobody, because you cannot fix it. Display is the right
+response there.
+
+This makes the work larger than it sounds, and it needs **two** proofs, not one — an earlier
+draft conflated them into a single unmeetable requirement.
+
+- **Before release:** a CLI test that `verify` exits non-zero on a credential fixture. This
+  runs against the working tree in the normal suite and proves the detector and the gate.
+- **After release:** a fixture in `action-selftest.yml` proving the Action propagates the
+  finding. It cannot run earlier: `action.yml:63` installs the engine with `pip install
+  schliff` from PyPI and every self-test job enters via `uses: ./`, so a fixture added in the
+  F3 PR would exercise 8.10.1 — which has no detector — and pass for the wrong reason. The
+  repo already documents this degradation mode in the `old-engine` job
+  (`action-selftest.yml:104-124`).
+
+The Action must also **contain the target path** before invoking schliff: it builds
+`SKILL_FULL="${GITHUB_WORKSPACE}/${INPUT_SKILL_PATH}"` and validates it with `[ ! -f ]`, which
+follows symlinks. See ADR 0016.
+
+## Rejected
+
+**`verify` only.** Leaves the Action unprotected, which is the surface most likely to be in
+use. Untenable once the `action.yml` call path was read.
+
+**Add `doctor`.** Red on files the operator cannot edit.
+
+**Every surface, including `score`.** Breaks the Action's own data collection and every script
+that reads the score.

--- a/docs/adr/0014-gate-surfaces-versus-reporting-surfaces.md
+++ b/docs/adr/0014-gate-surfaces-versus-reporting-surfaces.md
@@ -2,6 +2,9 @@
 
 - Status: accepted
 - Date: 2026-08-06
+- Superseded in part by ADR 0019 on 2026-08-10: the gate-surface list is empty — neither
+  `verify` nor the Action changes its exit code. The finding-payload rule (vendor and line, never
+  the value) and the reporting-surface rule remain in force, the latter now universally.
 
 ## Context
 

--- a/docs/adr/0015-gradients-apply-only-to-their-target.md
+++ b/docs/adr/0015-gradients-apply-only-to-their-target.md
@@ -1,0 +1,86 @@
+# ADR 0015: A gradient is applied only to the file it targets
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+`auto-improve.py` accepts an edit when schliff's composite rises. The composite is produced by
+the same rubric `text_gradient.py` inverts to generate the edit, so the loop grades its own
+homework. The proposed fix was a train/val split of `eval-suite.json`, imported from
+SkillOpt's `consolidate.py:54-90`.
+
+Two earlier drafts of this ADR got the diagnosis wrong, in opposite directions. The first said
+a split was enough. The second said the loop *rewrites the exam it is measured against* — and
+that is not supported by the code. There is no write path: every writer in the loop targets
+`skill_path` alone (`text_gradient.py:845`, `auto-improve.py:424/474/493`), and the only
+writer of `eval-suite.json` anywhere under `skills/schliff/scripts/` is `init-skill.py:898`,
+driven by `/schliff:init`. `auto-improve.py` mentions `claude -p` in its docstring but makes
+no such call.
+
+What the code does support is narrower and sharper. **Eleven** gradients carry
+`"target": "eval-suite.json"` — lines 155, 368, 382, 393, 404, 415, 435, 453, 467, 480, 491 —
+spanning **three** dimensions: `triggers`, `quality` (`:359-360`, *"targets eval-suite.json,
+not SKILL.md"*) and `edges` (`:427`), the last two called together at `:612-613`.
+
+And **`generate_patches` never looks at `target`**. Its filter is
+`if g.get("confidence") != "high" or g.get("effort", 2) > EFFORT_SIMPLE: continue` — confidence
+and effort only. Two of the eleven already satisfy it: `:480` and `:491`, both `dimension:
+edges`, `op: add`, with instructions such as *"Add assertions to all edge cases in
+eval-suite.json"*. They produce no patch today **only because `generate_patches` has no branch
+for their issue strings** — an accident of handler coverage, documented nowhere as a guard.
+
+So a file-A instruction sits one handler away from being handed to a patcher that only knows
+file B (`apply_patches(skill_path, patches)`).
+
+Suite sizes are a separate constraint, and there are three populations. The shipped
+`skills/schliff/eval-suite.json` holds 44 `triggers`, 4 `test_cases` and 14 `edge_cases`. A
+22/22 split on triggers is meaningful and a 7/7 split on edge cases is workable; a 2/2 split on
+test cases is not.
+
+## Decision
+
+**A gradient is only ever applied to the file its `target` names.** `generate_patches` gains a
+target check alongside its confidence and effort filter; a gradient aimed at anything other
+than the file being patched is passed through as a manual suggestion and never turned into a
+patch.
+
+Separately, and on its own merits: a train/val split where the case count supports it, and an
+explicit leak flag where it does not — reporting "this comparison carries no information"
+instead of a clean win.
+
+## Why
+
+The guard belongs at the filter because that is where the defect is. A policy of the form
+"eval-suite gradients are never auto-applied" describes one symptom of a filter that is missing
+a dimension; a target check closes the class — for every handler someone adds later, and for
+every future gradient that happens to be high-confidence and simple-effort. It is also
+smaller: one condition next to two that already exist.
+
+The current safety is an accident. Nothing in the code says "these two must not be patched";
+they are inert because nobody wrote the branch that would make them active. Relying on that is
+relying on a gap staying open.
+
+The split stands on its own. It raises the signal where enough cases exist, and the leak flag
+is what replaces it on a 4-case suite: naming a 2-versus-2 comparison as uninformative is the
+honest output, and silently reporting a delta from it is its own defect.
+
+## Rejected
+
+**A "never auto-apply eval-suite gradients" policy.** Fixes the two known instances and leaves
+the filter blind. The next gradient with `high`/`simple` and a foreign target is unprotected
+again.
+
+**Split only** — the original spec proposal. It defends against overfitting to a fixed set and
+says nothing about a gradient reaching the wrong file.
+
+**Rely on the existing behaviour.** The two qualifying gradients already produce nothing.
+But they are stopped by a missing handler, not by a rule, and `auto-improve.py:435` (`applied
+== 0` → skip) would quietly absorb a patch that matched nothing rather than report a gradient
+aimed at the wrong file.
+
+**Drop the suite-measuring dimensions from the gate entirely** — `triggers`, `quality` and
+`edges`, all three. They measure the suite rather than the skill, so the reasoning is tempting
+— but removing dimensions changes the composite definition, which is precisely the
+compatibility break ADR 0011 was designed to avoid. It would also be mislabelling: the
+dimensions stay in the published score either way.

--- a/docs/adr/0016-credential-scan-runs-on-raw-bytes.md
+++ b/docs/adr/0016-credential-scan-runs-on-raw-bytes.md
@@ -1,0 +1,109 @@
+# ADR 0016: The credential scan runs always-on, on the raw bytes of the real file
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+Two facts about the current scoring path decided where this check can live.
+
+**The security dimension is opt-in — for most formats.** `shared.py:250` skips it unless
+`include_security` is set. Placing credential detection inside `score_security` would mean it
+never runs in a plain `schliff score --json` — which is exactly the call the GitHub Action
+makes (`action.yml:93`), silently defeating ADR 0014.
+
+The exception matters: `shared.py:224-228` returns early for `system_prompt` and never
+consults `include_security` at all, while `registry.py:29` lists `security` in that format's
+scorer set at weight 0.15. For system prompts the dimension is therefore **always-on and
+inside the composite**. So the naive placement fails in both directions at once — invisible
+for the `AGENTS.md` family, and score-moving for system prompts.
+
+**Scorers do not see the user's file.** `shared.py:232-241` normalizes every format except
+`skill.md`, writes the result to a temp file, and reassigns `skill_path = tmp_path` with the
+comment *"scorers now see normalized content"*. For `AGENTS.md`, `CLAUDE.md` and
+`.cursorrules` the scorer therefore reads a temp file with synthetic frontmatter prepended.
+The comment block at `:212-220` records that this seam already caused two real scoring bugs —
+issue #168 and a 4.7–5.5 point inflation on frontmatter-less files.
+
+SkillOpt's own fix history is dominated by one class: `redact before clipping`,
+`measure refusal length after markdown stripping`, `strip refusal markers before bounding the
+head`, `detect markdown-formatted refusals`, `compare dispatched store against the normalized
+config value`, `share one char-bound parser between miner and validator`. Six commits, one
+lesson: detection run over transformed text misses.
+
+## Decision
+
+Credential detection is its own always-on check, independent of the security dimension. It
+reads the **raw bytes of the file the user named**, before `normalize_content` and before the
+temp file exists.
+
+**Containment is enforced at the trust boundary, which is the Action — not in the library.**
+Before invoking schliff, the Action verifies that **every path it hands to schliff** resolves
+inside `realpath("$GITHUB_WORKSPACE")`, and aborts otherwise. That is `$SKILL_FULL` *and*
+`$EVAL_PATH` — the latter is built at `action.yml:90` and passed at `:93` today with neither a
+`[ -f ]` test nor a resolve check. `read_skill_safe` keeps its documented symlink-following
+behaviour unchanged.
+
+**Second named limit:** even with both Action paths contained, `shared.py:171-177`
+auto-discovers `skill_dir/eval-suite.json` and reads it with no containment guard. Inside a
+contained skill directory that is reachable only via a symlinked `eval-suite.json` sitting
+next to the skill file. Closing it belongs to the eval-suite loading path, not to this ADR,
+and it is recorded here so the gap is not mistaken for covered.
+
+No `--repo-root` flag ships.
+
+**Named limit:** hand-rolled CI that calls `schliff verify` directly on a fork pull request,
+without the Action, does not get this containment. That is a real gap and it is stated here
+rather than papered over.
+
+## Why
+
+Three reasons, and the third is why this is the one place the risk was not worth taking.
+
+**Detect before you transform.** This is SkillOpt's most-repeated correction. Searching
+transformed text means searching something the user never wrote.
+
+**Line numbers must be true.** A finding reported against the temp file points at a line
+number shifted by the injected frontmatter. A security finding at the wrong position is worse
+than none — it sends the reader to the wrong line and costs trust on the first encounter.
+
+**This seam is empirically fragile here.** It has already corrupted schliff's own scores twice,
+by the repo's own record. Hanging a hard-fail gate on it is the specific gamble to decline.
+
+Consistency with the other scorers is not a virtue in this case. The others *assess structure*;
+this one *finds a fact*.
+
+**On containment.** A raw read of an attacker-nameable path in CI is an out-of-repo oracle,
+and a credential detector is a strictly stronger one than a score: it answers *"is there a key
+at this path"* about the runner's filesystem. `action.yml:78-79` validates the target with
+`[ ! -f "$SKILL_FULL" ]`, which dereferences symlinks, and `read_skill_safe` follows them
+deliberately (`shared.py:86-90`) — for good reasons that have nothing to do with CI: dotfile
+managers, `claude --worktree`, shared `~/.claude/skills` layouts. schliff already defends this
+exact class elsewhere: `command_resolution.py:76-81` guards every manifest read with
+`_contained`, commented as preventing *"an out-of-repo content/existence oracle when the check
+runs on an attacker's repo in CI"*.
+
+The oracle requires both an attacker-controlled path and attacker-visible output. In the
+Action both hold; locally neither does — you scan your own files and read your own output. So
+the guard belongs where the trust actually changes, and there it costs a `realpath` comparison
+in shell before the process starts. Putting it in the library would either break the symlink
+support that local users depend on, or need a root that local invocation has no way to define.
+
+## Rejected
+
+**Inside `score_security`.** Inherits the opt-in gate, so it never runs by default and ADR 0014
+becomes a no-op.
+
+**Inside `score_security`, with the dimension forced always-on.** Changes default behaviour and
+the composite for everyone — the break ADR 0011 was built to avoid.
+
+**Own check, but over normalized content.** Buys alignment with the other scorers and pays for
+it with wrong line numbers and exposure to the seam that has already failed twice.
+
+**Reject symlinks outright for the scan.** Closes the oracle, and breaks stow, chezmoi and
+`claude --worktree` users locally — where no oracle exists in the first place.
+
+**Containment in the library, behind a `--repo-root` flag.** Would also cover hand-rolled CI.
+Rejected because a security control that only works when the operator knows to switch it on is
+the same failure shape as the opt-out flag ADR 0011 declined, with the sign reversed: anyone
+who has not heard of the flag is unprotected and has no way to notice.

--- a/docs/adr/0017-score-neutral-changes-ship-as-minor.md
+++ b/docs/adr/0017-score-neutral-changes-ship-as-minor.md
@@ -1,0 +1,66 @@
+# ADR 0017: Score-neutral behaviour changes ship as a minor release
+
+- Status: accepted
+- Date: 2026-08-06
+
+## Context
+
+The credential gate introduces a new failure condition: a build that is green today can turn
+red tomorrow. `action.yml:22-25` shows `schliff-version` defaulting to `''`, so Action users
+pick up the change on their next run without acting. Pre-commit users are pinned through
+`rev:` and move only when they bump.
+
+That looks like grounds for a major. It is not, because of what the change deliberately does
+not touch.
+
+## Decision
+
+Ship as **8.11.0**, a minor. Three separate pull requests — F3 (the gate), F1 (the gradient
+target check and the split), F4 (the redaction patterns) — landing in one release.
+
+The policy this sets: score-neutral changes ship as minors; a change that moves the composite
+would be a major.
+
+Required alongside the release:
+
+- a CHANGELOG entry under an explicit **BREAKING BEHAVIOUR** heading, not under *Added*
+- a CLI test proving the red path: `verify` exits non-zero on a credential fixture. The
+  matching `action-selftest.yml` fixture is a **post-release follow-up** and cannot be part of
+  this release — see ADR 0014 for why
+- the README pinning recommendation raised to the new version
+- the **three version constants** moved in lockstep, since
+  `tests/unit/test_version_consistency.py` asserts all three are equal and fails the build
+  otherwise: `pyproject.toml:7`, `.claude-plugin/plugin.json:3`, and
+  `skills/schliff/__init__.py:3` — the last is the value `schliff version` actually prints
+  (`cli.py:1009`, reading `__version__` per `cli.py:41`), and an earlier draft omitted it
+- separately, the **README/docs occurrences** including the badge cache-bust. These are
+  cosmetic and untested, which is why they are not one of the three constants
+
+## Why
+
+ADR 0011 made the gate score-neutral precisely so the version contract would survive it.
+Composites, badges, comparisons and every pinned `--min-score` threshold behave identically
+before and after. What changes is one narrow failure condition that fires only where a
+structurally valid vendor token is present — and there, a red build is the correct answer, not
+a contract violation.
+
+New detection rules in minor releases is the established convention for linters; Ruff ships
+them the same way. A major would signal that scores or interfaces moved, provoking exactly the
+migration anxiety that score-neutrality was chosen to avoid.
+
+The CHANGELOG heading carries the honesty the version number does not. Filing a new red-build
+condition under *Added* would be the mislabelling this project's conventions exist to prevent.
+
+Three PRs rather than one because the gate — with its Action change and self-test fixture —
+needs a fundamentally different review from a regex addition in `evolve/sanitize.py`.
+
+## Rejected
+
+**Major 9.0.0.** Signals a score or interface break that did not happen, and invites everyone
+to audit a migration that consists of nothing.
+
+**One combined PR.** Bundles an unrelated regex change into a review that should concentrate on
+a security gate and a CI surface.
+
+**Three separate releases.** Three lockstep version bumps and three badge cache-busts for two
+internal changes nobody can observe from outside.

--- a/docs/adr/0018-one-branch-with-separated-commits.md
+++ b/docs/adr/0018-one-branch-with-separated-commits.md
@@ -1,0 +1,50 @@
+# ADR 0018: F3, F1 and F4 ship on one branch with separated commits
+
+- Status: accepted · supersedes the pull-request split in ADR 0017
+- Date: 2026-08-07
+
+## Context
+
+ADR 0017 decided "three separate pull requests — F3 (the gate), F1 (the gradient
+target check and the split), F4 (the redaction patterns) — landing in one release",
+reasoning that a security gate with an Action change needs a different review from a
+regex addition in `evolve/sanitize.py`.
+
+The work is now done and that reasoning has not survived contact with it. The three
+items turned out to share a spine rather than sit side by side: F4's real gap was only
+visible once F3's detector forced the distinction between a precise detection set and an
+aggressive redaction set (ADR 0013), and F1's target guard is what makes F3's
+"score-neutral" claim checkable at all, because a gradient that reaches the wrong file
+can move a score no gate is watching. Split across three pull requests, each reviewer
+would see a third of the argument.
+
+The rest of ADR 0017 is unaffected: still one minor release, still 8.11.0, still
+score-neutral, still a CHANGELOG entry under BREAKING BEHAVIOUR.
+
+## Decision
+
+One branch, `docs/skillopt-import-adrs`, with one commit per item and a commit message
+that carries that item's reasoning. The version bump stays out of it: this repo does the
+bump as its own `chore(release):` commit touching `pyproject.toml`,
+`.claude-plugin/plugin.json`, `skills/schliff/__init__.py`, `README.md`, `docs/README.md`
+and the CHANGELOG, which is a release step rather than a feature step.
+
+## Why
+
+The unit a reviewer needs is the argument, not the file. Six commits on one branch put
+the decisions and the code that implements them in one place, in order, and each commit
+message states what the red test proved before the fix existed. That is a better review
+artifact than three pull requests that each open mid-sentence.
+
+It also matches how the decisions were actually made — as one chain, revised twice by
+adversarial review — rather than pretending they were three independent pieces of work.
+
+## Rejected
+
+**Three pull requests, as ADR 0017 decided.** Splits an argument that reads as one, and
+would land F4 as an isolated regex change whose justification lives in a different pull
+request.
+
+**One pull request with one squashed commit.** Loses the per-item reasoning, which is the
+part worth keeping — several of these commits record a test that passed for the wrong
+reason before it was rewritten.

--- a/docs/adr/0019-credential-detection-reports-it-does-not-gate.md
+++ b/docs/adr/0019-credential-detection-reports-it-does-not-gate.md
@@ -1,0 +1,105 @@
+# ADR 0019: Credential detection reports; it does not gate
+
+- Status: supersedes ADR 0011, ADR 0014
+- Date: 2026-08-10
+
+## Context
+
+ADR 0011 made credential detection gate-effective with no opt-out, and ADR 0014 named the two
+surfaces that would carry the hard fail: `verify` and the GitHub Action. Both decisions were
+sound *given* ADR 0012's premise that a token's shape separates a real credential from a
+documentation placeholder. That premise is refuted; ADR 0020 records the measurement.
+
+What remains is a classification the detector cannot make. Every narrowing produces a false
+negative on a security gate, and every widening turns a third party's green build red. Three
+review passes produced ten confirmed findings each, and the majority of each pass were
+regressions from the previous pass's fixes — the errors move rather than disappear. That is
+what an undecidable classification looks like from the inside, not a tuning problem.
+
+Two facts decide how much that costs. `action.yml:22-25` defaults `schliff-version` to latest,
+so Action users receive the behaviour on their next run without acting. And a false positive is
+unfixable by the person it hits: they do not control schliff's release cycle and, under ADR
+0011, have no flag, threshold or suppression to reach for.
+
+A field measurement over this machine's real files makes it concrete. Across 128 instruction
+files — the detector's actual target population — the scan produces **no findings at all**.
+Across 601 documentation files it produces **11, every one of them documentation about
+credentials**: a plan document listing secret-masking test fixtures, and schliff's own decision
+brief. Zero real keys. A gate would have fired only where it was wrong.
+
+## Decision
+
+**No credential finding changes any exit code.** `verify` and the Action report it; neither
+gates on it.
+
+The Action keeps its step, downgraded to `::warning::` with the `exit 1` removed. Its `MISSING`
+branch stays: a pinned pre-8.11 engine still says that no scan was performed rather than
+implying a clean result.
+
+**No opt-in flag ships.** A caller who wants enforcement reads the `credentials` field from
+`score --json`, which is already the Action's own data source.
+
+The fail-closed path in `verify` — exit 2 on a file that could not be read — is removed. It was
+a gate stance: refusing to pass what could not be checked only makes sense while checking gates
+something. Without it, failing a build because the tool could not look, while passing a file
+that contains a real key, is incoherent. `credentials: null` survives as the third state, so
+"could not look" is still never rendered as "clean"; `doctor` already holds that contract.
+
+**What stays in force from ADR 0011:** score-neutrality, and its operative constraint. The
+detector must never enter `scoring.security._CATEGORIES` — for `system_prompt` that dimension
+is always-on and weighted 0.15, so an entry there would move a published composite silently.
+
+**What stays in force from ADR 0014:** the finding payload rule — vendor and line number, the
+matched value never in the data structure — and the rule that reporting surfaces do not change
+exit codes, which is now simply universal. The gate-surface list is empty.
+
+The post-release proof in `action-selftest.yml` becomes a **green**-path fixture: a file with a
+vendor token must leave the job green and produce the warning annotation. It still cannot run
+before release, for the reason ADR 0014 gave — `action.yml:63` installs the engine from PyPI.
+
+## Why
+
+The benefit that survives the refutation is the finding itself, and a report keeps all of it.
+What a gate adds on top is the one property an undecidable classification must not have: the
+power to break work that is not wrong.
+
+The inversion is asymmetric, and that settles the direction of travel. Promoting a report back
+to a gate is a minor release (ADR 0017) the day a precise discriminator exists. Retracting a
+gate that has already turned other people's builds red is not — it costs the trust that made
+anyone install a linter that grades their files in the first place.
+
+ADR 0010 justified F3 on the grounds that *"a committed credential damages the one person who
+has it, immediately and irreversibly"* — a harm that does not scale with adoption. That
+argument survives the refutation intact, and it argues for reporting rather than for dropping
+the feature: the person who needs to see the finding is the author, who is looking at the
+output either way.
+
+The counter-argument is real and is recorded here rather than answered away: a detector that
+misses real keys offers false assurance, and false assurance can be worse than none. Two things
+bound it. The finding is never presented as a clearance — schliff says what it found, never
+that a file is clean — and ADR 0020 documents the miss classes in the CHANGELOG rather than in
+a comment nobody reads.
+
+Route B — maintained-but-parked, 12 stars, the demand bet cashed RED on 2026-08-04 — decides
+the remaining margin. Every option that keeps the gate needs machinery (a baseline file, a
+resolution path, a staleness story) that ADR 0010 declined on a project with more users than
+this one has.
+
+## Rejected
+
+**Keep the gate, add a baseline or allowlist file.** How real scanners handle exactly this, and
+it accepts precisely the apparatus ADR 0010 rejected. It also reopens ADR 0011's "no opt-out"
+decision under another name: an allowlist is an opt-out with a file format attached.
+
+**Drop F3 entirely.** Honest — schliff would stop claiming a capability it cannot deliver
+deterministically — but it throws away a finding that is correct whenever it fires on a real
+key, and ADR 0010's harm argument is unaffected by the refutation.
+
+**An opt-in `--fail-on-credentials` flag.** Structurally different from the opt-out ADR 0011
+declined, since its default is safe. Still rejected: nobody asked for it, it is a permanent
+promise on a parked project, and the caller who wants it already has three lines of `jq`
+against `score --json`.
+
+**Keep the gate and keep tuning the patterns.** This is what the three review passes already
+were. A defect count that does not fall across rounds is a statement about the design, not an
+invitation to a fourth round.

--- a/docs/adr/0020-shape-does-not-separate-a-credential-from-a-placeholder.md
+++ b/docs/adr/0020-shape-does-not-separate-a-credential-from-a-placeholder.md
@@ -34,6 +34,11 @@ instruction files: no findings. In 601 documentation files: 11 findings, **all o
 documentation about credentials**, none of them a real key. The detector's observed behaviour in
 the wild is to fire on people writing about secrets.
 
+Re-running it after this ADR was written makes the point better than the numbers do: the file
+you are reading is documentation about credentials, and it now contributes seven findings of its
+own. Counts reproduced later will therefore exceed the ones above, and for exactly the reason
+this ADR gives.
+
 ## Decision
 
 **The premise is withdrawn.** Shape establishes that a string *could* be a credential of a given

--- a/docs/adr/0020-shape-does-not-separate-a-credential-from-a-placeholder.md
+++ b/docs/adr/0020-shape-does-not-separate-a-credential-from-a-placeholder.md
@@ -1,0 +1,108 @@
+# ADR 0020: Shape does not separate a credential from a placeholder
+
+- Status: supersedes ADR 0012
+- Date: 2026-08-10
+
+## Context
+
+ADR 0012's `## Why` opens with the sentence the whole design rested on:
+
+> Location carries no information about whether a token is real; shape carries all of it.
+
+The first half is right. The second is false, and it is false in the simplest possible way:
+`AKIA1234567890ABCDEF` and `AKIAJ7QRTUVWXY3BCDEF` are structurally identical and both satisfy
+every rule ADR 0012 specifies. One belongs in a README, the other is a credential. Nothing in
+the shape tells them apart, because a documentation placeholder is written by someone imitating
+the shape on purpose.
+
+Measured against `scoring/credentials.py` as it stood on `0751e45`:
+
+| Input | What it is | Gate |
+| --- | --- | --- |
+| `sk-proj-Ab3d-Kf9LmQ2xR7tYu1VwZ0nBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef` | **real** OpenAI project key | **silent** |
+| `AKIA0000TUVWXY3BCDEF` | **real** AWS key | **silent** |
+| `AKIA1234567890ABCDEF` | documentation placeholder | **fires** |
+| `ghp_abcdefghijklmnopqrstuvwxyz012345` | documentation placeholder | **fires** |
+
+The same input set, answered the opposite way round from the intent. The placeholder heuristic
+— `_PLACEHOLDER_MARKERS` plus a run of four identical characters — was the patch for the gap,
+and it fails in both directions at once: it eats a real key containing `0000`, and it passes any
+dummy that avoids its marker words.
+
+A field run over this machine's real files sharpens the picture rather than softening it. In 128
+instruction files: no findings. In 601 documentation files: 11 findings, **all of them
+documentation about credentials**, none of them a real key. The detector's observed behaviour in
+the wild is to fire on people writing about secrets.
+
+## Decision
+
+**The premise is withdrawn.** Shape establishes that a string *could* be a credential of a given
+vendor. It establishes nothing about whether it is one.
+
+ADR 0012's operative decisions are unchanged and stay in force, because none of them depended on
+the withdrawn sentence: credential patterns remain exempt from the code-block suppression, stay
+out of `_NEGATION_ELIGIBLE`, carry vendor and line only, and still require a vendor prefix plus
+that vendor's issued shape before anything is reported at all.
+
+What changes is the calibration, now that ADR 0019 has made a false positive cost a line of
+output rather than someone's build:
+
+- **The repeated-run heuristic is removed.** It suppressed real keys — `AKIA0000TUVWXY3BCDEF` is
+  a legal AWS key — to catch placeholders that spell themselves with `AAAA`.
+- **Marker words stay.** `example`, `your`, `replace`, `redacted` and the rest are the cheapest
+  true signal available: a real key does not contain them, and they silence AWS's own published
+  `AKIAIOSFODNN7EXAMPLE`, which appears in real instruction files.
+- **Hyphens are allowed in the OpenAI body behind a known key prefix** (`sk-proj-`,
+  `sk-svcacct-`, `sk-admin-`) and nowhere else. This is the form OpenAI has issued since 2024;
+  allowing them after a bare `sk-` would fire on kebab-case prose such as
+  `sk-add-credential-scanning-to-verify`, which already broke a third party's build once.
+- **No JWT pattern, and no entropy scoring.** ADR 0012's reasoning holds without the gate: the
+  jwt.io sample and Supabase's `anon` key are public by design and a service key is
+  structurally identical to both.
+
+The term **structurally valid vendor token** keeps its name and loses half its meaning: it
+asserts form, never authenticity. `docs/specs/glossary.md` is corrected accordingly.
+
+## Why
+
+The measurement is not a bug report against the patterns; it is a statement about the class. A
+placeholder is an imitation of a real key, authored by someone who wants it to look real. Any
+test that separates them has to read something other than the string — entropy against a
+corpus, a live call to the vendor, a baseline of known-accepted values. Those are what real
+secret scanners are, and ADR 0010 declined that apparatus deliberately.
+
+Removing the heuristic is a genuine trade and the evidence for it is thin in both directions:
+in the field it suppressed exactly one documentation placeholder, and in the brief it
+suppressed exactly one real key. One case each is a coin toss, not a calibration. The
+tie-breaker is the cost asymmetry ADR 0019 created — a missed key is the expensive error now,
+a noisy line is not — and the same asymmetry that ADR 0013 already established for redaction,
+with the sign matching for the first time.
+
+The field number belongs in the record precisely because it is unflattering: every finding this
+detector produced on real files was documentation. It is the reason the CHANGELOG documents the
+limitation instead of announcing a security feature, and the reason the honest description of
+this component is "a report that sometimes helps", not "a scanner".
+
+No further tuning round follows this one. Three passes produced ten findings each, most of them
+regressions from the previous pass's fixes; a defect count that does not fall is a design
+signal, and the design answer was ADR 0019.
+
+## Rejected
+
+**Leave the patterns as they are.** Minimal change, and it ships a report that answers two of the
+four measured cases wrongly — including the direction where a real key goes unseen. The honesty
+gap the decision was meant to close would survive, only more quietly.
+
+**Widen to JWTs and generic high-entropy strings.** Maximum recall, and it fires on every
+Supabase `anon` key and every published example token. A report people learn to ignore is worth
+less than no report.
+
+**Narrow to the unambiguous classes only** — `AKIA`, `gh[pousr]_`, `AIza`. Clean, and it drops
+`sk-` entirely: the most common key class in exactly the Claude and OpenAI instruction files
+schliff is written for.
+
+**Replace the run heuristic with a run-*count* heuristic** — suppress only when several repeated
+runs occur. It separates all five cases in hand (a real key had one run, the placeholder seven).
+Rejected because five cases are not a calibration set, and because the previous three passes
+were each a plausible refinement of this same heuristic. The pattern of that failure is the
+reason to stop refining it, not to refine it once more.

--- a/docs/specs/2026-08-06-skillopt-import-audit.md
+++ b/docs/specs/2026-08-06-skillopt-import-audit.md
@@ -1,0 +1,186 @@
+# What schliff should take from microsoft/SkillOpt — and what it must not
+
+**Status:** resolved by grilling, 2026-08-06 · **Branch:** — · **Audited:** 2026-08-06, `main` at `1893358`
+**Source:** `microsoft/SkillOpt` @ `9639719` (MIT, Microsoft Corp. 2026), full read of the tree
+
+> **Superseded in several places**, by a grilling session and two adversarial review passes on
+> 2026-08-06. Refuted: the F1 fix (neither a split nor a read-only policy — the defect is that
+> `generate_patches` never checks `target`, ADR 0015), the F3 placement (*"reusing the existing
+> machinery"* would build a blind detector — ADR 0012, ADR 0016), the F3 open decision
+> (non-scoring first was the wrong frame — ADR 0011), and two thirds of the F4 gap inventory
+> (`AIza`, `gho_` and `Password=` were already shipped — ADR 0010). The corrections are inline
+> below. Decisions of record: **ADR 0010–0017**. Vocabulary: `docs/specs/glossary.md`.
+> Final scope: **F3 → F1 → F4, F2 rejected**, shipping as 8.11.0.
+>
+> Both review passes ended at the round cap rather than converging, with roughly 25 unverified
+> candidates each. These documents are more correct than they were; they are not proven correct.
+
+Second-pass audit. The first pass looked at the training loop; this one covers security,
+robustness, and the two places SkillOpt touches schliff's own domain. Every candidate was
+checked against schliff's actual code before it was kept.
+
+## Refuted — do not import these
+
+Three obvious-looking imports are already covered, better, in schliff. Recorded so they
+are not proposed again.
+
+| SkillOpt offers | schliff already has | Verdict |
+| --- | --- | --- |
+| `skillopt_sleep/skill_resolver.py` — resolve skill name, states `found/missing/ambiguous/rejected` | `scoring/command_resolution.py` — three-state with **"anything unprovable is `unknown`, never `dangling`"** (`:11-13`), symlink containment `_contained` (`:76-88`), unresolved-include tracking | schliff is **stricter**. It refuses to claim absence without proof; SkillOpt has no such rule. |
+| `optimizer/skill.py:apply_patch_with_report` — per-edit applied/unmatched status (2 dedicated test files) | `text_gradient.py:845 apply_patches` returns `applied/skipped/errors`; `auto-improve.py:435` explicitly skips when `applied == 0` | Already covered. No latent "unmatched edit counted as applied" bug. |
+| `skillopt_sleep/staging.py:_SECRET_PATTERNS` — redaction before writing artifacts | `evolve/sanitize.py:12-26` — 7 patterns incl. `sk-ant-` (which SkillOpt **lacks**) | Not a gap. See F4 for the narrow real delta. |
+
+## F1 — `auto-improve.py` gates on the rubric that produced the edit
+
+The loop accepts a change when schliff's **own composite** rises (`auto-improve.py:1-20`,
+`:427-471`). That composite is the same rubric `text_gradient.py` inverted to generate the
+change. There is no held-out set, so a reported "+3.5 composite" can be the rubric agreeing
+with itself.
+
+schliff already knows this: `runtime-evaluator.py:5-7` says *"scoring measures file patterns,
+not runtime behavior. The runtime evaluator bridges that gap."* The evaluator exists but is
+not wired to the keep/revert decision.
+
+**CORRECTED TWICE — the split is not the fix, and neither is a read-only policy.** An earlier
+correction claimed the loop rewrites the exam it is measured against; the code does not support
+that, since no writer in the loop touches `eval-suite.json` (the only one anywhere is
+`init-skill.py:898`, driven by `/schliff:init`). The real defect is that **`generate_patches`
+filters on confidence and effort and never on `target`**, while eleven gradients target
+`eval-suite.json` and `apply_patches` only ever writes `skill_path`. Two of those eleven
+(`:480`, `:491`) already pass the filter and are inert only because no handler exists for their
+issue strings.
+
+**Fix (per ADR 0015):** a target check in `generate_patches` — a gradient is applied only to the
+file its `target` names. The split is a separate, still-valid measurement decision.
+
+- `eval-suite.json` gains a per-case `split` field (`train` | `val` | `test`); gradients come
+  from `train`, the gate reads `val`.
+- Where the case count cannot carry a split, the report **says so**. Real suites hold 44
+  `triggers` (22/22 meaningful) and 14 `edge_cases` (7/7 workable) but only 4 `test_cases`
+  (2/2 is not).
+- Reference: `skillopt_sleep/consolidate.py:54-90` (`_split` returns `holdout_leaked`) and the
+  pure decision function in `skillopt_sleep/gate.py`. Deterministic, netzfrei, zero new deps.
+
+## F2 — the runtime evaluator tests a fragment, not the substrate
+
+`runtime-evaluator.py:54-69` embeds the skill as **untrusted text inside a prompt**, wrapped
+in a nonce tag. It never installs the skill or loads it through an activation path — there is
+no `--plugin-dir` and no skills-dir install anywhere in `skills/schliff/scripts/`.
+
+That measures "does the model answer well when handed this text". It cannot measure "does
+this skill get selected and behave" — the skill is force-fed, so selection never happens.
+This is the failure recorded in `feedback_probe_against_original_substrate` and the CLAUDE.md
+rule *"Modell-/Agent-Inputs mit dem ECHTEN Agent testen"*.
+
+**Import:** the harness shape from `skillopt_sleep/adapters/superpowers.py:1-18` — clone a
+host at a **pinned SHA** into a temp workspace, overlay the candidate skill, load it through
+the **normal plugin bootstrap** so the real activation path runs, and score with **rule-based
+judges over harness-collected evidence, no LLM self-grading**. That last clause is schliff's
+own philosophy; SkillOpt states it explicitly in its docstring.
+
+Carry their scope warning verbatim: the evaluated agent gets Bash as the same OS user, so
+evidence is tamper-**evident**, not tamper-proof. Trusted local candidates only.
+
+This stays on the existing opt-in runtime path — the deterministic core keeps its
+"no model in the loop" promise untouched.
+
+## F3 — the security dimension detects no credentials
+
+`scoring/security.py:171 score_security` has negation-awareness (`_preceded_by_negation`),
+code-block awareness (`_find_code_block_ranges`), and domain detection (`_is_security_domain`)
+— but **zero credential patterns**. Confirmed: no `sk-`/`AKIA`/`ghp_`/`eyJ` anywhere under
+`scoring/`. The patterns exist only in `evolve/sanitize.py`, which is the opt-in LLM path.
+
+So schliff scores an `AGENTS.md` with a live API key in it without a word. Committed
+instruction files are a real leak surface, and detecting it is purely deterministic — exactly
+schliff's wheelhouse.
+
+The existing `_in_code_block` and `_preceded_by_negation` machinery is what makes this
+feasible without wrecking legitimate content: a doc showing `export OPENAI_API_KEY=sk-...`
+as an example must not be flagged as a leak. See `feedback_overcorrection_pattern` and
+`feedback_syntax_collision_detectors`.
+
+**RESOLVED — the open decision was a false binary.** "Score-affecting" and "gate-effective" are
+separable. The gate is **score-neutral and gate-effective** (ADR 0011): the composite is
+bit-identical, `verify` and the Action exit non-zero on a finding, no `--allow-secrets`.
+
+**CORRECTED — do not reuse the existing machinery as written above.** `_in_code_block`
+(`security.py:215`) and `_preceded_by_negation` (`:220`) both **suppress**. Inheriting them
+would blind the detector exactly where keys live — `export ANTHROPIC_API_KEY=sk-ant-…` inside a
+fence, or *"never commit your `sk-ant-…` key"*. Credentials are exempt from both, as
+`obfuscation` already is; the discriminator is the **value**, not the location (ADR 0012).
+
+**CORRECTED — it cannot live in `score_security`.** That dimension is opt-in
+(`shared.py:250`) and would never run in the plain `schliff score --json` the Action calls. It
+is an always-on check over the **raw bytes** of the real file, before `normalize_content` and
+the temp-file swap at `shared.py:241` (ADR 0016).
+
+Surfaces: `verify` + the Action gate; `score --json` carries the finding as data; `doctor`,
+`compare`, `report` display it and never change their exit code (ADR 0014).
+
+`feedback_field_test_over_fixtures` still applies — measure the false-positive rate against the
+tracked corpus, not synthetic fixtures.
+
+## F4 — two narrow pattern gaps in `evolve/sanitize.py`
+
+**This set stays separate from F3's** (ADR 0013). Redaction and detection have opposite error
+costs: a false positive here is harmless, a false negative leaks to the provider — so this set
+may be aggressive, while F3's must be precise. `Password=`/`Pwd=` therefore belong here **only**.
+
+**CORRECTED — two thirds of this gap did not exist.** `sanitize.py:25` already carries
+`AIza[a-zA-Z0-9_-]{35}` and `:20` already carries `gho_[a-zA-Z0-9]{36}`, both inside the very
+range cited above. The verified residual delta, from the side-by-side with `staging.py:105-204`:
+
+- The GitHub patterns are bounded at **exactly 36** characters and cover only `ghp_` (`:19`)
+  and `gho_` (`:20`). SkillOpt uses `gh[pousr]_[A-Za-z0-9]{20,}` — the missing part is the
+  `ghu_`/`ghs_`/`ghr_` prefixes and the variable length bound.
+- No ODBC `Pwd=`. **`Password=` is NOT a gap** — the generic assignment catcher at
+  `sanitize.py:41` lists `password`/`passwd` and already redacts it; running the shipped
+  `redact_secrets` on a connection string confirms it.
+- SkillOpt distinguishes ODBC `Pwd=` from the conventional all-caps `PWD` working-directory
+  variable (`staging.py:144-150`). Worth copying if `Pwd` is adopted.
+
+**CORRECTED — not via `validate_regex_complexity`** (ADR 0013). That validator's only
+production call sites are `runtime-evaluator.py:123` and `scoring/runtime.py:164`, both on
+eval-suite-supplied regexes; it guards *untrusted* patterns, not first-party ones. Run over the
+16 live `_SECRET_PATTERNS` it fails one that already ships — `sanitize.py:24` trips the
+nested-quantifier heuristic on `\s+(RSA\s+)?`. First-party patterns are instead guarded by a
+**ReDoS timing test**: pathological input of defined length, wall-clock bound. See
+`feedback_redos_untrusted_regex` and the existing `test_scoring_redos.py`.
+
+## Explicitly out of scope
+
+- **The LLM optimizer path** (`gradient/reflect.py`, `gradient/aggregate.py`, `optimizer/clip.py`,
+  `optimizer/lr_autonomous.py`). Every stage is a `chat_optimizer` call. Adopting it means
+  `openai` + `azure-identity` as dependencies, an API budget, and non-determinism — it deletes
+  the positioning that differentiates schliff from agnix.
+- **The harvest layer** (`skillopt_sleep/harvest*.py`, ~9k LOC over 5 agents). Documented data
+  boundary: *"Outbound prompts are not currently guaranteed to be secret-free"*
+  (`docs/sleep/README.md:29-33`). Reopens the question ADR 0008/0009 just closed.
+- **The five plugin integrations.** The opposite of Route B.
+
+## Sequencing — CORRECTED
+
+**F3 → F1 → F4. F2 is rejected** (ADR 0010).
+
+F1 moved behind F3: `auto-improve` is not a subcommand of the shipped CLI (no hit in
+`cli.py`) and `/schliff:auto` is barred from unattended use, so the lying gate sits on a path
+nobody currently runs unsupervised. F3 sits on the surfaces actually in use.
+
+Three PRs, one minor **8.11.0** (ADR 0017), with the CHANGELOG entry under **BREAKING
+BEHAVIOUR**, a **CLI test** proving the red path (`verify` exits non-zero on a credential
+fixture), and the **three version constants** moved in lockstep — `pyproject.toml:7`,
+`.claude-plugin/plugin.json:3`, `skills/schliff/__init__.py:3` — plus the separate cosmetic
+README/docs occurrences.
+
+The matching `action-selftest.yml` fixture is a **post-release follow-up**, not part of this
+release: `action.yml:63` installs the engine from PyPI and all five self-test jobs enter via
+`uses: ./`, so a fixture added now would exercise 8.10.1 and pass for the wrong reason
+(ADR 0014, ADR 0017).
+
+## Open questions
+
+None blocking. The F2 host-pinning question is moot while F2 is rejected; if it is ever
+revived, a purpose-built fixture beats schliff's own skill —
+`feedback_suite_extracted_from_artifact` (a suite derived from the artifact grades it 100% by
+construction).

--- a/docs/specs/2026-08-07-credential-gate-decision-brief.md
+++ b/docs/specs/2026-08-07-credential-gate-decision-brief.md
@@ -103,10 +103,38 @@ which misses real keys offers false assurance, which can be worse than none.
 - ADR 0011, 0012, 0014 and 0016 all rest on the refuted premise to some degree. Which are
   superseded, and which merely need their reasoning corrected?
 
-## Not in scope
+## Not in scope — but still open
 
-F1 (gradient target check + train/val split) and F4 (redaction patterns) ship regardless.
-Two open F4 items from the third pass are ordinary bugs, not premise failures, and are worth
-fixing whatever is decided here: short `PWD=` values are unredacted with no backstop
-(`sanitize.py:36`), and the redaction set cannot match a modern `sk-proj-` key
-(`sanitize.py:13`) — a miss that reaches a model provider.
+F1 (gradient target check + train/val split) and F4 (redaction patterns) ship regardless of
+this decision. **Four findings from the third pass are ordinary bugs rather than premise
+failures, and need fixing whatever is decided here:**
+
+- `evolve/sanitize.py:36` — short `PWD=` values go unredacted and no other pattern covers the
+  ODBC spelling, so the generic assignment catcher does not backstop it. Verified:
+  `redact_secrets('conn: Server=x;PWD=abc123;DB=y')` returns the string unchanged.
+- `evolve/sanitize.py:13` — the redaction set cannot match a modern `sk-proj-` OpenAI key
+  (alnum-only body stops at the hyphen). A miss here reaches a model provider, which is the
+  expensive direction for redaction (ADR 0013).
+- `auto-improve.py:321` — the empty-val guard fires only when **all three** populations are
+  empty, so holding out only triggers leaves `quality` and `edges` at the unmeasured sentinel
+  on the gate. Verified against the shipped fixture suite: a val side of
+  `{triggers: 22, test_cases: 0, edge_cases: 0}` satisfies `any(...)`, no fallback fires, and
+  destructive patches are written to the user's SKILL.md.
+- `auto-improve.py:404` — `_should_stop` still receives the val-basis score, so the
+  documented "composite reaches 98+" stop is evaluated against a number no other schliff
+  surface produces. Verified: a run printed `Baseline: 95.3` (gate basis) while the summary
+  reported `99 → 99`, and the loop kept iterating on a file `schliff score` already rates
+  past the threshold. The basis sweep of `a335ff9` was incomplete.
+
+## The rest of the backlog
+
+- **Version bump to 8.11.0** — its own `chore(release):` commit touching `pyproject.toml:7`,
+  `.claude-plugin/plugin.json:3`, `skills/schliff/__init__.py:3` (the three constants
+  `test_version_consistency.py` asserts), plus `README.md`, `docs/README.md` and the badge
+  cache-bust. A release step, not a feature step (ADR 0017).
+- **The CHANGELOG entry** currently sits under BREAKING BEHAVIOUR for a behaviour that may
+  not ship. It follows the decision.
+- **Push and PR** — nothing has left the local tree. The branch is ten commits.
+- **The `action-selftest.yml` red-path fixture** remains a post-release follow-up: the
+  composite action installs from PyPI, so no self-test can exercise a detector that is not
+  published yet (ADR 0014).

--- a/docs/specs/2026-08-07-credential-gate-decision-brief.md
+++ b/docs/specs/2026-08-07-credential-gate-decision-brief.md
@@ -1,0 +1,112 @@
+# Decision brief: does the credential gate ship, and in what shape?
+
+**Status:** open, awaiting decision · **Branch:** `docs/skillopt-import-adrs` at `0751e45`
+**Written:** 2026-08-07, after the third code-review pass
+
+Input for a grilling session. Everything here was measured on the branch, not inferred.
+The decision is F3's alone; **F1 and F4 are unaffected and healthy.**
+
+## The measurement that forces the decision
+
+Run against `scoring/credentials.py` as it stands on `0751e45`:
+
+| Input | What it is | Gate |
+| --- | --- | --- |
+| `sk-proj-Ab3d-Kf9LmQ2xR7tYu1VwZ0nBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef` | **real** OpenAI project key | **silent** |
+| `AKIA0000TUVWXY3BCDEF` | **real** AWS key | **silent** |
+| `AKIA1234567890ABCDEF` | documentation placeholder | **fires** |
+| `ghp_abcdefghijklmnopqrstuvwxyz012345` | documentation placeholder | **fires** |
+
+It misses real keys and fires on invented ones. Same input set, opposite of the intent.
+
+## The claim that turned out to be false
+
+ADR 0012, `## Why`, first paragraph:
+
+> Location carries no information about whether a token is real; shape carries all of it.
+
+`AKIA1234567890ABCDEF` and `AKIAJ7QRTUVWXY3BCDEF` are structurally identical and both
+satisfy every rule the ADR specifies. One belongs in a README, the other is a credential.
+Shape does not separate them.
+
+The placeholder heuristic (`_PLACEHOLDER_MARKERS` plus a four-identical-character run) was
+the patch for that gap. It both over- and under-fires: it eats a real key containing `0000`,
+and it passes any dummy that avoids its marker words.
+
+**Every narrowing produces a false negative on a security gate. Every widening breaks a third
+party's CI.** That is not a tuning problem; it is what an undecidable classification looks
+like from the inside.
+
+## Why more iteration is not the answer
+
+| Pass | Findings | Of which were regressions from the previous pass's fixes |
+| --- | --- | --- |
+| 1 | 10 | — |
+| 2 | 10 | 6 |
+| 3 | 10 | 4 (plus one I found myself before the run) |
+
+Thirty confirmed findings. The defect count per pass is flat while the subsystem churns —
+the errors move rather than disappear. Every pass was verified by execution, so this is not
+reviewer noise.
+
+Real secret scanners solve this with entropy scoring, live verification against the vendor
+API, allowlists and baseline files. That is precisely the machinery ADR 0010 declined when it
+rejected SkillOpt's heavier apparatus, and it is a different product from a deterministic
+rubric linter.
+
+## What makes it dangerous rather than merely wrong
+
+ADR 0011 decided **no opt-out ships** — no `--allow-secrets`, no threshold, no suppression.
+That decision was sound *given* the assumption that precision was achievable. With the
+assumption gone, it is the thing that converts a false positive into an unfixable red build
+for someone who does not control schliff's release cycle. `action.yml` also defaults
+`schliff-version` to latest, so Action users receive the behaviour without acting.
+
+## The options
+
+**(a) Report, do not gate.** The finding appears in `score`, `doctor` and `verify` output;
+no exit code changes. Supersedes ADR 0011's gate-effectiveness. Keeps the whole benefit that
+survives the refutation — you see the finding — and removes the property that makes an
+undecidable classification harmful. Cost: a leak no longer fails CI, so the feature stops
+being a gate and becomes a report.
+
+**(b) Keep the gate, add a baseline/allowlist file.** Matches how real scanners handle
+exactly this. Cost: accepts the machinery ADR 0010 rejected, adds a file format, a
+resolution path and a staleness problem, and reopens the "no opt-out" decision anyway — an
+allowlist *is* an opt-out with extra steps.
+
+**(c) Drop F3.** Ship F1 and F4, point the README at gitleaks. Cost: the audit's most
+user-visible item disappears; the honest gain is that schliff stops claiming a capability it
+cannot deliver deterministically.
+
+**Recommendation: (a).** It is the only option that neither invents machinery the project
+declined nor abandons the finding. It also inverts cleanly: if a precise discriminator is
+ever found, promoting a report back to a gate is a minor release, whereas retracting a gate
+that broke builds is not.
+
+## Standing pressure for the grilling
+
+Route B — maintained-but-parked, 12 stars, demand bet cashed RED 2026-08-04. F3 was justified
+in ADR 0010 on the grounds that *"a committed credential damages the one person who has it,
+immediately and irreversibly"* — a harm that does not scale with adoption. That argument
+survives the refutation and argues for (a) over (c). The counter-argument is that a detector
+which misses real keys offers false assurance, which can be worse than none.
+
+## Questions the grilling has to settle
+
+- Does the gate become a report (a), gain an allowlist (b), or go away (c)?
+- If (a): does `verify` keep a non-zero exit behind an explicit opt-**in** flag, or none at all?
+- Do the vendor patterns stay as they are, get widened for recall now that a false positive
+  is cheap, or get narrowed to the classes with no plausible documentation form?
+- What happens to the CHANGELOG entry, which is currently filed under BREAKING BEHAVIOUR for
+  a behaviour that may not ship?
+- ADR 0011, 0012, 0014 and 0016 all rest on the refuted premise to some degree. Which are
+  superseded, and which merely need their reasoning corrected?
+
+## Not in scope
+
+F1 (gradient target check + train/val split) and F4 (redaction patterns) ship regardless.
+Two open F4 items from the third pass are ordinary bugs, not premise failures, and are worth
+fixing whatever is decided here: short `PWD=` values are unredacted with no backstop
+(`sanitize.py:36`), and the redaction set cannot match a modern `sk-proj-` key
+(`sanitize.py:13`) — a miss that reaches a model provider.

--- a/docs/specs/2026-08-07-credential-gate-decision-brief.md
+++ b/docs/specs/2026-08-07-credential-gate-decision-brief.md
@@ -1,7 +1,8 @@
 # Decision brief: does the credential gate ship, and in what shape?
 
-**Status:** open, awaiting decision · **Branch:** `docs/skillopt-import-adrs` at `0751e45`
-**Written:** 2026-08-07, after the third code-review pass
+**Status:** open, awaiting decision · **Branch:** `docs/skillopt-import-adrs` at `846e171`
+**Written:** 2026-08-07, after the third code-review pass · **Updated:** 2026-08-10, the four
+decision-independent findings are fixed and the branch waits on this one question
 
 Input for a grilling session. Everything here was measured on the branch, not inferred.
 The decision is F3's alone; **F1 and F4 are unaffected and healthy.**
@@ -106,25 +107,33 @@ which misses real keys offers false assurance, which can be worse than none.
 ## Not in scope — but still open
 
 F1 (gradient target check + train/val split) and F4 (redaction patterns) ship regardless of
-this decision. **Four findings from the third pass are ordinary bugs rather than premise
-failures, and need fixing whatever is decided here:**
+this decision. **Four findings from the third pass were ordinary bugs rather than premise
+failures. All four are closed in `846e171`; they needed no decision:**
 
-- `evolve/sanitize.py:36` — short `PWD=` values go unredacted and no other pattern covers the
-  ODBC spelling, so the generic assignment catcher does not backstop it. Verified:
-  `redact_secrets('conn: Server=x;PWD=abc123;DB=y')` returns the string unchanged.
-- `evolve/sanitize.py:13` — the redaction set cannot match a modern `sk-proj-` OpenAI key
+- `evolve/sanitize.py:36` — short `PWD=` values went unredacted and no other pattern covers
+  the ODBC spelling, so the generic assignment catcher did not backstop it. Was:
+  `redact_secrets('conn: Server=x;PWD=abc123;DB=y')` returned the string unchanged. Fixed by
+  dropping the invented eight-character floor; `$PWD` and lowercase `pwd=` still survive.
+- `evolve/sanitize.py:13` — the redaction set could not match a modern `sk-proj-` OpenAI key
   (alnum-only body stops at the hyphen). A miss here reaches a model provider, which is the
-  expensive direction for redaction (ADR 0013).
-- `auto-improve.py:321` — the empty-val guard fires only when **all three** populations are
-  empty, so holding out only triggers leaves `quality` and `edges` at the unmeasured sentinel
-  on the gate. Verified against the shipped fixture suite: a val side of
-  `{triggers: 22, test_cases: 0, edge_cases: 0}` satisfies `any(...)`, no fallback fires, and
-  destructive patches are written to the user's SKILL.md.
-- `auto-improve.py:404` — `_should_stop` still receives the val-basis score, so the
-  documented "composite reaches 98+" stop is evaluated against a number no other schliff
-  surface produces. Verified: a run printed `Baseline: 95.3` (gate basis) while the summary
-  reported `99 → 99`, and the loop kept iterating on a file `schliff score` already rates
-  past the threshold. The basis sweep of `a335ff9` was incomplete.
+  expensive direction for redaction (ADR 0013). Fixed by allowing hyphens **behind a known
+  key prefix only**: a bare `sk-` with hyphens would have eaten kebab-case prose such as
+  `sk-add-credential-scanning-to-verify`, and over-redaction destroys the prompt it protects.
+- `auto-improve.py:321` — the empty-val guard fired only when **all three** populations were
+  empty, so holding out only triggers left `quality` and `edges` at the unmeasured sentinel
+  on the gate and destructive patches reached the user's SKILL.md. Fixed per population:
+  each population with no val cases falls back to the full suite and `gate_suite` names it,
+  while populations that do hold out keep their holdout. Measured on schliff's own 44/4/14
+  suite — the gate saw `quality -1, edges -1`, and now sees `90, 100`.
+- `auto-improve.py:404` — `_should_stop` received the val-basis score, so the documented
+  "composite reaches 98+" stop was evaluated against a number no other schliff surface
+  produces: a run printed `Baseline: 95.3` (gate basis) while the summary reported `99 → 99`.
+  The basis sweep of `a335ff9` was incomplete. Fixed: the stop check runs on the reported
+  basis, re-measured after each keep, and the verbose baseline line prints the reported
+  figure with the gate's number labelled beside it.
+
+Nothing in the four touches `scoring/credentials.py`, so the decision below is unchanged by
+them. The branch now has exactly one open question.
 
 ## The rest of the backlog
 

--- a/docs/specs/2026-08-07-credential-gate-decision-brief.md
+++ b/docs/specs/2026-08-07-credential-gate-decision-brief.md
@@ -1,8 +1,21 @@
 # Decision brief: does the credential gate ship, and in what shape?
 
-**Status:** open, awaiting decision · **Branch:** `docs/skillopt-import-adrs` at `846e171`
-**Written:** 2026-08-07, after the third code-review pass · **Updated:** 2026-08-10, the four
-decision-independent findings are fixed and the branch waits on this one question
+**Status:** decided 2026-08-10 — **(a) report, do not gate**, implemented in ADR 0019 and
+ADR 0020 · **Branch:** `docs/skillopt-import-adrs`
+**Written:** 2026-08-07, after the third code-review pass
+
+> The decision this brief was written to force has been taken, so the document below is the
+> record of the question and not a live proposal. What was settled, beyond the headline: no
+> opt-in flag; the Action annotates with a warning and never fails; the vendor patterns widen
+> (the repeated-run heuristic is gone, hyphens are allowed behind a known OpenAI prefix, JWTs
+> stay out); the CHANGELOG's BREAKING section is withdrawn; `verify`'s fail-closed exit 2 on an
+> unreadable file is withdrawn with it, while `credentials: null` survives as the third state;
+> the `action-selftest.yml` follow-up becomes a **green**-path fixture (post-release, since the
+> Action installs from PyPI); and ADR 0016 is untouched.
+>
+> One measurement was added after the fact and is not in the analysis below: across 128 real
+> instruction files the detector finds nothing, and across ~600 documentation files every
+> finding it produces is documentation *about* credentials. See ADR 0020.
 
 Input for a grilling session. Everything here was measured on the branch, not inferred.
 The decision is F3's alone; **F1 and F4 are unaffected and healthy.**
@@ -144,6 +157,7 @@ them. The branch now has exactly one open question.
 - **The CHANGELOG entry** currently sits under BREAKING BEHAVIOUR for a behaviour that may
   not ship. It follows the decision.
 - **Push and PR** — nothing has left the local tree. The branch is ten commits.
-- **The `action-selftest.yml` red-path fixture** remains a post-release follow-up: the
-  composite action installs from PyPI, so no self-test can exercise a detector that is not
-  published yet (ADR 0014).
+- **The `action-selftest.yml` fixture** remains a post-release follow-up, now proving the
+  **green** path: a file with a vendor token must leave the job green and produce the warning
+  annotation. The timing constraint is unchanged — the composite action installs from PyPI, so
+  no self-test can exercise a scan that is not published yet (ADR 0014, ADR 0019).

--- a/docs/specs/glossary.md
+++ b/docs/specs/glossary.md
@@ -1,0 +1,69 @@
+# Glossary
+
+One canonical name per concept, with the synonyms to stop using. Append across sessions;
+keep entries alphabetical.
+
+## Finding payload
+
+What a credential finding is allowed to carry: the vendor and the line number, and nothing
+else. The matched value never enters the data structure — not truncated, not prefixed, not
+masked downstream. The rule lives at the structure because the transport carries the whole
+object: `action.yml:210` hands the entire score JSON to the comment step as `RESULT_B64`.
+
+_Avoid:_ "masked", "redacted output", "sanitized finding" — all three imply the value is
+present and then hidden, which is the design that cannot be made safe when output sites are
+not enumerable.
+
+## Gate-effective
+
+A change that alters an exit code without altering any score. `verify` and the GitHub Action
+exit non-zero; the composite, badges, comparisons and every pinned `--min-score` threshold are
+bit-identical to before.
+
+_Avoid:_ "breaking", "score-affecting" — both blur the distinction the design depends on. A
+gate-effective change is breaking in *behaviour* and neutral in *score*, and collapsing the two
+is what made the credential gate look like it needed a major release and a rubric version.
+
+## Gradient target
+
+The file a gradient names in its `target` field, which is not always the file being patched:
+eleven gradients in `text_gradient.py` target `eval-suite.json` while `apply_patches` only ever
+writes `skill_path`. `generate_patches` filters on confidence and effort and never on target,
+so the two are free to diverge.
+
+_Avoid:_ "read-only eval suite" — it names a policy about one file rather than the property
+that matters, which is that a gradient and its patcher can disagree about which file is being
+edited. Also avoid "holdout" and "validation set" for the split: those describe a *partition*
+of the suite, a separate and weaker property. SkillOpt's own names drifted here
+(`replay`→`train`, `holdout`→`val`), which is the argument for fixing ours once.
+
+## Raw file
+
+The bytes of the file the user actually named. Distinct from the normalized content that
+scorers receive: for every format except `skill.md`, `shared.py:232-241` writes normalized
+content to a temp file and reassigns `skill_path` to it, so a scorer's "path" is a temp file
+with synthetic frontmatter prepended.
+
+_Avoid:_ "the skill path", "the input file" — after `shared.py:241` both name the temp file, so
+neither distinguishes the two things that matter when a finding needs a true line number.
+
+## Red-path proof
+
+Two distinct proofs that an earlier draft collapsed into one requirement. The **engine
+red path** — `verify` exits non-zero on a credential fixture — is a CLI test that runs against
+the working tree today. The **wiring red path** — the Action propagates the finding and fails
+— cannot run before release, because `action.yml:63` installs the engine from PyPI and every
+self-test job enters via `uses: ./`.
+
+_Avoid:_ "the red-path fixture" as a single item — it names a requirement that is only half
+satisfiable at any given time, and the unsatisfiable half passes green for the wrong reason.
+
+## Structurally valid vendor token
+
+A credential match that carries a known vendor prefix *and* the exact shape that vendor issues
+— `AKIA` plus 16 base32 characters, `gh[pousr]_` plus 20 or more, `sk-ant-` plus 20 or more.
+Placeholder shapes (`sk-...`, `<your-key>`, `${VAR}`, `[REDACTED…]`) are not tokens and never
+produce a finding.
+
+_Avoid:_ "secret", "API key", "credential" on their own — none of them separates a live key
+from the example in a setup snippet, and that separation is the entire false-positive defence.

--- a/docs/specs/glossary.md
+++ b/docs/specs/glossary.md
@@ -16,13 +16,14 @@ not enumerable.
 
 ## Gate-effective
 
-A change that alters an exit code without altering any score. `verify` and the GitHub Action
-exit non-zero; the composite, badges, comparisons and every pinned `--min-score` threshold are
-bit-identical to before.
+A change that alters an exit code without altering any score. The distinction stays useful — it
+is what separates "breaking in behaviour" from "breaking in score" — but **no credential finding
+is gate-effective any more** (ADR 0019). The credential scan is score-neutral *and* exit-neutral;
+the only gate-effective things left in schliff are the `--min-score` threshold and `--regression`.
 
-_Avoid:_ "breaking", "score-affecting" — both blur the distinction the design depends on. A
-gate-effective change is breaking in *behaviour* and neutral in *score*, and collapsing the two
-is what made the credential gate look like it needed a major release and a rubric version.
+_Avoid:_ "breaking", "score-affecting" — both blur the distinction the design depends on. Also
+avoid calling the credential scan a **gate**: it reports, and the word was what made an
+undecidable classification look like it could carry a build.
 
 ## Gradient target
 
@@ -49,21 +50,35 @@ neither distinguishes the two things that matter when a finding needs a true lin
 
 ## Red-path proof
 
-Two distinct proofs that an earlier draft collapsed into one requirement. The **engine
-red path** — `verify` exits non-zero on a credential fixture — is a CLI test that runs against
-the working tree today. The **wiring red path** — the Action propagates the finding and fails
-— cannot run before release, because `action.yml:63` installs the engine from PyPI and every
-self-test job enters via `uses: ./`.
+Two distinct proofs that an earlier draft collapsed into one requirement, of which **only the
+second still exists**. The engine red path is gone with the gate (ADR 0019): `verify` no longer
+exits non-zero on a credential, so the CLI test now proves the opposite — the finding is
+displayed *and* the exit code is unchanged. The **wiring proof** survives as a green path: the
+Action must annotate and stay green. It still cannot run before release, because `action.yml:63`
+installs the engine from PyPI and every self-test job enters via `uses: ./`.
 
 _Avoid:_ "the red-path fixture" as a single item — it names a requirement that is only half
 satisfiable at any given time, and the unsatisfiable half passes green for the wrong reason.
 
+## Reported, not gated
+
+The contract every credential surface now holds: the finding is displayed wherever a human or a
+machine looks — `score`, `score --json`, `doctor`, `verify`, the Action's annotations — and
+changes no exit code anywhere. Unknown stays a third state: a file that could not be read reports
+`credentials: null`, never `[]`.
+
+_Avoid:_ "advisory", "soft fail", "warning-only gate" — the first two suggest a severity dial
+that does not exist, and the third keeps the word *gate* for something that cannot fail.
+
 ## Structurally valid vendor token
 
-A credential match that carries a known vendor prefix *and* the exact shape that vendor issues
-— `AKIA` plus 16 base32 characters, `gh[pousr]_` plus 20 or more, `sk-ant-` plus 20 or more.
-Placeholder shapes (`sk-...`, `<your-key>`, `${VAR}`, `[REDACTED…]`) are not tokens and never
-produce a finding.
+A string carrying a known vendor prefix *and* the exact shape that vendor issues — `AKIA` plus
+16 base32 characters, `gh[pousr]_` plus 20 or more, `sk-ant-` plus 20 or more. It asserts **form
+only**. Whether the token is live, revoked, or invented for a README is not knowable from the
+string, and the term must never be read as "real" (ADR 0020). Tokens naming themselves as
+stand-ins (`<your-key>`, `sk-ant-EXAMPLE…`, `${VAR}`, `[REDACTED…]`) are excluded by marker word,
+which is the one exclusion that never cost a real key.
 
-_Avoid:_ "secret", "API key", "credential" on their own — none of them separates a live key
-from the example in a setup snippet, and that separation is the entire false-positive defence.
+_Avoid:_ "secret", "API key", "credential" on their own — each asserts authenticity the check
+cannot establish. Also avoid "valid" without "structurally": the word did the entire work of the
+premise that turned out to be false.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.10.1"
+version = "8.11.0"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.10.1"
+__version__ = "8.11.0"

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -169,6 +169,52 @@ def _score_content(
     return result
 
 
+# --- Gate suite ---
+
+# Populations a suite may carry. A dimension is scored from exactly one of
+# them, so a population the gate cannot see is a dimension it cannot judge.
+_POPULATIONS = ("triggers", "test_cases", "edge_cases")
+
+
+def _gate_suites(
+    eval_suite: Optional[dict],
+) -> tuple[Optional[dict], Optional[dict], bool, str]:
+    """Return ``(train_suite, val_suite, holdout_leaked, gate_basis)``.
+
+    Edits are derived from ``train`` and judged on ``val`` (ADR 0015). A val
+    side with no cases in some population scores that dimension at the
+    unmeasured sentinel (-1), and the keep/revert gate then cannot see a patch
+    that destroyed it — so every such population falls back to the full suite
+    and the run says the holdout is gone for it. Checking only whether ALL
+    populations were empty left a suite whose triggers alone carry `split: val`
+    gating on triggers while quality and edges went unjudged.
+    """
+    if not eval_suite:
+        # No suite at all: gradients and gate see the identical empty set, so
+        # nothing is held out. Reporting False here contradicted the field's
+        # own documented meaning in the most common configuration.
+        return None, None, True, "none"
+
+    train_suite, val_suite, leaked = split_eval_suite(eval_suite)
+
+    populated = [
+        p for p in _POPULATIONS
+        if isinstance(eval_suite.get(p), list) and eval_suite[p]
+    ]
+    blind = [p for p in populated if not val_suite.get(p)]
+    if not blind:
+        return train_suite, val_suite, leaked, "val"
+
+    val_suite = dict(val_suite)
+    for population in blind:
+        val_suite[population] = list(eval_suite[population])
+    basis = (
+        "full (val was empty)" if len(blind) == len(populated)
+        else "val + full (" + ", ".join(blind) + ")"
+    )
+    return train_suite, val_suite, True, basis
+
+
 # --- ROI Stopping ---
 
 def _has_dimension_regression(
@@ -312,24 +358,7 @@ def run_auto_improve(
     # Derive edits from `train`, judge them on `val` (ADR 0015). When the two
     # are not disjoint the loop still runs — but `holdout_leaked` travels into
     # the summary so the delta is never presented as evidence of generalisation.
-    if eval_suite:
-        train_suite, val_suite, holdout_leaked = split_eval_suite(eval_suite)
-        # A val side with no cases in any population cannot judge anything:
-        # triggers/quality/edges collapse to the unmeasured sentinel and the
-        # gate keeps a patch that destroyed every trigger match. Fall back to
-        # the full suite for gating and say the holdout is gone.
-        if not any(val_suite.get(k) for k in ("triggers", "test_cases", "edge_cases")):
-            val_suite = eval_suite
-            holdout_leaked = True
-            gate_basis = "full (val was empty)"
-        else:
-            gate_basis = "val"
-    else:
-        # No suite at all: gradients and gate see the identical empty set, so
-        # nothing is held out. Reporting False here contradicted the field's
-        # own documented meaning in the most common configuration.
-        train_suite, val_suite, holdout_leaked = None, None, True
-        gate_basis = "none"
+    train_suite, val_suite, holdout_leaked, gate_basis = _gate_suites(eval_suite)
 
     # Load existing state for resume
     state = _load_state(skill_path)
@@ -363,7 +392,19 @@ def run_auto_improve(
         state.append(baseline_entry)
 
     if verbose:
-        print(f"Baseline: {baseline['composite']}/100 ({baseline['measured']} dims)", file=sys.stderr)
+        # The reported basis, like every other number a user acts on. Printing
+        # the gate's baseline here and the full-suite figure in the summary put
+        # `Baseline: 95.3` and `99 → 99` in one stream.
+        print(
+            f"Baseline: {baseline_reported['composite']}/100 "
+            f"({baseline_reported['measured']} dims)",
+            file=sys.stderr,
+        )
+        if baseline["composite"] != baseline_reported["composite"]:
+            print(
+                f"  gate basis {gate_basis}: {baseline['composite']}/100",
+                file=sys.stderr,
+            )
 
     # Recall relevant episodes
     if not dry_run:
@@ -387,6 +428,11 @@ def run_auto_improve(
 
     _loop_start = time.monotonic()
     current_score = baseline
+    # `_should_stop` compares against documented absolute thresholds (98
+    # composite, 90 per dimension) that a user checks with `schliff score`.
+    # Those have to be judged on the reported basis; only the keep/revert gate
+    # and its deltas run on `val`.
+    current_reported = baseline_reported
     # The winning candidate's content, so a dry-run summary can score what the
     # run would have produced instead of re-reading the untouched file.
     last_candidate: Optional[str] = None
@@ -401,7 +447,7 @@ def run_auto_improve(
             print(f"\n--- Iteration {iteration} ---", file=sys.stderr)
 
         # Check stopping conditions
-        should_stop, reason = _should_stop(state, current_score)
+        should_stop, reason = _should_stop(state, current_reported)
         if should_stop:
             if verbose:
                 print(f"Stopping: {reason}", file=sys.stderr)
@@ -514,6 +560,16 @@ def run_auto_improve(
                 scorer.invalidate_cache(skill_path)
             old_composite = current_score["composite"]
             current_score = new_score
+            # Re-measure on the reported basis so the next stop check sees the
+            # kept patch. Only on a keep: a discard restores the file.
+            if content_after is not None:
+                if dry_run:
+                    current_reported = _score_content(
+                        content_after, skill_path, eval_suite
+                    )
+                else:
+                    scorer.invalidate_cache(skill_path)
+                    current_reported = _score_skill(skill_path, eval_suite)
             if delta > 0:
                 improvements += 1
             total_delta += delta

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -312,9 +312,24 @@ def run_auto_improve(
     # Derive edits from `train`, judge them on `val` (ADR 0015). When the two
     # are not disjoint the loop still runs — but `holdout_leaked` travels into
     # the summary so the delta is never presented as evidence of generalisation.
-    train_suite, val_suite, holdout_leaked = (
-        split_eval_suite(eval_suite) if eval_suite else (None, None, False)
-    )
+    if eval_suite:
+        train_suite, val_suite, holdout_leaked = split_eval_suite(eval_suite)
+        # A val side with no cases in any population cannot judge anything:
+        # triggers/quality/edges collapse to the unmeasured sentinel and the
+        # gate keeps a patch that destroyed every trigger match. Fall back to
+        # the full suite for gating and say the holdout is gone.
+        if not any(val_suite.get(k) for k in ("triggers", "test_cases", "edge_cases")):
+            val_suite = eval_suite
+            holdout_leaked = True
+            gate_basis = "full (val was empty)"
+        else:
+            gate_basis = "val"
+    else:
+        # No suite at all: gradients and gate see the identical empty set, so
+        # nothing is held out. Reporting False here contradicted the field's
+        # own documented meaning in the most common configuration.
+        train_suite, val_suite, holdout_leaked = None, None, True
+        gate_basis = "none"
 
     # Load existing state for resume
     state = _load_state(skill_path)
@@ -327,6 +342,11 @@ def run_auto_improve(
     # Clear scorer cache for fresh reads
     scorer.invalidate_cache(skill_path)
     baseline = _score_skill(skill_path, val_suite)
+    # Reported figures need ONE basis. The gate judges `val`; the headline
+    # compares full-suite against full-suite, or the summary subtracts two
+    # different measurements and prints `42 -> 40 (+0.0)`.
+    scorer.invalidate_cache(skill_path)
+    baseline_reported = _score_skill(skill_path, eval_suite)
 
     if start_iteration == 0:
         baseline_entry = {
@@ -367,6 +387,9 @@ def run_auto_improve(
 
     _loop_start = time.monotonic()
     current_score = baseline
+    # The winning candidate's content, so a dry-run summary can score what the
+    # run would have produced instead of re-reading the untouched file.
+    last_candidate: Optional[str] = None
     improvements = 0
     total_delta = 0
     reason = ""
@@ -470,13 +493,21 @@ def run_auto_improve(
                 continue
 
             if delta > best_delta:
-                content_after = Path(skill_path).read_text(encoding="utf-8") if not dry_run else None
+                # Keep the candidate in dry-run too: without it the summary
+                # re-scored the untouched file and erased the projection.
+                content_after = (
+                    Path(skill_path).read_text(encoding="utf-8")
+                    if not dry_run
+                    else result.get("new_content")
+                )
                 best_result = (new_score, delta, patch_candidate, content_after)
                 best_delta = delta
 
         # Determine outcome from exploration
         if best_result and best_delta >= 0:
             new_score, delta, chosen_patch, content_after = best_result
+            if content_after is not None:
+                last_candidate = content_after
             status = "keep"
             if not dry_run and content_after is not None:
                 Path(skill_path).write_text(content_after, encoding="utf-8")
@@ -571,7 +602,12 @@ def run_auto_improve(
     # figures therefore come from the full suite; `gate_suite` says which set
     # actually decided keep vs revert.
     scorer.invalidate_cache(skill_path)
-    reported = _score_skill(skill_path, eval_suite)
+    if not dry_run:
+        reported = _score_skill(skill_path, eval_suite)
+    elif last_candidate is not None:
+        reported = _score_content(last_candidate, skill_path, eval_suite)
+    else:
+        reported = baseline_reported
 
     # Sparkline of score progression
     score_history = [e.get("composite", 0) for e in state if e.get("status") in ("keep", "baseline")]
@@ -582,13 +618,17 @@ def run_auto_improve(
         "iterations": max(0, len(state) - 1),  # Exclude baseline
         "improvements": improvements,
         "total_delta": round(total_delta, 1),
-        "baseline_composite": baseline["composite"],
+        "baseline_composite": baseline_reported["composite"],
         "final_composite": reported["composite"],
+        "total_delta_reported": round(
+            reported["composite"] - baseline_reported["composite"], 1
+        ),
         "final_dimensions": reported["dimensions"],
         # Which set decided keep vs revert. The figures above are full-suite.
-        "gate_suite": "val" if val_suite is not None else "none",
+        "gate_suite": gate_basis,
         # What the gate itself saw, kept separate so the two are never confused.
         "gate_composite": final_score["composite"],
+        "gate_baseline_composite": baseline["composite"],
         "stop_reason": reason if should_stop else "max_iterations" if iteration >= start_iteration + max_iterations else "no_patches",
         "dry_run": dry_run,
         "elapsed_seconds": round(elapsed, 1),

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -640,6 +640,19 @@ def run_auto_improve(
     return summary
 
 
+def _printed_delta(summary: dict) -> float:
+    """The delta the human renderer shows, on the same basis as its arrow.
+
+    `total_delta` accumulates the GATE's per-step deltas, which are measured on
+    `val`. Printing it beside a full-suite arrow produced `42 -> 40 (+1.6)`:
+    two numbers, two bases, one line. The renderer uses this instead.
+    """
+    return summary.get(
+        "total_delta_reported",
+        round(summary["final_composite"] - summary["baseline_composite"], 1),
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Schliff Auto-Improve — Autonomous Loop Driver")
     parser.add_argument("skill_path", help="Path to SKILL.md")
@@ -674,7 +687,7 @@ def main():
         bar = progress_bar(sc, 20)
         grade = score_to_grade(sc)
         grade_str = grade_colored(grade)
-        print(f"  Score:  {summary['baseline_composite']:.0f} \u2192 {sc:.0f}/100  {bar}  ({summary['total_delta']:+.1f})  {grade_str}")
+        print(f"  Score:  {summary['baseline_composite']:.0f} \u2192 {sc:.0f}/100  {bar}  ({_printed_delta(summary):+.1f})  {grade_str}")
         print(f"  Iters:  {summary['iterations']}  |  Kept: {summary['improvements']}  |  Time: {time_str}")
         if summary.get('sparkline'):
             print(f"  Trend:  {summary['sparkline']}  ({summary['baseline_composite']:.0f} \u2192 {sc:.0f})")

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -564,6 +564,15 @@ def run_auto_improve(
     elapsed = time.monotonic() - _loop_start
     final_score = _score_skill(skill_path, val_suite) if not dry_run else current_score
 
+    # The keep/revert gate judges `val` — that is the whole point of the split.
+    # But the number the user READS has to be the one `schliff score` and
+    # `schliff verify` produce for the same file, otherwise the loop prints 60,
+    # the user sets --min-score 60, and CI computes 50 and fails. Reported
+    # figures therefore come from the full suite; `gate_suite` says which set
+    # actually decided keep vs revert.
+    scorer.invalidate_cache(skill_path)
+    reported = _score_skill(skill_path, eval_suite)
+
     # Sparkline of score progression
     score_history = [e.get("composite", 0) for e in state if e.get("status") in ("keep", "baseline")]
     sparkline_str = sparkline(score_history) if len(score_history) >= 2 else ""
@@ -574,8 +583,12 @@ def run_auto_improve(
         "improvements": improvements,
         "total_delta": round(total_delta, 1),
         "baseline_composite": baseline["composite"],
-        "final_composite": final_score["composite"],
-        "final_dimensions": final_score["dimensions"],
+        "final_composite": reported["composite"],
+        "final_dimensions": reported["dimensions"],
+        # Which set decided keep vs revert. The figures above are full-suite.
+        "gate_suite": "val" if val_suite is not None else "none",
+        # What the gate itself saw, kept separate so the two are never confused.
+        "gate_composite": final_score["composite"],
         "stop_reason": reason if should_stop else "max_iterations" if iteration >= start_iteration + max_iterations else "no_patches",
         "dry_run": dry_run,
         "elapsed_seconds": round(elapsed, 1),

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -41,9 +41,9 @@ import parallel_runner  # noqa: E402
 # Use underscore aliases for clean imports (wrapper modules for hyphenated originals)
 import score_skill as scorer  # noqa: E402
 import text_gradient as gradient_mod  # noqa: E402
+from eval_split import split_eval_suite  # noqa: E402
 from terminal_art import grade_colored, progress_bar, score_to_grade, sparkline  # noqa: E402
 
-from eval_split import split_eval_suite  # noqa: E402
 from shared import load_eval_suite  # noqa: E402
 
 # --- State Management ---

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -43,6 +43,7 @@ import score_skill as scorer  # noqa: E402
 import text_gradient as gradient_mod  # noqa: E402
 from terminal_art import grade_colored, progress_bar, score_to_grade, sparkline  # noqa: E402
 
+from eval_split import split_eval_suite  # noqa: E402
 from shared import load_eval_suite  # noqa: E402
 
 # --- State Management ---
@@ -308,6 +309,13 @@ def run_auto_improve(
     skill_path = str(Path(skill_path).resolve())
     eval_suite = load_eval_suite(skill_path)
 
+    # Derive edits from `train`, judge them on `val` (ADR 0015). When the two
+    # are not disjoint the loop still runs — but `holdout_leaked` travels into
+    # the summary so the delta is never presented as evidence of generalisation.
+    train_suite, val_suite, holdout_leaked = (
+        split_eval_suite(eval_suite) if eval_suite else (None, None, False)
+    )
+
     # Load existing state for resume
     state = _load_state(skill_path)
     start_iteration = len(state)
@@ -318,7 +326,7 @@ def run_auto_improve(
 
     # Clear scorer cache for fresh reads
     scorer.invalidate_cache(skill_path)
-    baseline = _score_skill(skill_path, eval_suite)
+    baseline = _score_skill(skill_path, val_suite)
 
     if start_iteration == 0:
         baseline_entry = {
@@ -386,7 +394,7 @@ def run_auto_improve(
         # Clear cache and compute gradients
         scorer.invalidate_cache(skill_path)
         gradients = gradient_mod.compute_gradients(
-            skill_path, eval_suite=eval_suite, include_clarity=True
+            skill_path, eval_suite=train_suite, include_clarity=True
         )
 
         if not gradients:
@@ -443,11 +451,11 @@ def run_auto_improve(
             # Score the in-memory candidate content instead.
             if dry_run:
                 new_score = _score_content(
-                    result["new_content"], skill_path, eval_suite
+                    result["new_content"], skill_path, val_suite
                 )
             else:
                 scorer.invalidate_cache(skill_path)
-                new_score = _score_skill(skill_path, eval_suite)
+                new_score = _score_skill(skill_path, val_suite)
             delta = round(new_score["composite"] - current_score["composite"], 1)
 
             if verbose and explore_width > 1:
@@ -554,7 +562,7 @@ def run_auto_improve(
 
     # Final summary
     elapsed = time.monotonic() - _loop_start
-    final_score = _score_skill(skill_path, eval_suite) if not dry_run else current_score
+    final_score = _score_skill(skill_path, val_suite) if not dry_run else current_score
 
     # Sparkline of score progression
     score_history = [e.get("composite", 0) for e in state if e.get("status") in ("keep", "baseline")]
@@ -572,6 +580,8 @@ def run_auto_improve(
         "dry_run": dry_run,
         "elapsed_seconds": round(elapsed, 1),
         "sparkline": sparkline_str,
+        # False only when gradients and gate genuinely saw different cases.
+        "holdout_leaked": holdout_leaked,
     }
 
     return summary

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -208,6 +208,14 @@ def cmd_score(args: argparse.Namespace) -> None:
             sys.exit(1)
         token_info = check_token_budget(skill_content, detected_fmt)
 
+        # Credential detection runs on the RAW file, not on the normalized content
+        # build_scores hands the scorers: line numbers must point at the file the
+        # user named, and the normalization seam at shared.py:232-241 has corrupted
+        # scores here twice already (ADR 0016). Score-neutral by construction — the
+        # findings ride alongside the composite and never enter it (ADR 0011).
+        from scoring.credentials import scan_credentials
+        credentials = scan_credentials(skill_content)
+
         if getattr(args, "json", False):
             # A dimension score of -1 is the sentinel for "not measured" (e.g.
             # triggers/quality/edges with no eval suite). Surface it as JSON null
@@ -232,6 +240,10 @@ def cmd_score(args: argparse.Namespace) -> None:
                 },
                 "warnings": composite["warnings"],
                 "token_budget": token_info,
+                # Vendor + line only. The matched value never enters this object:
+                # the Action hands the whole thing to its PR-comment step as
+                # RESULT_B64, so output sites are not enumerable (ADR 0014).
+                "credentials": credentials,
             }
             print(json.dumps(result, indent=2))
         else:

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -213,6 +213,10 @@ def cmd_score(args: argparse.Namespace) -> None:
         # user named, and the normalization seam at shared.py:232-241 has corrupted
         # scores here twice already (ADR 0016). Score-neutral by construction — the
         # findings ride alongside the composite and never enter it (ADR 0011).
+        # No unknown state to model here: the read above already exits 1 with an
+        # error on an unreadable or oversize file, so this line is only reached
+        # when the raw content is in hand. `verify` needs the third state
+        # because it decides pass/fail; `score` fails closed by not emitting.
         from scoring.credentials import scan_credentials
         credentials = scan_credentials(skill_content)
 

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -295,6 +295,18 @@ def cmd_score(args: argparse.Namespace) -> None:
             else:
                 print(f"  Tokens: {tok:,} / {bud:,} ({token_info['severity']})")
 
+            # Credential findings. `score` reports and never gates (ADR 0014) —
+            # `verify` is the surface that fails. Vendor and line only: naming
+            # the value here would print it into any CI log that runs `score`.
+            if credentials:
+                print()
+                for finding in credentials:
+                    print(
+                        f"  credential: {finding['vendor']} at line {finding['line']}"
+                    )
+                print("  → remove it from the file and rotate the key.")
+                print("    `schliff verify` fails on this at any --min-score.")
+
             # --tokens: section breakdown
             if getattr(args, "tokens", False):
                 lines = skill_content.splitlines()

--- a/skills/schliff/scripts/cli.py
+++ b/skills/schliff/scripts/cli.py
@@ -299,17 +299,19 @@ def cmd_score(args: argparse.Namespace) -> None:
             else:
                 print(f"  Tokens: {tok:,} / {bud:,} ({token_info['severity']})")
 
-            # Credential findings. `score` reports and never gates (ADR 0014) —
-            # `verify` is the surface that fails. Vendor and line only: naming
-            # the value here would print it into any CI log that runs `score`.
+            # Credential findings. No surface gates on these (ADR 0019); shape
+            # does not tell a live key from a documentation example (ADR 0020),
+            # so the wording claims a possibility and not a fact. Vendor and
+            # line only: naming the value here would print it into any CI log
+            # that runs `score`.
             if credentials:
                 print()
                 for finding in credentials:
                     print(
-                        f"  credential: {finding['vendor']} at line {finding['line']}"
+                        f"  possible credential: {finding['vendor']} "
+                        f"at line {finding['line']}"
                     )
-                print("  → remove it from the file and rotate the key.")
-                print("    `schliff verify` fails on this at any --min-score.")
+                print("  → if it is real, remove it from the file and rotate the key.")
 
             # --tokens: section breakdown
             if getattr(args, "tokens", False):

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -326,17 +326,20 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 
-        # Credentials print unconditionally, not behind --verbose: a leak is not
-        # a detail you opt into. Vendor and line only (ADR 0014). `None` is the
-        # third state — the file could not be read, which must not render as a
-        # clean row.
+        # Credentials print unconditionally, not behind --verbose: a possible
+        # leak is not a detail you opt into. Vendor and line only (ADR 0014).
+        # `None` is the third state — the file could not be read, which must not
+        # render as a clean row. "possible" is the same hedge `score` and
+        # `verify` use, because the finding asserts shape and not authenticity
+        # (ADR 0020); doctor in particular reads other people's files, where a
+        # confident claim is least warranted.
         found = r.get("credentials", [])
         if found is None:
             lines.append(f"    {'':25s}  └─ credential scan: could not read the file")
         else:
             for finding in found:
                 lines.append(
-                    f"    {'':25s}  └─ credential: {finding['vendor']} "
+                    f"    {'':25s}  └─ possible credential: {finding['vendor']} "
                     f"at line {finding['line']}"
                 )
 

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -67,10 +67,19 @@ def _default_skill_dirs() -> list[str]:
 
 def _score_single_skill(skill_path: str) -> dict:
     """Score a single skill and return summary."""
-    from shared import build_scores, load_eval_suite
+    from scoring.credentials import scan_credentials
+    from shared import build_scores, load_eval_suite, read_skill_safe
 
     eval_suite = load_eval_suite(skill_path)
     scores = build_scores(skill_path, eval_suite)
+
+    # Doctor reports, it never gates: these are usually somebody else's files
+    # and a red exit on a file you cannot edit helps nobody (ADR 0014). Raw
+    # content so the line points at the real file (ADR 0016).
+    try:
+        credentials = scan_credentials(read_skill_safe(skill_path))
+    except (OSError, ValueError):
+        credentials = []
 
     composite = scorer.compute_composite(scores)
 
@@ -118,6 +127,8 @@ def _score_single_skill(skill_path: str) -> dict:
         "action": action,
         "tokens": tokens,
         "recommendations": recommendations,
+        # Vendor + line only, never the value (ADR 0014).
+        "credentials": credentials,
     }
 
 
@@ -310,6 +321,14 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         action = r["action"][:35]
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
+
+        # Credentials print unconditionally, not behind --verbose: a leak is not
+        # a detail you opt into. Vendor and line only (ADR 0014).
+        for finding in r.get("credentials", []):
+            lines.append(
+                f"    {'':25s}  └─ credential: {finding['vendor']} "
+                f"at line {finding['line']}"
+            )
 
         if verbose and r.get("issues"):
             for issue in r["issues"][:5]:  # Cap at 5 to avoid flooding

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -73,9 +73,10 @@ def _score_single_skill(skill_path: str) -> dict:
     eval_suite = load_eval_suite(skill_path)
     scores = build_scores(skill_path, eval_suite)
 
-    # Doctor reports, it never gates: these are usually somebody else's files
-    # and a red exit on a file you cannot edit helps nobody (ADR 0014). Raw
-    # content so the line points at the real file (ADR 0016).
+    # Doctor reports, it never gates — as every surface now does (ADR 0019).
+    # Doctor was the first place the argument held: these are usually somebody
+    # else's files, and a red exit on a file you cannot edit helps nobody
+    # (ADR 0014). Raw content so the line points at the real file (ADR 0016).
     # `None` means "could not scan", which is not the same as "scanned, clean".
     # verify.py got this contract; doctor did not, so an oversize file with a
     # live key printed a row with no credential line and any `--json` consumer

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -76,10 +76,14 @@ def _score_single_skill(skill_path: str) -> dict:
     # Doctor reports, it never gates: these are usually somebody else's files
     # and a red exit on a file you cannot edit helps nobody (ADR 0014). Raw
     # content so the line points at the real file (ADR 0016).
+    # `None` means "could not scan", which is not the same as "scanned, clean".
+    # verify.py got this contract; doctor did not, so an oversize file with a
+    # live key printed a row with no credential line and any `--json` consumer
+    # testing `if r["credentials"]:` read it as clean.
     try:
         credentials = scan_credentials(read_skill_safe(skill_path))
     except (OSError, ValueError):
-        credentials = []
+        credentials = None
 
     composite = scorer.compute_composite(scores)
 
@@ -323,12 +327,18 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 
         # Credentials print unconditionally, not behind --verbose: a leak is not
-        # a detail you opt into. Vendor and line only (ADR 0014).
-        for finding in r.get("credentials", []):
-            lines.append(
-                f"    {'':25s}  └─ credential: {finding['vendor']} "
-                f"at line {finding['line']}"
-            )
+        # a detail you opt into. Vendor and line only (ADR 0014). `None` is the
+        # third state — the file could not be read, which must not render as a
+        # clean row.
+        found = r.get("credentials", [])
+        if found is None:
+            lines.append(f"    {'':25s}  └─ credential scan: could not read the file")
+        else:
+            for finding in found:
+                lines.append(
+                    f"    {'':25s}  └─ credential: {finding['vendor']} "
+                    f"at line {finding['line']}"
+                )
 
         if verbose and r.get("issues"):
             for issue in r["issues"][:5]:  # Cap at 5 to avoid flooding

--- a/skills/schliff/scripts/eval_split.py
+++ b/skills/schliff/scripts/eval_split.py
@@ -1,0 +1,67 @@
+"""Split an eval suite into a train side and a val side, honestly.
+
+The improvement loop derives its edits from one side and judges them on the
+other. When the two are not disjoint, the comparison carries no information
+about generalisation — and the caller must say so rather than report a delta
+from it. That is what ``leaked`` is for.
+
+Imported from SkillOpt's ``skillopt_sleep/consolidate.py:54-90`` (MIT), whose
+``_split`` returns ``holdout_leaked`` for the same reason.
+
+A case opts in by carrying ``"split": "train" | "val" | "test"``. The ``test``
+split reaches neither side: it is held back from the loop entirely so it can
+still answer a question the loop has not already optimised against.
+"""
+from __future__ import annotations
+
+# Population keys a suite may carry. Anything else is metadata and is copied
+# to both sides unchanged.
+_POPULATIONS = ("triggers", "test_cases", "edge_cases")
+
+_TRAIN, _VAL, _TEST = "train", "val", "test"
+
+
+def split_eval_suite(suite: dict) -> tuple[dict, dict, bool]:
+    """Return ``(train_suite, val_suite, leaked)``.
+
+    ``leaked`` is True when the two sides are not disjoint — because the suite
+    carries no split labels at all, or because a population has cases on only
+    one side. A leaked split is still returned so the loop can run; the caller
+    is responsible for not presenting its delta as evidence.
+    """
+    train: dict = {k: v for k, v in suite.items() if k not in _POPULATIONS}
+    val: dict = dict(train)
+    leaked = False
+
+    for population in _POPULATIONS:
+        cases = suite.get(population)
+        if not isinstance(cases, list) or not cases:
+            continue
+
+        labelled = [c for c in cases if isinstance(c, dict) and c.get("split")]
+        if not labelled:
+            # No opt-in: the loop reads and judges the same cases. Runnable,
+            # but it proves nothing about generalisation.
+            train[population] = list(cases)
+            val[population] = list(cases)
+            leaked = True
+            continue
+
+        train_cases = [c for c in cases if _label(c) == _TRAIN]
+        val_cases = [c for c in cases if _label(c) == _VAL]
+
+        # One side empty means nothing is being held out for this population.
+        if not train_cases or not val_cases:
+            leaked = True
+
+        train[population] = train_cases
+        val[population] = val_cases
+
+    return train, val, leaked
+
+
+def _label(case: object) -> str:
+    if not isinstance(case, dict):
+        return ""
+    value = case.get("split")
+    return value.strip().lower() if isinstance(value, str) else ""

--- a/skills/schliff/scripts/eval_split.py
+++ b/skills/schliff/scripts/eval_split.py
@@ -32,6 +32,7 @@ def split_eval_suite(suite: dict) -> tuple[dict, dict, bool]:
     train: dict = {k: v for k, v in suite.items() if k not in _POPULATIONS}
     val: dict = dict(train)
     leaked = False
+    held_something_out = False
 
     for population in _POPULATIONS:
         cases = suite.get(population)
@@ -40,14 +41,19 @@ def split_eval_suite(suite: dict) -> tuple[dict, dict, bool]:
 
         labelled = [c for c in cases if isinstance(c, dict) and c.get("split")]
         if not labelled:
-            # No opt-in: the loop reads and judges the same cases. Runnable,
-            # but it proves nothing about generalisation.
+            # No opt-in anywhere: the loop reads and judges the same cases.
+            # Runnable, but it proves nothing about generalisation.
             train[population] = list(cases)
             val[population] = list(cases)
             leaked = True
             continue
 
-        train_cases = [c for c in cases if _label(c) == _TRAIN]
+        # An unlabelled case in a partly labelled population goes to `train`.
+        # Dropping it — as an earlier version did — deleted 43 of 44 cases the
+        # moment a user marked one `test`, which emptied the population, turned
+        # three dimensions into the unmeasured sentinel and blinded the gate
+        # without saying so.
+        train_cases = [c for c in cases if _label(c) in (_TRAIN, "")]
         val_cases = [c for c in cases if _label(c) == _VAL]
 
         # One side empty means nothing is being held out for this population.
@@ -56,6 +62,14 @@ def split_eval_suite(suite: dict) -> tuple[dict, dict, bool]:
 
         train[population] = train_cases
         val[population] = val_cases
+        if val_cases:
+            held_something_out = True
+
+    # A suite with no populations, or only empty ones, held nothing out — the
+    # flag has to say so, because its documented meaning is "gradients and gate
+    # genuinely saw different cases".
+    if not held_something_out:
+        leaked = True
 
     return train, val, leaked
 

--- a/skills/schliff/scripts/eval_split.py
+++ b/skills/schliff/scripts/eval_split.py
@@ -48,13 +48,12 @@ def split_eval_suite(suite: dict) -> tuple[dict, dict, bool]:
             leaked = True
             continue
 
-        # An unlabelled case in a partly labelled population goes to `train`.
-        # Dropping it — as an earlier version did — deleted 43 of 44 cases the
-        # moment a user marked one `test`, which emptied the population, turned
-        # three dimensions into the unmeasured sentinel and blinded the gate
-        # without saying so.
-        train_cases = [c for c in cases if _label(c) in (_TRAIN, "")]
+        # Only `val` and `test` are special. Everything else — unlabelled AND
+        # unrecognised — is train, so a typo like "traing" can never delete a
+        # case. Dropping on an unknown label was the same silent-drop class the
+        # unlabelled fix removed, one branch over.
         val_cases = [c for c in cases if _label(c) == _VAL]
+        train_cases = [c for c in cases if _label(c) not in (_VAL, _TEST)]
 
         # One side empty means nothing is being held out for this population.
         if not train_cases or not val_cases:

--- a/skills/schliff/scripts/evolve/sanitize.py
+++ b/skills/schliff/scripts/evolve/sanitize.py
@@ -28,9 +28,12 @@ _SECRET_PATTERNS = [
     (re.compile(r'Bearer\s+[a-zA-Z0-9._-]{20,}'), '[REDACTED:bearer-token]'),
     (re.compile(r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----'), '[REDACTED:private-key]'),
     (re.compile(r'AIza[a-zA-Z0-9_-]{35}'), '[REDACTED:google-api-key]'),
-    # ODBC abbreviates Password as Pwd. The lookbehind keeps the conventional
-    # all-caps $PWD working-directory variable intact, per SkillOpt staging.py.
-    (re.compile(r'(?<![A-Za-z0-9])(Pwd|pwd)\s*=\s*[^\s;"\']{8,}'), r'\1=[REDACTED:db-pass]'),
+    # ODBC abbreviates Password as Pwd. Capital-P spelling ONLY: a lowercase
+    # `pwd=` alternative also matched ordinary shell (`pwd=$(pwd)/artifacts`)
+    # and rewrote it to a broken command. The lookbehind stops `Passwd=` style
+    # suffix matches; what keeps the all-caps `$PWD` variable safe is simply
+    # that `PWD` is not in this pattern at all.
+    (re.compile(r'(?<![A-Za-z0-9])Pwd\s*=\s*[^\s;"\']{8,}'), 'Pwd=[REDACTED:db-pass]'),
     (re.compile(r'eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+'), '[REDACTED:jwt]'),
     # Generic assignment catcher — keep last so vendor-specific patterns win.
     # Matches keyword-bearing identifiers (e.g. AWS_SECRET_ACCESS_KEY, db_password,

--- a/skills/schliff/scripts/evolve/sanitize.py
+++ b/skills/schliff/scripts/evolve/sanitize.py
@@ -10,6 +10,13 @@ import re
 # Patterns that indicate secrets — compiled for performance
 _SECRET_PATTERNS = [
     (re.compile(r'sk-ant-[a-zA-Z0-9_-]{20,}'), '[REDACTED:anthropic-key]'),
+    # Modern OpenAI keys (`sk-proj-`, `sk-svcacct-`, `sk-admin-`) carry `-` and
+    # `_` inside the body, so the alnum-only rule below stops at the first
+    # hyphen and cannot match them at all. Hyphens are allowed only behind a
+    # known key prefix: allowing them after a bare `sk-` would redact
+    # kebab-case prose like `sk-add-credential-scanning-to-verify`, and
+    # over-redaction destroys the very prompt it is protecting.
+    (re.compile(r'sk-(?:proj|svcacct|admin)-[a-zA-Z0-9_-]{20,}'), '[REDACTED:openai-key]'),
     (re.compile(r'sk-[a-zA-Z0-9]{20,}'), '[REDACTED:openai-key]'),
     (re.compile(r'AKIA[0-9A-Z]{16}'), '[REDACTED:aws-key]'),
     (re.compile(r'postgres://[^\s"\']+'), '[REDACTED:postgres-url]'),
@@ -31,9 +38,13 @@ _SECRET_PATTERNS = [
     # ODBC abbreviates Password as Pwd, and Microsoft's own connection strings
     # use the all-caps `PWD=`. Both spellings, never the lowercase one: `pwd=`
     # is ordinary shell (`pwd=$(pwd)/artifacts`) and redacting it rewrote the
-    # command. `$` in the lookbehind keeps a `$PWD` reference intact; the
-    # {8,} value bound keeps short assignments out.
-    (re.compile(r'(?<![A-Za-z0-9$])((?:PWD|Pwd)\s*=\s*)[^\s;"\']{8,}'), r'\1[REDACTED:db-pass]'),
+    # command. `$` in the lookbehind keeps a `$PWD` reference intact.
+    #
+    # No length floor: a connection-string password may be six characters, and
+    # nothing else in this set covers the spelling — the generic catcher below
+    # needs a keyword-bearing identifier and a 16-character value, so a short
+    # `PWD=` reached the lineage file verbatim.
+    (re.compile(r'(?<![A-Za-z0-9$])((?:PWD|Pwd)\s*=\s*)[^\s;"\']+'), r'\1[REDACTED:db-pass]'),
     (re.compile(r'eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+'), '[REDACTED:jwt]'),
     # Generic assignment catcher — keep last so vendor-specific patterns win.
     # Matches keyword-bearing identifiers (e.g. AWS_SECRET_ACCESS_KEY, db_password,

--- a/skills/schliff/scripts/evolve/sanitize.py
+++ b/skills/schliff/scripts/evolve/sanitize.py
@@ -28,12 +28,12 @@ _SECRET_PATTERNS = [
     (re.compile(r'Bearer\s+[a-zA-Z0-9._-]{20,}'), '[REDACTED:bearer-token]'),
     (re.compile(r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----'), '[REDACTED:private-key]'),
     (re.compile(r'AIza[a-zA-Z0-9_-]{35}'), '[REDACTED:google-api-key]'),
-    # ODBC abbreviates Password as Pwd. Capital-P spelling ONLY: a lowercase
-    # `pwd=` alternative also matched ordinary shell (`pwd=$(pwd)/artifacts`)
-    # and rewrote it to a broken command. The lookbehind stops `Passwd=` style
-    # suffix matches; what keeps the all-caps `$PWD` variable safe is simply
-    # that `PWD` is not in this pattern at all.
-    (re.compile(r'(?<![A-Za-z0-9])Pwd\s*=\s*[^\s;"\']{8,}'), 'Pwd=[REDACTED:db-pass]'),
+    # ODBC abbreviates Password as Pwd, and Microsoft's own connection strings
+    # use the all-caps `PWD=`. Both spellings, never the lowercase one: `pwd=`
+    # is ordinary shell (`pwd=$(pwd)/artifacts`) and redacting it rewrote the
+    # command. `$` in the lookbehind keeps a `$PWD` reference intact; the
+    # {8,} value bound keeps short assignments out.
+    (re.compile(r'(?<![A-Za-z0-9$])((?:PWD|Pwd)\s*=\s*)[^\s;"\']{8,}'), r'\1[REDACTED:db-pass]'),
     (re.compile(r'eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+'), '[REDACTED:jwt]'),
     # Generic assignment catcher — keep last so vendor-specific patterns win.
     # Matches keyword-bearing identifiers (e.g. AWS_SECRET_ACCESS_KEY, db_password,

--- a/skills/schliff/scripts/evolve/sanitize.py
+++ b/skills/schliff/scripts/evolve/sanitize.py
@@ -16,13 +16,21 @@ _SECRET_PATTERNS = [
     (re.compile(r'mongodb(\+srv)?://[^\s"\']+'), '[REDACTED:mongodb-url]'),
     (re.compile(r'redis://[^\s"\']+'), '[REDACTED:redis-url]'),
     (re.compile(r'mysql://[^\s"\']+'), '[REDACTED:mysql-url]'),
-    (re.compile(r'ghp_[a-zA-Z0-9]{36}'), '[REDACTED:github-token]'),
-    (re.compile(r'gho_[a-zA-Z0-9]{36}'), '[REDACTED:github-oauth]'),
+    # All five GitHub token classes, variable length. The previous pair bound at
+    # exactly 36 and covered only ghp_/gho_, so a shorter token or a ghu_/ghs_/ghr_
+    # one survived unless the surrounding text happened to trip the generic
+    # assignment catcher below. Redaction may over-reach; a miss here reaches a
+    # model provider (ADR 0013).
+    (re.compile(r'gho_[a-zA-Z0-9]{20,}'), '[REDACTED:github-oauth]'),
+    (re.compile(r'gh[pusr]_[a-zA-Z0-9]{20,}'), '[REDACTED:github-token]'),
     (re.compile(r'glpat-[a-zA-Z0-9_-]{20,}'), '[REDACTED:gitlab-token]'),
     (re.compile(r'xox[bporas]-[a-zA-Z0-9-]+'), '[REDACTED:slack-token]'),
     (re.compile(r'Bearer\s+[a-zA-Z0-9._-]{20,}'), '[REDACTED:bearer-token]'),
     (re.compile(r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----'), '[REDACTED:private-key]'),
     (re.compile(r'AIza[a-zA-Z0-9_-]{35}'), '[REDACTED:google-api-key]'),
+    # ODBC abbreviates Password as Pwd. The lookbehind keeps the conventional
+    # all-caps $PWD working-directory variable intact, per SkillOpt staging.py.
+    (re.compile(r'(?<![A-Za-z0-9])(Pwd|pwd)\s*=\s*[^\s;"\']{8,}'), r'\1=[REDACTED:db-pass]'),
     (re.compile(r'eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+'), '[REDACTED:jwt]'),
     # Generic assignment catcher — keep last so vendor-specific patterns win.
     # Matches keyword-bearing identifiers (e.g. AWS_SECRET_ACCESS_KEY, db_password,

--- a/skills/schliff/scripts/scoring/credentials.py
+++ b/skills/schliff/scripts/scoring/credentials.py
@@ -9,6 +9,7 @@ A finding carries the vendor and the line, never the matched value (ADR 0014).
 """
 from __future__ import annotations
 
+import bisect
 import re
 
 # (vendor, pattern). Each requires the vendor prefix AND the exact shape that
@@ -22,10 +23,12 @@ _PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
     ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")),
     ("slack_token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}")),
     ("google_api_key", re.compile(r"\bAIza[A-Za-z0-9_-]{31,}")),
-    (
-        "jwt",
-        re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
-    ),
+    # No JWT pattern. A JWT's shape says nothing about whether it is secret:
+    # the jwt.io sample and Supabase's `anon` key are public by design and appear
+    # in real instruction files, and no structural test separates them from a
+    # service key. Under a hard-fail gate with no opt-out (ADR 0011), a class we
+    # cannot decide is a class we must not fire on. Redaction keeps its JWT
+    # pattern — there a false positive is free (ADR 0013).
 )
 
 
@@ -55,6 +58,12 @@ def scan_credentials(content: str) -> list[dict]:
     Each finding is ``{"vendor": str, "line": int}`` with 1-based line numbers.
     The matched value is deliberately absent — see ADR 0014.
     """
+    # Line starts once, then a binary search per finding. Counting newlines per
+    # match made the scan quadratic, and the content comes from a file a CI
+    # caller does not control: 20k findings in 420 KB took 2.8s that way.
+    line_starts = [0]
+    line_starts.extend(m.end() for m in re.finditer(r"\n", content))
+
     findings: list[dict] = []
     for vendor, pattern in _PATTERNS:
         for match in pattern.finditer(content):
@@ -62,6 +71,6 @@ def scan_credentials(content: str) -> list[dict]:
                 continue
             findings.append({
                 "vendor": vendor,
-                "line": content.count("\n", 0, match.start()) + 1,
+                "line": bisect.bisect_right(line_starts, match.start()),
             })
     return findings

--- a/skills/schliff/scripts/scoring/credentials.py
+++ b/skills/schliff/scripts/scoring/credentials.py
@@ -42,9 +42,11 @@ _PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
     # No JWT pattern. A JWT's shape says nothing about whether it is secret:
     # the jwt.io sample and Supabase's `anon` key are public by design and appear
     # in real instruction files, and no structural test separates them from a
-    # service key. Under a hard-fail gate with no opt-out (ADR 0011), a class we
-    # cannot decide is a class we must not fire on. Redaction keeps its JWT
-    # pattern — there a false positive is free (ADR 0013).
+    # service key. The reason outlived the gate that first motivated it: a class
+    # nothing can decide is a class this scan stays out of, because a report
+    # that fires on every published example token is one people learn to ignore
+    # (ADR 0020). Redaction keeps its JWT pattern — there a false positive is
+    # free (ADR 0013).
 )
 
 

--- a/skills/schliff/scripts/scoring/credentials.py
+++ b/skills/schliff/scripts/scoring/credentials.py
@@ -1,0 +1,67 @@
+"""Deterministic credential detection.
+
+Score-neutral and gate-effective (ADR 0011): this module never contributes to a
+score. It is deliberately NOT a scoring dimension and must never be added to
+``scoring.security._CATEGORIES`` — for ``system_prompt`` that dimension is
+always-on and weighted, so a category there would move a published composite.
+
+A finding carries the vendor and the line, never the matched value (ADR 0014).
+"""
+from __future__ import annotations
+
+import re
+
+# (vendor, pattern). Each requires the vendor prefix AND the exact shape that
+# vendor issues, so a placeholder cannot satisfy it (ADR 0012).
+_PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("anthropic_api_key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}")),
+    # `sk-` is Anthropic's prefix too; the lookahead keeps one token from
+    # producing two findings and keeps the vendor label honest.
+    ("openai_api_key", re.compile(r"\bsk-(?!ant-)[A-Za-z0-9_-]{20,}")),
+    ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")),
+    ("slack_token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}")),
+    ("google_api_key", re.compile(r"\bAIza[A-Za-z0-9_-]{31,}")),
+    (
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+    ),
+)
+
+
+# Words a real credential does not contain but a documentation placeholder does.
+# Matching one is decisive: precision is worth more than recall here, because a
+# false positive turns a third party's green build red (ADR 0012).
+_PLACEHOLDER_MARKERS = (
+    "example", "replace", "your", "here", "placeholder", "sample",
+    "dummy", "todo", "fixme", "changeme", "insert", "redacted", "notreal",
+)
+
+# Four or more identical characters in a row — `sk-ant-xxxxxxxx`, `AKIA0000…`.
+_REPEATED_RUN = re.compile(r"(.)\1{3,}")
+
+
+def _is_placeholder(value: str) -> bool:
+    """True when the token announces itself as a stand-in rather than a secret."""
+    lowered = value.lower()
+    if any(marker in lowered for marker in _PLACEHOLDER_MARKERS):
+        return True
+    return bool(_REPEATED_RUN.search(value))
+
+
+def scan_credentials(content: str) -> list[dict]:
+    """Return one finding per structurally valid vendor token in ``content``.
+
+    Each finding is ``{"vendor": str, "line": int}`` with 1-based line numbers.
+    The matched value is deliberately absent — see ADR 0014.
+    """
+    findings: list[dict] = []
+    for vendor, pattern in _PATTERNS:
+        for match in pattern.finditer(content):
+            if _is_placeholder(match.group(0)):
+                continue
+            findings.append({
+                "vendor": vendor,
+                "line": content.count("\n", 0, match.start()) + 1,
+            })
+    return findings

--- a/skills/schliff/scripts/scoring/credentials.py
+++ b/skills/schliff/scripts/scoring/credentials.py
@@ -1,9 +1,14 @@
 """Deterministic credential detection.
 
-Score-neutral and gate-effective (ADR 0011): this module never contributes to a
-score. It is deliberately NOT a scoring dimension and must never be added to
-``scoring.security._CATEGORIES`` — for ``system_prompt`` that dimension is
-always-on and weighted, so a category there would move a published composite.
+Score-neutral (ADR 0011) and reported rather than gated (ADR 0019): this module
+never contributes to a score and never decides an exit code. It is deliberately
+NOT a scoring dimension and must never be added to ``scoring.security._CATEGORIES``
+— for ``system_prompt`` that dimension is always-on and weighted, so a category
+there would move a published composite.
+
+**What a finding claims:** that a string has the shape of a given vendor's
+credential. Not that it is one. Shape does not separate a live key from a
+documentation example (ADR 0020), which is why nothing here gates.
 
 A finding carries the vendor and the line, never the matched value (ADR 0014).
 """
@@ -18,14 +23,18 @@ _PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
     ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
     ("anthropic_api_key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}")),
     # `sk-` is Anthropic's prefix too; the lookahead keeps one token from
-    # producing two findings and keeps the vendor label honest. No BARE hyphens
-    # after the prefix: an earlier `[A-Za-z0-9_-]{20,}` matched kebab-case prose
-    # such as `sk-production-cluster-namespace`, which failed a third party's
-    # build with no way to suppress it. Real keys are `sk-<alnum>` or one known
-    # segment (`proj-`, `svcacct-`, `admin-`) followed by alnum.
+    # producing two findings and keeps the vendor label honest. Hyphens are
+    # allowed inside the body only BEHIND a known key segment (`proj-`,
+    # `svcacct-`, `admin-`), which is the form OpenAI has issued since 2024;
+    # after a bare `sk-` they matched kebab-case prose such as
+    # `sk-production-cluster-namespace` and failed a third party's build
+    # (ADR 0020).
     (
         "openai_api_key",
-        re.compile(r"\bsk-(?!ant-)(?:proj-|svcacct-|admin-)?[A-Za-z0-9_]{20,}"),
+        re.compile(
+            r"\bsk-(?!ant-)(?:(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}"
+            r"|[A-Za-z0-9_]{20,})"
+        ),
     ),
     ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")),
     ("slack_token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}")),
@@ -40,23 +49,23 @@ _PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
 
 
 # Words a real credential does not contain but a documentation placeholder does.
-# Matching one is decisive: precision is worth more than recall here, because a
-# false positive turns a third party's green build red (ADR 0012).
+# These stay: they are the cheapest true signal available, and they silence AWS's
+# own published `AKIAIOSFODNN7EXAMPLE`, which appears in real instruction files.
+#
+# A run of four identical characters used to be treated the same way. It is gone
+# (ADR 0020): `AKIA0000TUVWXY3BCDEF` is a legal AWS key, and suppressing real
+# keys to catch placeholders spelled with `AAAA` was the wrong trade once the
+# finding stopped failing builds (ADR 0019). Recall is the expensive direction
+# now.
 _PLACEHOLDER_MARKERS = (
     "example", "replace", "your", "here", "placeholder", "sample",
     "dummy", "todo", "fixme", "changeme", "insert", "redacted", "notreal",
 )
 
-# Four or more identical characters in a row — `sk-ant-xxxxxxxx`, `AKIA0000…`.
-_REPEATED_RUN = re.compile(r"(.)\1{3,}")
-
 
 def _is_placeholder(value: str) -> bool:
     """True when the token announces itself as a stand-in rather than a secret."""
-    lowered = value.lower()
-    if any(marker in lowered for marker in _PLACEHOLDER_MARKERS):
-        return True
-    return bool(_REPEATED_RUN.search(value))
+    return any(marker in value.lower() for marker in _PLACEHOLDER_MARKERS)
 
 
 def scan_credentials(content: str) -> list[dict]:

--- a/skills/schliff/scripts/scoring/credentials.py
+++ b/skills/schliff/scripts/scoring/credentials.py
@@ -18,8 +18,15 @@ _PATTERNS: tuple[tuple[str, "re.Pattern[str]"], ...] = (
     ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
     ("anthropic_api_key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}")),
     # `sk-` is Anthropic's prefix too; the lookahead keeps one token from
-    # producing two findings and keeps the vendor label honest.
-    ("openai_api_key", re.compile(r"\bsk-(?!ant-)[A-Za-z0-9_-]{20,}")),
+    # producing two findings and keeps the vendor label honest. No BARE hyphens
+    # after the prefix: an earlier `[A-Za-z0-9_-]{20,}` matched kebab-case prose
+    # such as `sk-production-cluster-namespace`, which failed a third party's
+    # build with no way to suppress it. Real keys are `sk-<alnum>` or one known
+    # segment (`proj-`, `svcacct-`, `admin-`) followed by alnum.
+    (
+        "openai_api_key",
+        re.compile(r"\bsk-(?!ant-)(?:proj-|svcacct-|admin-)?[A-Za-z0-9_]{20,}"),
+    ),
     ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}")),
     ("slack_token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}")),
     ("google_api_key", re.compile(r"\bAIza[A-Za-z0-9_-]{31,}")),

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -673,6 +673,27 @@ def format_gradients(gradients: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _targets_another_file(target: object, skill_path: str) -> bool:
+    """True when a gradient's ``target`` names a file other than the patched one.
+
+    ``apply_patches`` only ever writes ``skill_path``, but ``target`` is free to
+    name something else — eleven gradients here name ``eval-suite.json``. Without
+    this check the filter admits them on confidence and effort alone, and a
+    file-A instruction becomes a file-B patch (ADR 0015).
+
+    In-file targets pass through: locators (``line:1``), section names
+    (``body``, ``frontmatter``, ``description``, ``references``, ``directory``),
+    and the skill's own filename.
+    """
+    if not isinstance(target, str) or not target:
+        return False
+    if ":" in target:          # in-file locator, e.g. "line:12"
+        return False
+    if "." not in target:      # a section, not a filename
+        return False
+    return Path(target).name != Path(skill_path).name
+
+
 def generate_patches(skill_path: str, gradients: list[dict]) -> list[dict]:
     """Generate concrete patches for deterministic gradients.
 
@@ -735,6 +756,11 @@ def generate_patches(skill_path: str, gradients: list[dict]) -> list[dict]:
 
     for g in gradients:
         if g.get("confidence") != "high" or g.get("effort", 2) > EFFORT_SIMPLE:
+            continue
+        # Third filter dimension: which file the gradient is even about. Without
+        # it the two already-qualifying eval-suite gradients are stopped only by
+        # a missing handler, which is a gap, not a guard (ADR 0015).
+        if _targets_another_file(g.get("target"), skill_path):
             continue
 
         patch = None

--- a/skills/schliff/scripts/verify.py
+++ b/skills/schliff/scripts/verify.py
@@ -178,6 +178,7 @@ def run_verify(
         "previous_score": None, "delta": None, "regression": False,
         # Uniform key set with the normal verdict (provenance is N/A on an error path).
         "weight_source": "default", "weights_hash": None, "credentials": [],
+        "credential_error": None,
     }
 
     if not Path(skill_path).exists():
@@ -223,45 +224,29 @@ def run_verify(
         "weight_source": result.get("weight_source", "default"),
         "weights_hash": result.get("weights_hash"),
         "credentials": [],
+        # Set only when the raw read failed, so `credentials: None` can say why.
+        "credential_error": None,
     }
 
-    # Credential gate — categorical and independent of --min-score (ADR 0011,
-    # ADR 0014). A leak is not a quality deduction that competes with a
-    # threshold; it fails the build on its own. Reads the raw file so the
-    # reported line points at what the user wrote (ADR 0016), and the message
-    # names vendor and line only — never the value (ADR 0014).
+    # Credential scan — reported, never gated (ADR 0019). Shape does not
+    # separate a real token from a documentation placeholder (ADR 0020), so a
+    # false positive is not fixable by the person it would hit; it must not
+    # decide anyone's exit code. Reads the raw file so the reported line points
+    # at what the user wrote (ADR 0016), and records vendor and line only —
+    # never the value (ADR 0014, still in force).
     from scoring.credentials import scan_credentials
     from shared import read_skill_safe
 
     # Failing to read is NOT "no credentials". An oversize or unreadable file
     # used to swallow the error and scan an empty string, so a 1.6 MB SKILL.md
-    # with a live key passed the gate green. A gate that cannot distinguish
-    # "nothing found" from "could not look" is not a gate.
+    # with a live key rendered as `credentials: []`. `None` keeps "could not
+    # look" distinguishable from "nothing found" — the gate is gone, the three
+    # states are not (`doctor` holds the same contract).
     try:
-        raw_content = read_skill_safe(skill_path)
+        verdict["credentials"] = scan_credentials(read_skill_safe(skill_path))
     except (OSError, ValueError) as exc:
         verdict["credentials"] = None
-        verdict["exit_code"] = 2
-        verdict["message"] = (
-            f"ERROR: cannot scan for credentials: {exc}. "
-            f"Refusing to pass a file that could not be checked."
-        )
-        return verdict
-
-    credentials = scan_credentials(raw_content)
-    if credentials:
-        verdict["credentials"] = credentials
-        verdict["exit_code"] = 1
-        # Rendered as pairs. Two parallel lists — sorted vendors against
-        # scan-ordered lines — pointed the reader at the wrong line and invited
-        # rotating the wrong credential.
-        located = ", ".join(f"{c['vendor']} at line {c['line']}" for c in credentials)
-        verdict["message"] = (
-            f"FAIL: credential detected — {located}. "
-            f"Remove it from the file and rotate the key."
-        )
-        append_history(skill_path, result, history_path)
-        return verdict
+        verdict["credential_error"] = str(exc)
 
     # Threshold check (coverage-aware)
     if composite < effective_min:
@@ -339,6 +324,24 @@ def run_verify(
 def format_verdict(verdict: dict) -> str:
     """Format verdict for human-readable terminal output."""
     lines = [verdict["message"]]
+
+    # The finding has to survive the removal of the gate — it used to be visible
+    # only because it was the failure message (ADR 0019). Vendor and line, never
+    # the value, rendered as pairs: two parallel lists once pointed the reader at
+    # the wrong line and invited rotating the wrong credential.
+    credentials = verdict.get("credentials")
+    if credentials:
+        located = ", ".join(f"{c['vendor']} at line {c['line']}" for c in credentials)
+        lines.append(f"  NOTE: possible credential — {located}.")
+        lines.append(
+            "    If it is real, remove it from the file and rotate the key. "
+            "schliff reports this and does not fail the build: a token's shape "
+            "does not tell a live key from a documentation example."
+        )
+    elif credentials is None:
+        reason = verdict.get("credential_error")
+        detail = f": {reason}" if reason else ""
+        lines.append(f"  NOTE: could not scan for credentials{detail}.")
 
     # Show dimension breakdown on failure or regression
     if verdict["exit_code"] != 0:

--- a/skills/schliff/scripts/verify.py
+++ b/skills/schliff/scripts/verify.py
@@ -177,7 +177,7 @@ def run_verify(
         "passed_threshold": False, "exit_code": 2, "message": "",
         "previous_score": None, "delta": None, "regression": False,
         # Uniform key set with the normal verdict (provenance is N/A on an error path).
-        "weight_source": "default", "weights_hash": None,
+        "weight_source": "default", "weights_hash": None, "credentials": [],
     }
 
     if not Path(skill_path).exists():
@@ -222,7 +222,33 @@ def run_verify(
         # Provenance so CI consumers can confirm the gate used canonical weights.
         "weight_source": result.get("weight_source", "default"),
         "weights_hash": result.get("weights_hash"),
+        "credentials": [],
     }
+
+    # Credential gate — categorical and independent of --min-score (ADR 0011,
+    # ADR 0014). A leak is not a quality deduction that competes with a
+    # threshold; it fails the build on its own. Reads the raw file so the
+    # reported line points at what the user wrote (ADR 0016), and the message
+    # names vendor and line only — never the value (ADR 0014).
+    from scoring.credentials import scan_credentials
+    from shared import read_skill_safe
+
+    try:
+        raw_content = read_skill_safe(skill_path)
+    except (OSError, ValueError):
+        raw_content = ""
+    credentials = scan_credentials(raw_content)
+    if credentials:
+        verdict["credentials"] = credentials
+        verdict["exit_code"] = 1
+        vendors = ", ".join(sorted({c["vendor"] for c in credentials}))
+        locations = ", ".join(str(c["line"]) for c in credentials)
+        verdict["message"] = (
+            f"FAIL: credential detected ({vendors}) at line {locations} — "
+            f"remove it from the file and rotate the key"
+        )
+        append_history(skill_path, result, history_path)
+        return verdict
 
     # Threshold check (coverage-aware)
     if composite < effective_min:

--- a/skills/schliff/scripts/verify.py
+++ b/skills/schliff/scripts/verify.py
@@ -233,19 +233,32 @@ def run_verify(
     from scoring.credentials import scan_credentials
     from shared import read_skill_safe
 
+    # Failing to read is NOT "no credentials". An oversize or unreadable file
+    # used to swallow the error and scan an empty string, so a 1.6 MB SKILL.md
+    # with a live key passed the gate green. A gate that cannot distinguish
+    # "nothing found" from "could not look" is not a gate.
     try:
         raw_content = read_skill_safe(skill_path)
-    except (OSError, ValueError):
-        raw_content = ""
+    except (OSError, ValueError) as exc:
+        verdict["credentials"] = None
+        verdict["exit_code"] = 2
+        verdict["message"] = (
+            f"ERROR: cannot scan for credentials: {exc}. "
+            f"Refusing to pass a file that could not be checked."
+        )
+        return verdict
+
     credentials = scan_credentials(raw_content)
     if credentials:
         verdict["credentials"] = credentials
         verdict["exit_code"] = 1
-        vendors = ", ".join(sorted({c["vendor"] for c in credentials}))
-        locations = ", ".join(str(c["line"]) for c in credentials)
+        # Rendered as pairs. Two parallel lists — sorted vendors against
+        # scan-ordered lines — pointed the reader at the wrong line and invited
+        # rotating the wrong credential.
+        located = ", ".join(f"{c['vendor']} at line {c['line']}" for c in credentials)
         verdict["message"] = (
-            f"FAIL: credential detected ({vendors}) at line {locations} — "
-            f"remove it from the file and rotate the key"
+            f"FAIL: credential detected — {located}. "
+            f"Remove it from the file and rotate the key."
         )
         append_history(skill_path, result, history_path)
         return verdict

--- a/skills/schliff/tests/unit/test_auto_improve_split.py
+++ b/skills/schliff/tests/unit/test_auto_improve_split.py
@@ -90,3 +90,23 @@ def test_summary_headline_matches_the_full_suite_not_val(tmp_path, monkeypatch):
     assert full != val_only, "fixture must actually discriminate"
     assert summary["final_dimensions"]["triggers"] == full
     assert summary["gate_suite"] == "val"
+
+
+def test_printed_delta_matches_the_printed_arrow(tmp_path, monkeypatch, capsys):
+    """The arrow and the parenthesised delta must come from one basis.
+
+    The first attempt at this fix moved baseline and final to the full suite but
+    left the printed delta accumulating gate-side deltas, so `42 -> 40 (+1.6)`
+    was still possible.
+    """
+    skill = _write(tmp_path)
+    monkeypatch.setattr(auto_improve, "load_eval_suite", lambda _p: _suite(labelled=True))
+
+    summary = auto_improve.run_auto_improve(skill, max_iterations=2, dry_run=True)
+
+    arrow_delta = round(
+        summary["final_composite"] - summary["baseline_composite"], 1
+    )
+    assert summary["total_delta_reported"] == arrow_delta
+    # The value the renderer actually prints must be the one matching the arrow.
+    assert auto_improve._printed_delta(summary) == arrow_delta

--- a/skills/schliff/tests/unit/test_auto_improve_split.py
+++ b/skills/schliff/tests/unit/test_auto_improve_split.py
@@ -55,3 +55,38 @@ def test_summary_flags_an_unlabelled_suite(tmp_path, monkeypatch):
     summary = auto_improve.run_auto_improve(skill, max_iterations=1, dry_run=True)
 
     assert summary["holdout_leaked"] is True
+
+
+def test_summary_headline_matches_the_full_suite_not_val(tmp_path, monkeypatch):
+    """Finding 5 of the 2026-08-07 review.
+
+    The gate rightly judges `val`, but the number the user sees has to be the
+    one `schliff score` and `schliff verify` report for the same file —
+    otherwise `/schliff:auto` prints 81, the user sets --min-score 80, and the
+    build fails on a different composite.
+    """
+    # The description must match the val prompts and miss the train ones, or
+    # both sides score the same sentinel and the test proves nothing.
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "---\nname: deploy-helper\n"
+        "description: Deploys the service to staging. Use when asked to deploy or ship.\n"
+        "---\n\n# deploy-helper\n\nRun `make deploy`.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "eval-suite.json").write_text("{}", encoding="utf-8")
+    skill = str(skill_file)
+    suite = {"triggers": (
+        [{"prompt": "rotate the TLS certificate", "should_trigger": True, "split": "train"}] * 4
+        + [{"prompt": "deploy to staging", "should_trigger": True, "split": "val"}] * 4
+    )}
+    monkeypatch.setattr(auto_improve, "load_eval_suite", lambda _p: suite)
+
+    summary = auto_improve.run_auto_improve(skill, max_iterations=1, dry_run=True)
+
+    import score_skill as scorer
+    full = scorer.score_triggers(skill, suite)["score"]
+    val_only = scorer.score_triggers(skill, {"triggers": suite["triggers"][4:]})["score"]
+    assert full != val_only, "fixture must actually discriminate"
+    assert summary["final_dimensions"]["triggers"] == full
+    assert summary["gate_suite"] == "val"

--- a/skills/schliff/tests/unit/test_auto_improve_split.py
+++ b/skills/schliff/tests/unit/test_auto_improve_split.py
@@ -1,0 +1,57 @@
+"""The loop derives edits from `train` and judges them on `val` (ADR 0015).
+
+When the two sides are not disjoint the run must say so, because a delta from a
+non-disjoint comparison is not evidence of anything.
+"""
+import importlib.util
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location("auto_improve", SCRIPTS / "auto-improve.py")
+auto_improve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(auto_improve)
+
+SKILL = """\
+---
+name: deploy-helper
+description: Deploys the service. Use when asked to deploy or ship.
+---
+
+# deploy-helper
+
+Run `make deploy`.
+"""
+
+
+def _suite(labelled: bool):
+    def case(name, split):
+        c = {"prompt": name, "should_trigger": True}
+        if labelled:
+            c["split"] = split
+        return c
+    return {"triggers": [case("a", "train"), case("b", "val")]}
+
+
+def _write(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(SKILL, encoding="utf-8")
+    (tmp_path / "eval-suite.json").write_text("{}", encoding="utf-8")
+    return str(p)
+
+
+def test_summary_reports_a_clean_split(tmp_path, monkeypatch):
+    skill = _write(tmp_path)
+    monkeypatch.setattr(auto_improve, "load_eval_suite", lambda _p: _suite(labelled=True))
+
+    summary = auto_improve.run_auto_improve(skill, max_iterations=1, dry_run=True)
+
+    assert summary["holdout_leaked"] is False
+
+
+def test_summary_flags_an_unlabelled_suite(tmp_path, monkeypatch):
+    skill = _write(tmp_path)
+    monkeypatch.setattr(auto_improve, "load_eval_suite", lambda _p: _suite(labelled=False))
+
+    summary = auto_improve.run_auto_improve(skill, max_iterations=1, dry_run=True)
+
+    assert summary["holdout_leaked"] is True

--- a/skills/schliff/tests/unit/test_credential_gate.py
+++ b/skills/schliff/tests/unit/test_credential_gate.py
@@ -130,3 +130,54 @@ class TestVerifyGate:
         result = _run_cli("verify", skill, "--min-score", "0")
 
         assert LIVE_KEY not in result.stdout + result.stderr
+
+
+class TestReportingSurfaces:
+    """ADR 0014: reporting surfaces display the finding and never change their
+    exit code. A human running `score` must see it too — the JSON branch is for
+    machines, and a leak that only machines can see helps nobody.
+    """
+
+    def test_human_score_output_shows_vendor_and_line(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("score", skill)
+
+        assert "aws_access_key" in result.stdout
+        assert "17" in result.stdout
+        assert LIVE_KEY not in result.stdout
+
+    def test_human_score_still_exits_zero(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("score", skill)
+
+        assert result.returncode == 0, "score reports, it does not gate"
+
+    def test_clean_file_says_nothing_about_credentials(self, tmp_path):
+        skill = _write_skill(tmp_path, "Set `AWS_ACCESS_KEY_ID` in your environment.")
+
+        result = _run_cli("score", skill)
+
+        assert "credential" not in result.stdout.lower()
+
+    def test_doctor_json_reports_the_finding_without_gating(self, tmp_path):
+        _write_skill(tmp_path / "leaky", f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("doctor", "--skill-dirs", str(tmp_path), "--json")
+
+        assert result.returncode == 0, "doctor reports on other people's files"
+        report = json.loads(result.stdout)
+        entries = [r for r in report["results"] if r.get("credentials")]
+        assert len(entries) == 1
+        assert entries[0]["credentials"] == [{"vendor": "aws_access_key", "line": 17}]
+        assert LIVE_KEY not in result.stdout
+
+    def test_doctor_human_output_flags_the_skill(self, tmp_path):
+        _write_skill(tmp_path / "leaky", f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("doctor", "--skill-dirs", str(tmp_path))
+
+        assert "credential" in result.stdout.lower()
+        assert "aws_access_key" in result.stdout
+        assert LIVE_KEY not in result.stdout

--- a/skills/schliff/tests/unit/test_credential_gate.py
+++ b/skills/schliff/tests/unit/test_credential_gate.py
@@ -1,9 +1,10 @@
 """Tests for wiring the credential detector into schliff's surfaces.
 
 ADR 0011 — score-neutral: the composite is bit-identical with and without a
-credential in the file.
-ADR 0014 — gate-effective: `verify` exits non-zero on a finding, independently
-of `--min-score`; reporting surfaces display it and never change their exit code.
+credential in the file. Still in force.
+ADR 0019 — every surface reports and none gates: no finding changes an exit
+code anywhere. The risk this file guards is that removing the gate also removes
+the finding from sight, which would leave the feature with no purpose at all.
 """
 import json
 import subprocess
@@ -107,22 +108,49 @@ class TestScoreNeutrality:
         assert dirty_payload["dimensions"] == clean_payload["dimensions"]
 
 
-class TestVerifyGate:
-    """ADR 0014: `verify` fails on a credential regardless of the threshold."""
+class TestVerifyReportsWithoutGating:
+    """ADR 0019: `verify` shows the finding and exits on the threshold alone."""
 
-    def test_verify_fails_even_with_the_threshold_satisfied(self, tmp_path):
+    def test_verify_exits_zero_with_a_credential_present(self, tmp_path):
         skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
 
         result = _run_cli("verify", skill, "--min-score", "0")
 
-        assert result.returncode != 0, "a credential must fail the gate at any threshold"
+        assert result.returncode == 0, (
+            "a credential no longer fails the build; the classification is "
+            "undecidable and the false positive is not fixable by the person it hits"
+        )
 
-    def test_verify_passes_a_clean_file_at_the_same_threshold(self, tmp_path):
+    def test_verify_still_shows_vendor_and_line(self, tmp_path):
+        """The finding must survive the removal of the gate.
+
+        Deleting the gate by deleting the branch would take the only place
+        `verify` ever mentions a credential with it, and the feature would exit
+        the release silently.
+        """
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("verify", skill, "--min-score", "0")
+        output = result.stdout + result.stderr
+
+        assert "aws_access_key" in output
+        assert "17" in output
+
+    def test_verify_still_fails_on_the_threshold(self, tmp_path):
+        """The other gate is untouched — removing one must not remove both."""
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("verify", skill, "--min-score", "100")
+
+        assert result.returncode == 1
+
+    def test_verify_says_nothing_about_credentials_on_a_clean_file(self, tmp_path):
         skill = _write_skill(tmp_path, "Set `AWS_ACCESS_KEY_ID` in your environment.")
 
         result = _run_cli("verify", skill, "--min-score", "0")
 
         assert result.returncode == 0, result.stderr
+        assert "credential" not in (result.stdout + result.stderr).lower()
 
     def test_verify_never_echoes_the_value(self, tmp_path):
         skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
@@ -154,6 +182,20 @@ class TestReportingSurfaces:
 
         assert result.returncode == 0, "score reports, it does not gate"
 
+    def test_score_does_not_promise_a_gate_that_no_longer_exists(self, tmp_path):
+        """The renderer used to tell the reader that `verify` would fail on this.
+
+        Instructions that outlive the behaviour they describe are the exact
+        follow-on damage that dominated the three review passes: the rule was
+        changed in one module and its neighbouring sentence was left standing.
+        """
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        out = _run_cli("score", skill).stdout.lower()
+
+        assert "verify" not in out or "fails" not in out
+        assert "--min-score" not in out
+
     def test_clean_file_says_nothing_about_credentials(self, tmp_path):
         skill = _write_skill(tmp_path, "Set `AWS_ACCESS_KEY_ID` in your environment.")
 
@@ -181,3 +223,21 @@ class TestReportingSurfaces:
         assert "credential" in result.stdout.lower()
         assert "aws_access_key" in result.stdout
         assert LIVE_KEY not in result.stdout
+
+    def test_every_human_surface_hedges_the_same_way(self, tmp_path):
+        """One wording across surfaces, because one claim is being made.
+
+        `score` and `verify` were changed to say "possible"; `doctor` kept the
+        confident noun for a release. It reads other people's files, where an
+        unhedged claim is least defensible.
+        """
+        skill = _write_skill(tmp_path / "leaky", f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        surfaces = {
+            "score": _run_cli("score", skill).stdout,
+            "verify": _run_cli("verify", skill, "--min-score", "0").stdout,
+            "doctor": _run_cli("doctor", "--skill-dirs", str(tmp_path)).stdout,
+        }
+
+        for name, out in surfaces.items():
+            assert "possible credential" in out.lower(), f"{name} states it as a fact"

--- a/skills/schliff/tests/unit/test_credential_gate.py
+++ b/skills/schliff/tests/unit/test_credential_gate.py
@@ -1,0 +1,132 @@
+"""Tests for wiring the credential detector into schliff's surfaces.
+
+ADR 0011 — score-neutral: the composite is bit-identical with and without a
+credential in the file.
+ADR 0014 — gate-effective: `verify` exits non-zero on a finding, independently
+of `--min-score`; reporting surfaces display it and never change their exit code.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI_PATH = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "cli.py")
+
+# Structurally valid, and free of any placeholder marker.
+LIVE_KEY = "AKIA3XZQ7RBN2WKPLMTV"
+
+SKILL_TEMPLATE = """\
+---
+name: deploy-helper
+description: >
+  Deploys the service to staging and production. Use when the user asks to
+  deploy, ship, release or roll back. Trigger phrases: "deploy to staging",
+  "ship it", "roll back the release". Do NOT use for local dev servers.
+---
+
+# deploy-helper
+
+## Commands
+
+- `make deploy` — deploy to staging
+
+## Configuration
+
+{config}
+
+## Edge cases
+
+- Deploy fails mid-rollout: re-run `make deploy`; it is idempotent.
+"""
+
+
+def _run_cli(*args, timeout=60):
+    return subprocess.run(
+        [sys.executable, CLI_PATH, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _write_skill(tmp_path: Path, config: str) -> str:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    p = tmp_path / "SKILL.md"
+    p.write_text(SKILL_TEMPLATE.format(config=config), encoding="utf-8")
+    return str(p)
+
+
+class TestScoreJsonCarriesTheFinding:
+    """`score --json` is the Action's only data source (ADR 0014)."""
+
+    def test_json_reports_vendor_and_line(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("score", skill, "--json")
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        # Line 17 of the rendered file — verified against the file, not counted
+        # by eye. A wrong line number is worse than no finding (ADR 0016).
+        assert payload["credentials"] == [{"vendor": "aws_access_key", "line": 17}]
+
+    def test_json_omits_nothing_when_clean(self, tmp_path):
+        skill = _write_skill(tmp_path, "Set `AWS_ACCESS_KEY_ID` in your environment.")
+
+        result = _run_cli("score", skill, "--json")
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["credentials"] == []
+
+    def test_finding_never_carries_the_value(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("score", skill, "--json")
+
+        assert LIVE_KEY not in result.stdout, "the matched value leaked into score output"
+
+
+class TestScoreNeutrality:
+    """ADR 0011: the composite is bit-identical with and without a credential.
+
+    This is a guard, not a driver. It fails the day someone folds the detector
+    into `security._CATEGORIES` — which is exactly the silent break ADR 0011
+    exists to prevent, and it would surface first on `system_prompt`, where the
+    security dimension is always-on and weighted.
+    """
+
+    def test_composite_is_unchanged_by_a_credential(self, tmp_path):
+        clean = _write_skill(tmp_path / "clean", "Set `AWS_ACCESS_KEY_ID` in your environment.")
+        dirty = _write_skill(tmp_path / "dirty", f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        clean_payload = json.loads(_run_cli("score", clean, "--json").stdout)
+        dirty_payload = json.loads(_run_cli("score", dirty, "--json").stdout)
+
+        assert dirty_payload["credentials"], "fixture must actually contain a credential"
+        assert dirty_payload["composite_score"] == clean_payload["composite_score"]
+        assert dirty_payload["dimensions"] == clean_payload["dimensions"]
+
+
+class TestVerifyGate:
+    """ADR 0014: `verify` fails on a credential regardless of the threshold."""
+
+    def test_verify_fails_even_with_the_threshold_satisfied(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("verify", skill, "--min-score", "0")
+
+        assert result.returncode != 0, "a credential must fail the gate at any threshold"
+
+    def test_verify_passes_a_clean_file_at_the_same_threshold(self, tmp_path):
+        skill = _write_skill(tmp_path, "Set `AWS_ACCESS_KEY_ID` in your environment.")
+
+        result = _run_cli("verify", skill, "--min-score", "0")
+
+        assert result.returncode == 0, result.stderr
+
+    def test_verify_never_echoes_the_value(self, tmp_path):
+        skill = _write_skill(tmp_path, f"Set `AWS_ACCESS_KEY_ID={LIVE_KEY}`.")
+
+        result = _run_cli("verify", skill, "--min-score", "0")
+
+        assert LIVE_KEY not in result.stdout + result.stderr

--- a/skills/schliff/tests/unit/test_credential_review_fixes.py
+++ b/skills/schliff/tests/unit/test_credential_review_fixes.py
@@ -70,10 +70,17 @@ class TestScanIsLinear:
         assert [f["line"] for f in scan_credentials(content)] == [4, 6]
 
 
-class TestVerifyCannotFailOpen:
-    """Finding 1. `read_skill_safe` raising must never read as 'no credentials'."""
+class TestUnscannableIsNeverReportedAsClean:
+    """Finding 1, as it survives ADR 0019.
 
-    def test_oversize_skill_does_not_pass_the_gate(self, tmp_path):
+    The gate is gone, so an unreadable file no longer fails the build — that
+    stance only made sense while a finding gated. What must NOT come back is the
+    original defect: swallowing the read error and scanning an empty string, so
+    a 1.6 MB file with a live key rendered as `credentials: []`. Unknown is a
+    third state and stays distinguishable from clean.
+    """
+
+    def test_oversize_skill_reports_unknown_not_empty(self, tmp_path):
         skill = tmp_path / "SKILL.md"
         skill.write_text(
             "---\nname: x\ndescription: d\n---\n\n# x\n\n"
@@ -85,9 +92,11 @@ class TestVerifyCannotFailOpen:
             str(skill), min_score=0.0, history_path=str(tmp_path / "h.jsonl")
         )
 
-        assert verdict["exit_code"] != 0, (
-            "a file that cannot be scanned must not pass the credential gate"
+        assert verdict["credentials"] is None, "unscannable must not read as clean"
+        assert verdict["exit_code"] == 0, (
+            "the threshold decides the exit code now; failing to look is not a failure"
         )
+        assert LIVE_KEY not in verify_mod.format_verdict(verdict)
 
 
 class TestVerifyMessagePairsVendorWithLine:
@@ -107,10 +116,14 @@ class TestVerifyMessagePairsVendorWithLine:
         verdict = verify_mod.run_verify(
             str(skill), min_score=0.0, history_path=str(tmp_path / "h.jsonl")
         )
-        message = verdict["message"]
+        # The pairing rule outlived the gate: under ADR 0019 the finding is a
+        # note in the rendered verdict rather than the failure message, but
+        # sending an operator to the wrong line still risks rotating the wrong
+        # credential.
+        rendered = verify_mod.format_verdict(verdict)
 
-        assert "aws_access_key at line 5" in message
-        assert "anthropic_api_key at line 7" in message
+        assert "aws_access_key at line 5" in rendered
+        assert "anthropic_api_key at line 7" in rendered
 
 
 class TestScoreFailsClosedOnAnUnreadableFile:
@@ -209,6 +222,12 @@ class TestVendorShapesAreActuallyVendorShapes:
     @pytest.mark.parametrize("token", [
         "sk-proj-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3",
         "sk-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ",
+        # Row 1 of the decision brief: hyphens inside the body of a modern
+        # project key. Silent until ADR 0020 widened the body behind a known
+        # prefix — the kebab-case cases above are the other half of that trade
+        # and must stay silent, so the two belong in one class.
+        "sk-proj-Ab3d-Kf9LmQ2xR7tYu1VwZ0nBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef",
+        "sk-svcacct-Ab3d_Kf9-LmQ2xR7tYu1VwZ0nBcDeFgHiJ",
     ])
     def test_real_openai_shapes_still_fire(self, token):
         assert [f["vendor"] for f in scan_credentials(f"key {token}")] == ["openai_api_key"]

--- a/skills/schliff/tests/unit/test_credential_review_fixes.py
+++ b/skills/schliff/tests/unit/test_credential_review_fixes.py
@@ -185,3 +185,91 @@ class TestPwdRedactionDoesNotEatShell:
         secret = "Sup3rSecretValue12345"
 
         assert secret not in redact_secrets(f"DRIVER={{ODBC}};Pwd={secret};")
+
+
+# --- Second review pass, 2026-08-07 -----------------------------------------
+# Six of these were regressions from the first pass's fixes: each repaired the
+# one line the reviewer named and left the symmetric case next to it.
+
+
+class TestVendorShapesAreActuallyVendorShapes:
+    """An OpenAI key has no bare hyphens after its prefix. Kebab-case prose
+    starting with `sk-` must not trip a gate that has no opt-out."""
+
+    @pytest.mark.parametrize("text", [
+        "run: kubectl get pods -n sk-production-cluster-namespace",
+        "Branch naming: sk-add-credential-scanning-to-verify",
+        "See https://docs.acme.com/sk-slovenska-verzia-dokumentacie for details",
+    ])
+    def test_kebab_case_prose_is_not_a_credential(self, text):
+        assert scan_credentials(text) == []
+
+    @pytest.mark.parametrize("token", [
+        "sk-proj-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3",
+        "sk-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ",
+    ])
+    def test_real_openai_shapes_still_fire(self, token):
+        assert [f["vendor"] for f in scan_credentials(f"key {token}")] == ["openai_api_key"]
+
+
+class TestOdbcCoversBothSpellings:
+    """`PWD=` is what Microsoft's own ODBC and pyodbc connection strings use;
+    narrowing to `Pwd` alone traded one blind spot for another."""
+
+    @pytest.mark.parametrize("spelling", ["PWD", "Pwd"])
+    def test_connection_string_password_is_redacted(self, spelling):
+        secret = "Pr0dPassw0rd12345"
+        text = f"DRIVER={{ODBC Driver 17}};SERVER=db;UID=sa;{spelling}={secret};"
+
+        assert secret not in redact_secrets(text)
+
+    def test_lowercase_shell_pwd_still_survives(self):
+        text = "export pwd=/Users/franz/projects/schliff/build"
+
+        assert redact_secrets(text) == text
+
+    def test_the_shell_variable_reference_survives(self):
+        text = "Run the build from $PWD before deploying."
+
+        assert redact_secrets(text) == text
+
+
+class TestSplitNeverDropsACase:
+    """Finding 6. An unrecognised label is a typo, not an instruction to
+    delete the case."""
+
+    def test_a_mistyped_label_keeps_the_case_on_the_train_side(self):
+        suite = {"triggers": [{"prompt": f"p{i}", "split": "traing"} for i in range(40)]}
+
+        train, val, leaked = split_eval_suite(suite)
+
+        assert len(train["triggers"]) == 40, "a typo must not delete 40 cases"
+        assert val["triggers"] == []
+        assert leaked is True
+
+    def test_test_labelled_cases_reach_neither_side(self):
+        suite = {"triggers": [{"prompt": "a", "split": "train"},
+                              {"prompt": "b", "split": "val"},
+                              {"prompt": "c", "split": "test"}]}
+
+        train, val, _ = split_eval_suite(suite)
+
+        assert "c" not in [x["prompt"] for x in train["triggers"] + val["triggers"]]
+
+
+class TestDoctorHonoursTheThreeStateContract:
+    """Finding 3. The rule was applied to verify and not carried to doctor."""
+
+    def test_unreadable_skill_reports_none_not_empty(self, tmp_path):
+        import doctor
+
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: x\ndescription: d\n---\n\n# x\n\n"
+            f"AWS key: {LIVE_KEY}\n" + ("filler\n" * 200000),
+            encoding="utf-8",
+        )
+
+        result = doctor._score_single_skill(str(skill))
+
+        assert result["credentials"] is None, "unscannable must not read as clean"

--- a/skills/schliff/tests/unit/test_credential_review_fixes.py
+++ b/skills/schliff/tests/unit/test_credential_review_fixes.py
@@ -1,0 +1,187 @@
+"""Regression tests for the ten findings of the 2026-08-07 code review.
+
+Each test was confirmed red against the branch before the corresponding fix.
+The theme of the review was a gate that fails in both directions: it fired on
+published example tokens, and it stayed silent when it could not read the file.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+import verify as verify_mod
+from eval_split import split_eval_suite
+from evolve.sanitize import redact_secrets
+from scoring.credentials import scan_credentials
+
+CLI_PATH = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "cli.py")
+LIVE_KEY = "AKIAZ3F7Q2W9B1N4K6XD"
+
+JWT_IO_SAMPLE = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
+    ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+)
+
+
+class TestNoFalsePositiveOnPublishedTokens:
+    """Finding 3. A JWT's shape says nothing about whether it is secret: the
+    jwt.io sample and a Supabase `anon` key are public by design and appear in
+    real instruction files. A gate with no opt-out cannot fire on them."""
+
+    def test_jwt_io_sample_is_not_a_finding(self):
+        assert scan_credentials(f"Example token: {JWT_IO_SAMPLE}\n") == []
+
+    def test_supabase_anon_key_is_not_a_finding(self):
+        anon = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            ".eyJpc3MiOiJzdXBhYmFzZSIsInJvbGUiOiJhbm9uIiwiaWF0IjoxNzAwMDAwMDAwfQ"
+            ".7mQqM4vRtY2wX9zB6cF8gH3jL5pQaScDeFgHiJkLmNo"
+        )
+        assert scan_credentials(f"SUPABASE_ANON_KEY={anon}\n") == []
+
+    def test_a_real_vendor_key_still_fires(self):
+        assert scan_credentials(f"key {LIVE_KEY}\n") != []
+
+
+class TestScanIsLinear:
+    """Finding 10. The scan runs on attacker-controlled content in CI."""
+
+    def test_many_findings_do_not_take_quadratic_time(self):
+        payload = "\n".join(f"AKIA3XZQ7RBN2WKPLMT{chr(65 + i % 26)}" for i in range(20000))
+
+        started = time.perf_counter()
+        findings = scan_credentials(payload)
+        elapsed = time.perf_counter() - started
+
+        assert len(findings) == 20000
+        # Measured at 2.8s before the fix on this input; linear lands far under.
+        assert elapsed < 1.0, f"{len(payload)} bytes took {elapsed:.2f}s"
+
+    def test_line_numbers_stay_correct_after_the_rewrite(self):
+        content = "a\nb\nc\n" + f"key {LIVE_KEY}\n" + "d\n" + f"key {LIVE_KEY}\n"
+
+        assert [f["line"] for f in scan_credentials(content)] == [4, 6]
+
+
+class TestVerifyCannotFailOpen:
+    """Finding 1. `read_skill_safe` raising must never read as 'no credentials'."""
+
+    def test_oversize_skill_does_not_pass_the_gate(self, tmp_path):
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: x\ndescription: d\n---\n\n# x\n\n"
+            f"AWS key: {LIVE_KEY}\n" + ("filler line\n" * 140000),
+            encoding="utf-8",
+        )
+
+        verdict = verify_mod.run_verify(
+            str(skill), min_score=0.0, history_path=str(tmp_path / "h.jsonl")
+        )
+
+        assert verdict["exit_code"] != 0, (
+            "a file that cannot be scanned must not pass the credential gate"
+        )
+
+
+class TestVerifyMessagePairsVendorWithLine:
+    """Finding 7. Sending an operator to the wrong line risks rotating the
+    wrong credential."""
+
+    def test_two_vendors_are_reported_as_pairs(self, tmp_path):
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: x\ndescription: d\n---\n"
+            f"AWS {LIVE_KEY}\n"
+            "filler\n"
+            "ANT sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx\n",
+            encoding="utf-8",
+        )
+
+        verdict = verify_mod.run_verify(
+            str(skill), min_score=0.0, history_path=str(tmp_path / "h.jsonl")
+        )
+        message = verdict["message"]
+
+        assert "aws_access_key at line 5" in message
+        assert "anthropic_api_key at line 7" in message
+
+
+class TestScoreFailsClosedOnAnUnreadableFile:
+    """The cli.py half of finding 2 did NOT reproduce: `score` already exits 1
+    with an error and emits no JSON, so no consumer can read an empty
+    `credentials` list as an all-clear. Pinned here so a later refactor that
+    makes `score` emit JSON on a failed read has to confront this."""
+
+    def test_oversize_file_emits_no_json_at_all(self, tmp_path):
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: x\ndescription: d\n---\n\n# x\n\n"
+            f"AWS key: {LIVE_KEY}\n" + ("filler line\n" * 140000),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [sys.executable, CLI_PATH, "score", str(skill), "--json"],
+            capture_output=True, text=True, timeout=120,
+        )
+
+        assert result.returncode == 1
+        assert result.stdout.strip() == ""
+        assert "could not read" in result.stderr
+
+
+class TestSplitKeepsUnlabelledCases:
+    """Finding 4. One `split` label must not delete the other 43 cases."""
+
+    def test_partial_labelling_keeps_the_rest_on_the_train_side(self):
+        suite = {
+            "triggers": [{"prompt": f"p{i}"} for i in range(43)]
+            + [{"prompt": "held", "split": "test"}]
+        }
+
+        train, val, leaked = split_eval_suite(suite)
+
+        assert len(train["triggers"]) == 43, "unlabelled cases must not vanish"
+        assert [c["prompt"] for c in val["triggers"]] == []
+        assert leaked is True, "an empty val side holds nothing out"
+
+    def test_explicit_labels_still_partition(self):
+        suite = {"triggers": [{"prompt": "a", "split": "train"},
+                              {"prompt": "b", "split": "val"}]}
+
+        train, val, leaked = split_eval_suite(suite)
+
+        assert [c["prompt"] for c in train["triggers"]] == ["a"]
+        assert [c["prompt"] for c in val["triggers"]] == ["b"]
+        assert leaked is False
+
+
+class TestLeakFlagIsHonest:
+    """Finding 6. `holdout_leaked` False must mean something was held out."""
+
+    @pytest.mark.parametrize("suite", [
+        {"triggers": []},
+        {"name": "no populations at all"},
+        {},
+    ])
+    def test_a_suite_that_holds_nothing_out_is_flagged(self, suite):
+        assert split_eval_suite(suite)[2] is True
+
+
+class TestPwdRedactionDoesNotEatShell:
+    """Finding 9. Over-redaction destroys the prompt it is protecting."""
+
+    def test_lowercase_shell_assignment_survives(self):
+        text = "export pwd=/Users/franz/projects/schliff/build"
+
+        assert redact_secrets(text) == text
+
+    def test_odbc_pwd_is_still_redacted(self):
+        secret = "Sup3rSecretValue12345"
+
+        assert secret not in redact_secrets(f"DRIVER={{ODBC}};Pwd={secret};")

--- a/skills/schliff/tests/unit/test_credential_review_fixes.py
+++ b/skills/schliff/tests/unit/test_credential_review_fixes.py
@@ -4,6 +4,7 @@ Each test was confirmed red against the branch before the corresponding fix.
 The theme of the review was a gate that fails in both directions: it fired on
 published example tokens, and it stayed silent when it could not read the file.
 """
+import importlib.util
 import json
 import subprocess
 import sys
@@ -13,9 +14,10 @@ from pathlib import Path
 
 import pytest
 
+import score_skill as scorer
 import verify as verify_mod
 from eval_split import split_eval_suite
-from evolve.sanitize import redact_secrets
+from evolve.sanitize import contains_secrets, redact_secrets
 from scoring.credentials import scan_credentials
 
 CLI_PATH = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "cli.py")
@@ -273,3 +275,175 @@ class TestDoctorHonoursTheThreeStateContract:
         result = doctor._score_single_skill(str(skill))
 
         assert result["credentials"] is None, "unscannable must not read as clean"
+
+
+# --- Third review pass, 2026-08-07 ------------------------------------------
+# Four of the ten findings are ordinary bugs rather than premise failures, so
+# they are fixed regardless of what happens to the credential gate itself.
+# Two are redaction misses (F4, ADR 0013); two are basis errors in the loop.
+
+_AUTO_SPEC = importlib.util.spec_from_file_location(
+    "auto_improve", Path(__file__).resolve().parent.parent.parent / "scripts" / "auto-improve.py"
+)
+auto_improve = importlib.util.module_from_spec(_AUTO_SPEC)
+_AUTO_SPEC.loader.exec_module(auto_improve)
+
+_SKILL_MD = (
+    "---\nname: deploy-helper\n"
+    "description: Deploys the service to staging. Use when asked to deploy or ship.\n"
+    "---\n\n# deploy-helper\n\nRun `make deploy`.\n"
+)
+
+
+def _skill_file(tmp_path: Path) -> str:
+    path = tmp_path / "SKILL.md"
+    path.write_text(_SKILL_MD, encoding="utf-8")
+    (tmp_path / "eval-suite.json").write_text("{}", encoding="utf-8")
+    return str(path)
+
+
+class TestOdbcPasswordsAreNotLengthGated:
+    """A connection-string password may be short, and nothing else in the set
+    covers the ODBC spelling — the generic assignment catcher needs a
+    keyword-bearing identifier and 16 characters, so `PWD=abc123` reached the
+    lineage file verbatim. The eight-character floor was an invented bound."""
+
+    @pytest.mark.parametrize("secret", ["abc123", "s3cr3t", "Pa55"])
+    def test_a_short_connection_string_password_is_redacted(self, secret):
+        text = f"conn: Server=db;PWD={secret};DB=main"
+
+        assert secret not in redact_secrets(text)
+
+    @pytest.mark.parametrize("spelling", ["PWD", "Pwd"])
+    def test_both_spellings_lose_the_short_value(self, spelling):
+        assert "abc123" not in redact_secrets(f"Driver={{ODBC}};{spelling}=abc123;")
+
+    def test_the_shell_variable_reference_still_survives(self):
+        text = "Run the build from $PWD before deploying."
+
+        assert redact_secrets(text) == text
+
+    def test_the_lowercase_shell_assignment_still_survives(self):
+        text = "export pwd=/Users/franz/projects/schliff/build"
+
+        assert redact_secrets(text) == text
+
+
+class TestModernOpenAIKeysAreRedacted:
+    """`sk-proj-` and `sk-svcacct-` keys carry hyphens and underscores inside
+    the body. An alnum-only body stopped at the first hyphen, so the redaction
+    set could not match the key format OpenAI has issued since 2024 — and a
+    miss here reaches a model provider (ADR 0013)."""
+
+    @pytest.mark.parametrize("token", [
+        "sk-proj-Ab3d-Kf9LmQ2xR7tYu1VwZ0nBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef",
+        "sk-svcacct-Ab3d_Kf9LmQ2xR7tYu1VwZ0nBcDeFgHiJkLmNoPqRsTu",
+    ])
+    def test_a_prefixed_key_in_prose_is_redacted(self, token):
+        # Bare prose deliberately: in an assignment the generic name=value rule
+        # would redact it whatever the vendor pattern does, proving nothing.
+        assert token not in redact_secrets(f"Authenticate with {token} and retry.")
+
+    def test_an_anthropic_key_is_still_reported_as_anthropic(self):
+        # Widening the OpenAI body must not make sk-ant- keys match twice and
+        # get reported under the wrong vendor.
+        key = "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx"
+
+        assert contains_secrets(f"Authenticate with {key} please") == [
+            "[REDACTED:anthropic-key]"
+        ]
+
+    @pytest.mark.parametrize("text", [
+        "Branch naming: sk-add-credential-scanning-to-verify",
+        "run: kubectl get pods -n sk-production-cluster-namespace",
+    ])
+    def test_kebab_case_prose_survives(self, text):
+        # Redaction may over-reach, but not into the prompt it is protecting:
+        # hyphens are only allowed behind a known key prefix.
+        assert redact_secrets(text) == text
+
+
+class TestTheGateSeesEveryPopulationTheSuiteHas:
+    """The empty-val guard fired only when ALL THREE populations were empty.
+    A suite whose triggers alone carry `split: val` leaves quality and edges at
+    the unmeasured sentinel on the gate, so a patch that destroys them is kept
+    and written to the user's SKILL.md."""
+
+    SUITE = {
+        "triggers": [
+            {"prompt": "deploy to staging", "should_trigger": True, "split": "val"},
+            {"prompt": "rotate the TLS certificate", "should_trigger": False, "split": "train"},
+        ],
+        "test_cases": [
+            {"name": "deploys", "prompt": "deploy", "split": "train",
+             "assertions": [{"type": "contains", "value": "make deploy", "description": "runs it"}]},
+        ],
+        "edge_cases": [
+            {"name": "no target", "category": "minimal_input", "split": "train",
+             "expected_behavior": "asks which environment",
+             "assertions": [{"type": "contains", "value": "environment"}]},
+        ],
+    }
+
+    def test_a_population_with_no_val_cases_falls_back_to_the_full_suite(self, tmp_path):
+        skill = _skill_file(tmp_path)
+        raw_val = split_eval_suite(self.SUITE)[1]
+        assert scorer.score_quality(skill, raw_val)["score"] == -1, "fixture must reproduce"
+        assert scorer.score_edges(skill, raw_val)["score"] == -1, "fixture must reproduce"
+
+        _train, val, leaked, basis = auto_improve._gate_suites(self.SUITE)
+
+        assert scorer.score_quality(skill, val)["score"] != -1
+        assert scorer.score_edges(skill, val)["score"] != -1
+        assert leaked is True, "a population judged on its own train cases holds nothing out"
+        assert "test_cases" in basis and "edge_cases" in basis
+
+    def test_the_population_that_does_hold_out_keeps_its_holdout(self, tmp_path):
+        _train, val, _leaked, _basis = auto_improve._gate_suites(self.SUITE)
+
+        assert [c["prompt"] for c in val["triggers"]] == ["deploy to staging"]
+
+    def test_a_clean_split_is_left_alone(self):
+        suite = {"triggers": [{"prompt": "a", "should_trigger": True, "split": "train"},
+                              {"prompt": "b", "should_trigger": True, "split": "val"}]}
+
+        _train, _val, leaked, basis = auto_improve._gate_suites(suite)
+
+        assert (leaked, basis) == (False, "val")
+
+
+class TestTheStopThresholdUsesTheReportedBasis:
+    """`_should_stop` compares against 98 and against 90 per dimension — both
+    documented in the module header and both read by a user who runs
+    `schliff score`. Feeding it the val-basis composite made the loop keep
+    iterating on a file every other schliff surface already rates past the
+    threshold."""
+
+    SUITE = {"triggers": (
+        [{"prompt": "rotate the TLS certificate", "should_trigger": True, "split": "train"}] * 4
+        + [{"prompt": "deploy to staging", "should_trigger": True, "split": "val"}] * 4
+    )}
+
+    def test_the_score_it_judges_is_the_score_the_user_reads(self, tmp_path, monkeypatch):
+        skill = _skill_file(tmp_path)
+        monkeypatch.setattr(auto_improve, "load_eval_suite", lambda _p: self.SUITE)
+        seen: list[float] = []
+        real_should_stop = auto_improve._should_stop
+
+        def spy(state, current_score):
+            seen.append(current_score["composite"])
+            return real_should_stop(state, current_score)
+
+        monkeypatch.setattr(auto_improve, "_should_stop", spy)
+
+        auto_improve.run_auto_improve(skill, max_iterations=1, dry_run=True)
+
+        scorer.invalidate_cache(skill)
+        full = auto_improve._score_skill(skill, self.SUITE)["composite"]
+        scorer.invalidate_cache(skill)
+        val_only = auto_improve._score_skill(
+            skill, {"triggers": self.SUITE["triggers"][4:]}
+        )["composite"]
+        assert full != val_only, "fixture must actually discriminate"
+        assert seen, "the loop must reach its stopping check"
+        assert seen[0] == full

--- a/skills/schliff/tests/unit/test_credentials.py
+++ b/skills/schliff/tests/unit/test_credentials.py
@@ -59,16 +59,27 @@ class TestVendorCoverage:
         ("slack_token", "xoxb-2417-9821-A9dK2mNqR7vT4wX1zB6c"),
         ("google_api_key", "AIzaSyD3kL9mN2pQ7rT4vW8xZ1bC6fG5hJ0"),
         ("openai_api_key", "sk-proj-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3"),
-        (
-            "jwt",
-            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0"
-            ".dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-        ),
     ])
     def test_vendor_token_is_detected(self, vendor, token):
         findings = scan_credentials(f"credential: {token}\n")
 
         assert [f["vendor"] for f in findings] == [vendor]
+
+    def test_jwts_are_deliberately_not_detected(self):
+        """A JWT's shape does not say whether it is secret.
+
+        The jwt.io sample and Supabase's `anon` key are public by design and
+        appear in real instruction files; nothing structural separates them
+        from a service key. Under a hard-fail gate with no opt-out, an
+        undecidable class must not fire. Redaction keeps its JWT pattern,
+        where a false positive costs nothing.
+        """
+        jwt = (
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0"
+            ".dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        )
+
+        assert scan_credentials(f"credential: {jwt}\n") == []
 
 
 class TestPlaceholdersNeverFire:

--- a/skills/schliff/tests/unit/test_credentials.py
+++ b/skills/schliff/tests/unit/test_credentials.py
@@ -1,0 +1,136 @@
+"""Unit tests for deterministic credential detection (ADR 0011-0016).
+
+The detector is score-neutral and gate-effective: it never changes a score, and
+a finding never carries the matched value — only the vendor and the line.
+"""
+import time
+
+import pytest
+
+from scoring.credentials import _PATTERNS, scan_credentials
+
+
+class TestFindingPayload:
+    """A finding carries vendor + line, and nothing else (ADR 0014)."""
+
+    def test_reports_aws_key_with_vendor_and_line(self):
+        content = (
+            "# Setup\n"
+            "\n"
+            "Export your key:\n"
+            "\n"
+            "```bash\n"
+            "export AWS_ACCESS_KEY_ID=AKIA3XZQ7RBN2WKPLMTV\n"
+            "```\n"
+        )
+
+        findings = scan_credentials(content)
+
+        assert len(findings) == 1
+        assert findings[0]["vendor"] == "aws_access_key"
+        assert findings[0]["line"] == 6
+
+    def test_reports_anthropic_key(self):
+        content = "Set ANTHROPIC_API_KEY=sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx in your env.\n"
+
+        findings = scan_credentials(content)
+
+        assert len(findings) == 1
+        assert findings[0]["vendor"] == "anthropic_api_key"
+
+    def test_finding_never_carries_the_matched_value(self):
+        secret = "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWx"
+
+        findings = scan_credentials(f"key: {secret}\n")
+
+        assert findings, "expected a finding to assert against"
+        rendered = repr(findings)
+        assert secret not in rendered
+        assert "AbCdEfGh" not in rendered, "no fragment of the value may survive"
+
+
+class TestVendorCoverage:
+    """Each supported vendor is recognised by its own issued shape."""
+
+    @pytest.mark.parametrize("vendor,token", [
+        ("github_token", "ghp_9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ"),
+        ("github_token", "gho_9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ"),
+        ("github_token", "ghs_9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ"),
+        ("slack_token", "xoxb-2417-9821-A9dK2mNqR7vT4wX1zB6c"),
+        ("google_api_key", "AIzaSyD3kL9mN2pQ7rT4vW8xZ1bC6fG5hJ0"),
+        ("openai_api_key", "sk-proj-Nx7Qm2Kd9dK2mNqR7vT4wX1zB6cF8gH3"),
+        (
+            "jwt",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0"
+            ".dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+        ),
+    ])
+    def test_vendor_token_is_detected(self, vendor, token):
+        findings = scan_credentials(f"credential: {token}\n")
+
+        assert [f["vendor"] for f in findings] == [vendor]
+
+
+class TestPlaceholdersNeverFire:
+    """The discriminator is the value, not the location (ADR 0012).
+
+    A false positive here turns somebody else's green build red, so a shape that
+    announces itself as a placeholder must never produce a finding.
+    """
+
+    @pytest.mark.parametrize("placeholder", [
+        "sk-ant-REPLACE_ME_WITH_YOUR_KEY",
+        "sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx",
+        "sk-ant-YOUR_API_KEY_GOES_HERE_1",
+        "sk-ant-api03-EXAMPLE_KEY_NOT_REAL",
+        "AKIAIOSFODNN7EXAMPLE",
+    ])
+    def test_placeholder_produces_no_finding(self, placeholder):
+        assert scan_credentials(f"ANTHROPIC_API_KEY={placeholder}\n") == []
+
+
+class TestReDoSBound:
+    """ADR 0013: first-party patterns prove ReDoS safety by timing, not by the
+    `validate_regex_complexity` heuristic (which guards eval-suite regexes and
+    false-positives on a pattern schliff already ships).
+
+    These patterns run over untrusted file content, so a catastrophic one is a
+    denial of service on any CI that gates with schliff.
+    """
+
+    # Long runs of each pattern's own alphabet, plus near-miss prefixes: the
+    # shapes that make a backtracking engine explore the most.
+    PATHOLOGICAL = (
+        "AKIA" + "A" * 20000,
+        "sk-ant-" + "a" * 20000,
+        "sk-" + "a" * 20000,
+        "ghp_" + "a" * 20000,
+        "xoxb-" + "a-" * 10000,
+        "AIza" + "a" * 20000,
+        "eyJ" + "a" * 20000,
+        "eyJ" + ("a" * 100 + ".") * 200,
+        ("AKIA" + "sk-ant-" + "ghp_") * 2000,
+    )
+
+    # Generous: a catastrophic pattern does not take 1s, it takes minutes. The
+    # margin is what keeps this from flaking on a loaded CI runner.
+    BUDGET_SECONDS = 1.0
+
+    @pytest.mark.parametrize("payload", PATHOLOGICAL)
+    def test_every_pattern_completes_within_budget(self, payload):
+        for vendor, pattern in _PATTERNS:
+            started = time.perf_counter()
+            pattern.findall(payload)
+            elapsed = time.perf_counter() - started
+            assert elapsed < self.BUDGET_SECONDS, (
+                f"{vendor} took {elapsed:.3f}s on a {len(payload)}-char payload"
+            )
+
+    def test_full_scan_completes_within_budget(self):
+        payload = "\n".join(self.PATHOLOGICAL)
+
+        started = time.perf_counter()
+        scan_credentials(payload)
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < self.BUDGET_SECONDS, f"scan took {elapsed:.3f}s"

--- a/skills/schliff/tests/unit/test_credentials.py
+++ b/skills/schliff/tests/unit/test_credentials.py
@@ -83,21 +83,40 @@ class TestVendorCoverage:
 
 
 class TestPlaceholdersNeverFire:
-    """The discriminator is the value, not the location (ADR 0012).
+    """A token that names itself a stand-in produces no finding (ADR 0020).
 
-    A false positive here turns somebody else's green build red, so a shape that
-    announces itself as a placeholder must never produce a finding.
+    Marker words are all that is left of the placeholder test, and they are the
+    only part that never cost a real key: `example`, `your`, `replace` and the
+    rest do not occur in issued credentials.
     """
 
     @pytest.mark.parametrize("placeholder", [
         "sk-ant-REPLACE_ME_WITH_YOUR_KEY",
-        "sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx",
         "sk-ant-YOUR_API_KEY_GOES_HERE_1",
         "sk-ant-api03-EXAMPLE_KEY_NOT_REAL",
         "AKIAIOSFODNN7EXAMPLE",
     ])
     def test_placeholder_produces_no_finding(self, placeholder):
         assert scan_credentials(f"ANTHROPIC_API_KEY={placeholder}\n") == []
+
+
+class TestTheAcceptedFalsePositives:
+    """The price of dropping the repeated-run heuristic, pinned so it is a
+    decision on record rather than a surprise (ADR 0020).
+
+    `sk-ant-xxxxxxxx` is documentation and now produces a finding, because the
+    same rule that suppressed it also suppressed `AKIA0000TUVWXY3BCDEF`, which
+    is a legal AWS key. Under ADR 0019 this costs a line of output; before it,
+    the reverse error cost an unseen credential.
+    """
+
+    def test_a_repeated_character_placeholder_now_fires(self):
+        assert scan_credentials("ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxx\n") != []
+
+    def test_and_the_real_key_it_used_to_hide_fires_too(self):
+        assert [f["vendor"] for f in scan_credentials("AKIA0000TUVWXY3BCDEF\n")] == [
+            "aws_access_key"
+        ]
 
 
 class TestReDoSBound:

--- a/skills/schliff/tests/unit/test_eval_split.py
+++ b/skills/schliff/tests/unit/test_eval_split.py
@@ -1,0 +1,81 @@
+"""Train/val split of an eval suite, with an honest leak flag (ADR 0015).
+
+Imported from SkillOpt's `skillopt_sleep/consolidate.py:54-90`, whose `_split`
+returns `holdout_leaked` precisely so a non-disjoint comparison cannot be
+reported as a clean win.
+"""
+from eval_split import split_eval_suite
+
+
+def _case(name, split=None):
+    case = {"prompt": name}
+    if split is not None:
+        case["split"] = split
+    return case
+
+
+class TestExplicitSplit:
+    def test_partitions_each_population_by_its_split_field(self):
+        suite = {
+            "triggers": [_case("a", "train"), _case("b", "val"), _case("c", "test")],
+            "test_cases": [_case("d", "train"), _case("e", "val")],
+        }
+
+        train, val, leaked = split_eval_suite(suite)
+
+        assert [c["prompt"] for c in train["triggers"]] == ["a"]
+        assert [c["prompt"] for c in val["triggers"]] == ["b"]
+        assert [c["prompt"] for c in train["test_cases"]] == ["d"]
+        assert [c["prompt"] for c in val["test_cases"]] == ["e"]
+        assert leaked is False
+
+    def test_test_split_reaches_neither_side(self):
+        suite = {"triggers": [_case("a", "train"), _case("b", "val"), _case("c", "test")]}
+
+        train, val, _ = split_eval_suite(suite)
+
+        prompts = [c["prompt"] for c in train["triggers"] + val["triggers"]]
+        assert "c" not in prompts, "the test split is held back from the loop entirely"
+
+
+class TestLeakFlag:
+    """A non-disjoint comparison must announce itself rather than report a win."""
+
+    def test_unlabelled_suite_is_flagged_as_leaked(self):
+        suite = {"triggers": [_case("a"), _case("b"), _case("c")]}
+
+        train, val, leaked = split_eval_suite(suite)
+
+        assert leaked is True, "without split labels, gradient and gate see the same cases"
+        assert train["triggers"] == val["triggers"]
+
+    def test_population_with_only_a_train_side_is_flagged(self):
+        suite = {"triggers": [_case("a", "train"), _case("b", "train")]}
+
+        _, _, leaked = split_eval_suite(suite)
+
+        assert leaked is True, "an empty val side cannot hold anything out"
+
+    def test_a_single_case_cannot_carry_a_split(self):
+        suite = {"triggers": [_case("a", "train")]}
+
+        _, _, leaked = split_eval_suite(suite)
+
+        assert leaked is True
+
+
+class TestShapePreserved:
+    def test_unknown_keys_survive_on_both_sides(self):
+        suite = {"version": 2, "triggers": [_case("a", "train"), _case("b", "val")]}
+
+        train, val, _ = split_eval_suite(suite)
+
+        assert train["version"] == 2
+        assert val["version"] == 2
+
+    def test_input_suite_is_not_mutated(self):
+        suite = {"triggers": [_case("a", "train"), _case("b", "val")]}
+
+        split_eval_suite(suite)
+
+        assert len(suite["triggers"]) == 2

--- a/skills/schliff/tests/unit/test_gradient_target.py
+++ b/skills/schliff/tests/unit/test_gradient_target.py
@@ -1,0 +1,72 @@
+"""A gradient is applied only to the file its `target` names (ADR 0015).
+
+`generate_patches` filters on confidence and effort and never on target, while
+eleven gradients in `text_gradient.py` name `eval-suite.json` and `apply_patches`
+only ever writes `skill_path`. Two of those eleven already satisfy the filter
+(`:480`, `:491`) and are inert only because no handler exists for their issue
+strings — an accident of handler coverage, not a guard.
+"""
+import text_gradient as tg
+
+SKILL_WITHOUT_FRONTMATTER = "# deploy-helper\n\nDeploys the service.\n"
+
+
+def _write(tmp_path, content=SKILL_WITHOUT_FRONTMATTER):
+    p = tmp_path / "SKILL.md"
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def _gradient(target):
+    """A gradient that generate_patches would otherwise turn into a patch."""
+    return {
+        "dimension": "structure",
+        "issue": "no_frontmatter",
+        "target": target,
+        "op": "insert",
+        "instruction": "Add YAML frontmatter",
+        "delta": 6.0,
+        "confidence": "high",
+        "effort": tg.EFFORT_SIMPLE,
+    }
+
+
+class TestForeignTargetIsNeverPatched:
+    def test_gradient_naming_another_file_produces_no_patch(self, tmp_path):
+        skill = _write(tmp_path)
+
+        patches = tg.generate_patches(skill, [_gradient("eval-suite.json")])
+
+        assert patches == [], "a gradient for another file must not patch the skill"
+
+    def test_gradient_naming_an_arbitrary_other_file_produces_no_patch(self, tmp_path):
+        skill = _write(tmp_path)
+
+        patches = tg.generate_patches(skill, [_gradient("references/api.md")])
+
+        assert patches == []
+
+
+class TestInFileTargetsStillPatch:
+    """The guard must not disturb the targets that mean 'somewhere in this file'."""
+
+    def test_in_file_locator_still_produces_a_patch(self, tmp_path):
+        skill = _write(tmp_path)
+
+        patches = tg.generate_patches(skill, [_gradient("line:1")])
+
+        assert len(patches) == 1
+
+    def test_section_name_still_produces_a_patch(self, tmp_path):
+        skill = _write(tmp_path)
+
+        patches = tg.generate_patches(skill, [_gradient("frontmatter")])
+
+        assert len(patches) == 1
+
+    def test_naming_the_skill_itself_still_produces_a_patch(self, tmp_path):
+        skill = _write(tmp_path)
+
+        patches = tg.generate_patches(skill, [_gradient("SKILL.md")])
+
+        assert len(patches) == 1

--- a/skills/schliff/tests/unit/test_sanitize_coverage.py
+++ b/skills/schliff/tests/unit/test_sanitize_coverage.py
@@ -1,0 +1,42 @@
+"""Redaction gaps in `evolve/sanitize.py` (F4, ADR 0013).
+
+Redaction has the opposite error cost to detection: a false positive here is
+harmless, a false negative sends a credential to a model provider. So this set
+may be aggressive where `scoring/credentials.py` must be precise.
+"""
+import pytest
+
+from evolve.sanitize import redact_secrets
+
+
+class TestGitHubTokenCoverage:
+    """The shipped patterns bound at exactly 36 and cover only ghp_ and gho_."""
+
+    # Bare prose, deliberately: an assignment like `token: <value>` is caught by
+    # the generic name=value rule at sanitize.py:41 whatever the prefix, so it
+    # would pass without any vendor pattern at all and prove nothing.
+    @pytest.mark.parametrize("prefix", ["ghp_", "gho_", "ghu_", "ghs_", "ghr_"])
+    def test_every_github_prefix_is_redacted(self, prefix):
+        token = prefix + "9dK2mNqR7vT4wX1zB6cF8gH3jL5pQ"
+
+        assert token not in redact_secrets(f"Authenticate with {token} and retry.")
+
+    def test_a_token_shorter_than_36_is_still_redacted(self):
+        token = "ghp_" + "9dK2mNqR7vT4wX1zB6cF"  # 20 chars after the prefix
+
+        assert token not in redact_secrets(f"Authenticate with {token} and retry.")
+
+
+class TestOdbcPassword:
+    def test_odbc_pwd_spelling_is_redacted(self):
+        secret = "Sup3rSecretValue12345"
+
+        out = redact_secrets(f"DRIVER={{ODBC}};Pwd={secret};")
+
+        assert secret not in out
+
+    def test_the_conventional_pwd_working_directory_survives(self):
+        # All-caps PWD is the shell's working-directory variable, not a secret.
+        text = "Run the build from $PWD before deploying."
+
+        assert redact_secrets(text) == text

--- a/skills/schliff/tests/unit/test_verify.py
+++ b/skills/schliff/tests/unit/test_verify.py
@@ -576,6 +576,8 @@ class TestVerdictStructure:
             "passed_threshold", "exit_code", "message",
             "previous_score", "delta", "regression",
             "weight_source", "weights_hash",
+            # Vendor + line per finding, never the matched value (ADR 0014).
+            "credentials",
         }
         assert set(verdict.keys()) == expected_keys
 

--- a/skills/schliff/tests/unit/test_verify.py
+++ b/skills/schliff/tests/unit/test_verify.py
@@ -578,6 +578,9 @@ class TestVerdictStructure:
             "weight_source", "weights_hash",
             # Vendor + line per finding, never the matched value (ADR 0014).
             "credentials",
+            # Why `credentials` is None, so "could not look" can say what stopped
+            # it without ever collapsing into "nothing found".
+            "credential_error",
         }
         assert set(verdict.keys()) == expected_keys
 


### PR DESCRIPTION
Imports three things from [microsoft/SkillOpt](https://github.com/microsoft/SkillOpt) (MIT) and ships them as 8.11.0. Two arrived healthy. The third arrived with a premise that turned out to be false, and most of this branch is what followed from measuring that rather than iterating on it.

## What ships

**F1 — the loop stops lying about what it measured.** A gradient that names `eval-suite.json` as its target no longer gets applied to `SKILL.md`, and edits are derived from `train` while the keep/revert gate judges `val` (ADR 0015). `holdout_leaked` travels into the summary, so a delta from a non-disjoint comparison is never presented as evidence.

**F4 — redaction covers what it claimed to cover.** All five GitHub token classes, the ODBC `Pwd=`/`PWD=` spellings including short values, and modern `sk-proj-` keys whose body carries hyphens. `$PWD` and lowercase `pwd=` still survive: over-redaction destroys the prompt it is protecting (ADR 0013).

**F3 — a credential report, not a credential gate.** `score`, `score --json`, `doctor`, `verify` and the Action all display a finding; **none of them changes an exit code**. The composite is bit-identical to 8.10.1, so every pinned `--min-score` behaves exactly as before.

## Why F3 is a report

ADR 0012 rested on one sentence: *"Location carries no information about whether a token is real; shape carries all of it."* Measured against the shipped detector:

| Input | What it is | Old gate |
| --- | --- | --- |
| `sk-proj-…` (hyphens in body) | **real** OpenAI project key | **silent** |
| `AKIA0000TUVWXY3BCDEF` | **real** AWS key | **silent** |
| `AKIA1234567890ABCDEF` | documentation placeholder | **fires** |
| `ghp_abcdefghij…` | documentation placeholder | **fires** |

The same inputs, answered the opposite way round from the intent. Three review passes produced ten confirmed findings each, and the majority of each pass were regressions from the previous pass's fixes — the errors moved rather than disappeared. That is an undecidable classification, not a tuning backlog.

A field run over ~740 real files on the author's machine settles the cost: across 128 instruction files the detector finds **nothing**, and across ~600 documentation files **every finding it produces is documentation about credentials**. A hard-fail gate would have fired only where it was wrong — on someone who cannot fix it, since `schliff-version` defaults to latest and ADR 0011 shipped no opt-out.

So the gate is withdrawn and the finding is kept. Reporting keeps the whole benefit that survives the refutation. It also inverts cleanly: promoting a report back to a gate is a minor release the day a precise discriminator exists; retracting a gate that broke other people's builds is not.

## ADRs

`0010`–`0018` decide the import. Two new ones close it:

- **0019** *(supersedes 0011, 0014)* — nothing gates. Names what survives: 0011's score-neutrality with its `_CATEGORIES` constraint, and 0014's rule that a finding carries vendor and line and never the value.
- **0020** *(supersedes 0012)* — the premise is withdrawn; 0012's decisions stand on corrected reasoning. Recalibrates the patterns now that a false positive costs a line of output rather than a build.

`0011`, `0012` and `0014` each carry a dated superseded-by line. Their reasoning is untouched — without the pointer a reader meets the refuted premise as accepted truth.

## Verification

- **2050 unit tests**, 100 integration, 21 self, 6 proof — all green.
- Every fix on this branch was confirmed red before it was written; the four decision-independent bugs were each reproduced by execution first.
- The README hero is byte-identical to live `schliff score AGENTS.md` output, `install.sh --help` reports v8.11.0, and the widened patterns were timed (80 KB worst-case body: 0.009s).
- The accepted regression is pinned as a test rather than left to be discovered: `sk-ant-xxxxxxxx` is documentation and now produces a finding.

## Follow-up

The `action-selftest.yml` fixture stays post-release and now proves the **green** path — a vendor token must leave the job green and produce the warning annotation. It cannot run earlier: the composite action installs the engine from PyPI, so a fixture added here would exercise 8.10.1 and pass for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)