### PR TITLE
Prove the Action's credential path stays green, in the real wiring

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -18,6 +18,7 @@ on:
       - 'AGENTS.md'
       - '.github/workflows/action-selftest.yml'
       - 'skills/schliff/tests/fixtures/dangling-repo/**'
+      - 'skills/schliff/tests/fixtures/credential-repo/**'
   workflow_dispatch:
 
 permissions:
@@ -144,6 +145,47 @@ jobs:
           set -euo pipefail
           test "${{ steps.gate.outcome }}" = "failure" || { echo "expected failure, got '${{ steps.gate.outcome }}'"; exit 1; }
           echo "fail-on-dangling correctly failed the action"
+
+  # V9: a credential in the file is REPORTED and the job stays GREEN (ADR 0019).
+  #
+  # This is the wiring proof ADR 0014 deferred, inverted. It could not run before
+  # 8.11.0: `action.yml` installs the engine from PyPI, so a fixture added in the
+  # F3 PR would have exercised 8.10.1 — which has no scan — and passed for the
+  # wrong reason. The published engine now has one.
+  #
+  # No `continue-on-error` here on purpose: if the action ever starts exiting
+  # non-zero on a finding again, this job goes red at the action step and never
+  # reaches the assertion. Reaching the assertion IS the green-path proof.
+  credential-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run against a file that carries a vendor token
+        id: cred
+        uses: ./
+        with:
+          skill-path: 'skills/schliff/tests/fixtures/credential-repo/AGENTS.md'
+          comment-on-pr: 'false'
+      - name: Assert the finding is reported, and carries no value
+        env:
+          RESULT_B64: ${{ steps.cred.outputs.result_b64 }}
+        run: |
+          set -euo pipefail
+          python3 -P -c "
+          import base64, json, os
+          raw = base64.b64decode(os.environ['RESULT_B64'])
+          result = json.loads(raw)
+          creds = result['credentials']
+          # Without this the job would also pass on a fixture the detector never
+          # sees, which is the failure mode a green-path test invites.
+          assert creds == [{'vendor': 'aws_access_key', 'line': 16}], creds
+          # ADR 0014 in the real transport: this payload is handed to the
+          # PR-comment step verbatim, so the value must not be in it at all.
+          assert b'AKIA3XZQ7RBN2WKPLMTV' not in raw, 'matched value reached the payload'
+          print('credential reported, job green, value absent')
+          "
 
   # V8: a non-AGENTS format skips the dangling step entirely (empty output).
   non-agents-format:

--- a/skills/schliff/tests/fixtures/credential-repo/AGENTS.md
+++ b/skills/schliff/tests/fixtures/credential-repo/AGENTS.md
@@ -1,0 +1,28 @@
+# Payments service
+
+Fixture for the Action self-test. It carries a structurally valid AWS access
+key ID so the credential scan has something to find — the point of the test is
+that finding it does **not** turn the job red (ADR 0019).
+
+The key is invented. It is not a placeholder in the detector's sense either: it
+carries no marker word, which is deliberate, because a fixture the detector
+skips would leave the self-test green for the wrong reason.
+
+## Setup
+
+Export the deploy credentials before running anything:
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA3XZQ7RBN2WKPLMTV
+export AWS_REGION=eu-central-1
+```
+
+## Commands
+
+- `make deploy` — ship to staging
+- `make rollback` — undo the last deploy
+
+## Conventions
+
+- Never commit a key. This file does, on purpose, and schliff says so without
+  failing the build.


### PR DESCRIPTION
Closes the one follow-up ADR 0014 deferred to after release, in the shape ADR 0019 left it.

## What this proves

The Action's credential path had no end-to-end test, and could not have one before 8.11.0: `action.yml:63` installs the engine from PyPI, so a fixture added in the F3 PR would have exercised 8.10.1 — which has no scan — and passed for the wrong reason. The repo already documents that degradation mode in the `old-engine` job.

8.11.0 is published, so the wiring is testable. What it now asserts is the **green** path, since ADR 0019 removed the red one:

- a file carrying a structurally valid vendor token leaves the job **green**;
- the finding is actually made — exactly `aws_access_key` at line 16;
- the base64 payload handed to the PR-comment step **does not contain the matched value**.

## Why each assertion is there

**The exact finding, not just "some finding".** A green-path test invites the failure mode this repo has hit twice: a fixture the detector never sees produces a green job too. Pinning vendor and line means the job can only pass if the scan really fired.

**The value's absence, in the real transport.** ADR 0014 keeps the matched value out of the data structure because `action.yml:210` hands the whole object to the comment step as `RESULT_B64`, where output sites are not enumerable. Unit tests check the structure; this is the only place the rule is checked on the object that actually travels.

**No `continue-on-error`.** If the action ever starts exiting non-zero on a finding again, the job goes red at the action step and never reaches the assertion. Reaching it is the proof.

## Verification

The assertion was run before pushing against the **published** 8.11.0 in a clean venv — not against the working tree, since that is what the Action installs:

```
credential reported, job green, value absent
[{'vendor': 'aws_access_key', 'line': 16}]
```

The `credential-report` job runs on this PR because the workflow's `paths:` now includes the new fixture directory, so the proof lands in this PR's own checks rather than being asserted in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
