### PR TITLE
Stop the mesh comparing a skill against itself

### DIFF
--- a/skills/schliff/scripts/dashboard.py
+++ b/skills/schliff/scripts/dashboard.py
@@ -119,7 +119,12 @@ def generate_dashboard(
         mesh_result = {"issues": []}
     mesh_issues = [
         i for i in mesh_result.get("issues", [])
-        if skill_name in (i.get("skill_a", ""), i.get("skill_b", ""), i.get("skill", ""))
+        # `name` carries the skill for single-skill findings such as
+        # duplicate_name, which name one skill rather than a pair. Without it
+        # the dashboard silently drops every issue of that shape.
+        if skill_name in (
+            i.get("skill_a", ""), i.get("skill_b", ""), i.get("skill", ""), i.get("name", ""),
+        )
     ]
 
     # 4. Untriaged failures

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -377,7 +377,11 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
     mesh_health = report.get("mesh_health", 100)
     mesh_issues = report.get("mesh_issue_count", 0)
     if mesh_issues > 0:
-        lines.append(f"  Mesh Health: {mesh_health}/100 ({mesh_issues} cross-skill issues)")
+        # "cross-skill" was accurate while every finding named a pair. A
+        # duplicate name names one skill at two paths, so the summary says how
+        # many findings there are and lets `/schliff:mesh` say what they are.
+        noun = "finding" if mesh_issues == 1 else "findings"
+        lines.append(f"  Mesh Health: {mesh_health}/100 ({mesh_issues} mesh {noun})")
         lines.append("  Run /schliff:mesh for details.")
         lines.append("")
 

--- a/skills/schliff/scripts/skill_mesh.py
+++ b/skills/schliff/scripts/skill_mesh.py
@@ -229,12 +229,34 @@ def _lsh_candidates(signatures: list[list[int]], bands: int = 16) -> set[tuple[i
     return candidates
 
 
+def _skill_key(skill: dict) -> str:
+    """Identity of a skill for pairing purposes: its declared name.
+
+    Two SKILL.md files with the same name are one skill found at two paths —
+    a global install plus a project-local copy, a vendored fixture — not two
+    skills competing. Comparing such a pair produces a perfect overlap and a
+    patch instruction naming the same skill on both sides ("Narrow scope: X
+    should own this domain"), which nobody can carry out. Reported separately
+    by `detect_duplicate_names`.
+    """
+    return (skill.get("name") or "").strip().lower()
+
+
+def _is_same_skill(a: dict, b: dict) -> bool:
+    key_a, key_b = _skill_key(a), _skill_key(b)
+    # An unnamed skill parses as "unknown"; two of those are not known to be
+    # the same thing, so they stay comparable.
+    return bool(key_a) and key_a not in ("", "unknown") and key_a == key_b
+
+
 def _detect_overlaps_bruteforce(skills: list[dict], vectors: dict) -> list[dict]:
     """O(n^2) brute-force trigger overlap detection for small skill sets."""
     overlaps = []
     for i in range(len(skills)):
         for j in range(i + 1, len(skills)):
             if i not in vectors or j not in vectors:
+                continue
+            if _is_same_skill(skills[i], skills[j]):
                 continue
 
             sim = _cosine_similarity(vectors[i], vectors[j])
@@ -291,6 +313,11 @@ def detect_trigger_overlaps(skills: list[dict]) -> list[dict]:
     overlaps = []
     for i, j in candidates:
         if i not in vectors or j not in vectors:
+            continue
+        # Same rule as the brute-force path above. Applying it to only one of
+        # the two would make the finding depend on whether the machine happens
+        # to hold 50 skills.
+        if _is_same_skill(skills[i], skills[j]):
             continue
 
         sim = _cosine_similarity(vectors[i], vectors[j])
@@ -378,6 +405,33 @@ def _classify_domain(skill: dict) -> dict[str, float]:
     return domains
 
 
+def detect_duplicate_names(skills: list[dict]) -> list[dict]:
+    """Report one skill name found at more than one path.
+
+    This is what the overlap detectors used to call a critical conflict. It is
+    a real thing worth seeing — only one of the copies wins when the agent
+    resolves the name, and which one is not obvious from the file — but it is
+    not a scope problem, and it is not the author's mistake to fix by rewriting
+    a description. Hence `info`: visible, and costing no health.
+    """
+    by_name: dict[str, list[str]] = defaultdict(list)
+    for skill in skills:
+        key = _skill_key(skill)
+        if key and key != "unknown":
+            by_name[key].append(skill["path"])
+
+    return [
+        {
+            "type": "duplicate_name",
+            "severity": "info",
+            "name": name,
+            "paths": sorted(paths),
+        }
+        for name, paths in sorted(by_name.items())
+        if len(paths) > 1
+    ]
+
+
 def detect_scope_collisions(skills: list[dict]) -> list[dict]:
     """Detect skills with overlapping primary domains and positive scope overlap.
 
@@ -400,6 +454,9 @@ def detect_scope_collisions(skills: list[dict]) -> list[dict]:
         for a_pos in range(len(indices)):
             for b_pos in range(a_pos + 1, len(indices)):
                 i, j = indices[a_pos], indices[b_pos]
+
+                if _is_same_skill(skills[i], skills[j]):
+                    continue
 
                 # Check scope overlap via token overlap
                 tokens_i = set(skills[i].get("tokens", []))
@@ -506,18 +563,33 @@ def generate_mesh_actions(issues: list[dict], skills: list[dict]) -> list[dict]:
 _MESH_CACHE_PATH = Path.home() / ".schliff" / "meta" / "mesh-cache.json"
 
 
+# Bump whenever a detector's verdict changes for unchanged input. The cache
+# keys on skill CONTENT, so without this an upgrade is invisible to everyone who
+# has run `doctor` before: same files, same hashes, cached verdict returned, and
+# the fix they installed never shows. Raised to 2 when same-name pairs stopped
+# being reported as collisions.
+_MESH_CACHE_VERSION = 2
+
+
 def _load_mesh_cache() -> dict:
     """Load mesh analysis cache (content_hash -> analysis results)."""
     if not _MESH_CACHE_PATH.exists():
         return {}
     try:
-        return json.loads(_MESH_CACHE_PATH.read_text(encoding="utf-8"))
+        cache = json.loads(_MESH_CACHE_PATH.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
+    if not isinstance(cache, dict) or cache.get("_version") != _MESH_CACHE_VERSION:
+        # Written by a different analysis. Discard rather than migrate: the
+        # entries are verdicts, and a verdict from older logic is exactly what
+        # must not survive.
+        return {}
+    return cache
 
 
 def _save_mesh_cache(cache: dict) -> None:
     """Save mesh analysis cache."""
+    cache["_version"] = _MESH_CACHE_VERSION
     _MESH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
     _MESH_CACHE_PATH.write_text(json.dumps(cache), encoding="utf-8")
 
@@ -627,6 +699,7 @@ def run_mesh_analysis(
     issues = []
     issues.extend(detect_trigger_overlaps(skills))
     issues.extend(detect_scope_collisions(skills))
+    issues.extend(detect_duplicate_names(skills))
 
     # Generate evolution actions for issues
     actions = generate_mesh_actions(issues, skills)
@@ -711,6 +784,13 @@ def format_mesh_report(result: dict) -> str:
                     f"  [{sev}] Scope collision: {issue['skill_a']} <-> {issue['skill_b']}"
                     f" (domain: {issue['shared_domain']}, overlap: {issue['overlap_score']:.1%})"
                 )
+            elif itype == "duplicate_name":
+                lines.append(
+                    f"  [{sev}] Duplicate name: '{issue['name']}' found at "
+                    f"{len(issue['paths'])} paths — only one of them resolves"
+                )
+                for path in issue["paths"]:
+                    lines.append(f"         {path}")
             lines.append("")
     else:
         lines.append("  No issues found — mesh is healthy!")

--- a/skills/schliff/tests/unit/test_skill_mesh.py
+++ b/skills/schliff/tests/unit/test_skill_mesh.py
@@ -1,0 +1,184 @@
+"""The mesh compares skills against each other — never one against itself.
+
+Two SKILL.md files carrying the same `name` are one skill found at two paths,
+not two skills competing for the same triggers. The mesh used to report the
+pair as a critical scope collision AND a critical trigger overlap, costing 27
+health points and emitting a patch instruction — "Narrow scope: X should own
+this domain" — that names the same skill on both sides and cannot be carried
+out by anyone.
+
+The case is ordinary, not exotic: a skill installed in `~/.claude/skills` and
+again inside a project is the shape schliff itself is distributed in.
+"""
+import json
+
+import skill_mesh
+
+SKILL = """\
+---
+name: {name}
+description: Improve and score a deployment skill. Use when you want to iterate
+  on triggers, run an eval, or forge a better deploy skill.
+---
+
+# {name}
+
+Run `make deploy`.
+"""
+
+
+def _write(root, subdir, name):
+    d = root / subdir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(SKILL.format(name=name), encoding="utf-8")
+    return d / "SKILL.md"
+
+
+def _same_skill_twice(tmp_path):
+    _write(tmp_path, "global", "deploy-helper")
+    _write(tmp_path, "project", "deploy-helper")
+    return skill_mesh.discover_skills([str(tmp_path)])
+
+
+def _two_distinct_skills(tmp_path):
+    _write(tmp_path, "global", "deploy-helper")
+    _write(tmp_path, "project", "release-helper")
+    return skill_mesh.discover_skills([str(tmp_path)])
+
+
+class TestOneSkillAtTwoPathsIsNotAConflict:
+    def test_the_fixture_really_produces_two_entries(self, tmp_path):
+        """Guard: if discovery ever deduplicates by content, the tests below
+        would pass without the code under test doing anything."""
+        skills = _same_skill_twice(tmp_path)
+
+        assert len(skills) == 2
+        assert {s["name"] for s in skills} == {"deploy-helper"}
+
+    def test_it_is_not_a_scope_collision(self, tmp_path):
+        skills = _same_skill_twice(tmp_path)
+
+        assert skill_mesh.detect_scope_collisions(skills) == []
+
+    def test_it_is_not_a_trigger_overlap(self, tmp_path):
+        skills = _same_skill_twice(tmp_path)
+
+        assert skill_mesh.detect_trigger_overlaps(skills) == []
+
+    def test_it_is_reported_as_a_duplicate_name(self, tmp_path):
+        """Silence would be the wrong fix: the same name at two paths means one
+        of them is shadowed, and which one wins is not obvious."""
+        skills = _same_skill_twice(tmp_path)
+
+        dupes = skill_mesh.detect_duplicate_names(skills)
+
+        assert len(dupes) == 1
+        assert dupes[0]["type"] == "duplicate_name"
+        assert dupes[0]["severity"] == "info"
+        assert dupes[0]["name"] == "deploy-helper"
+        assert len(dupes[0]["paths"]) == 2
+
+    def test_it_costs_no_health(self, tmp_path):
+        skills = _same_skill_twice(tmp_path)
+        issues = (
+            skill_mesh.detect_trigger_overlaps(skills)
+            + skill_mesh.detect_scope_collisions(skills)
+            + skill_mesh.detect_duplicate_names(skills)
+        )
+
+        assert skill_mesh.compute_mesh_health(issues)["score"] == 100
+
+
+class TestDistinctSkillsStillCollide:
+    """The discriminator. A fix that silences same-name pairs by silencing the
+    detectors would pass every test above and destroy the module's purpose."""
+
+    def test_two_different_names_still_produce_findings(self, tmp_path):
+        skills = _two_distinct_skills(tmp_path)
+
+        findings = (
+            skill_mesh.detect_scope_collisions(skills)
+            + skill_mesh.detect_trigger_overlaps(skills)
+        )
+
+        assert findings, "identical descriptions under different names must still collide"
+        assert {f["skill_a"] for f in findings} | {f["skill_b"] for f in findings} == {
+            "deploy-helper", "release-helper",
+        }
+
+    def test_and_they_are_not_reported_as_duplicates(self, tmp_path):
+        skills = _two_distinct_skills(tmp_path)
+
+        assert skill_mesh.detect_duplicate_names(skills) == []
+
+
+class TestTheCacheCannotOutliveTheLogic:
+    """`doctor` runs the mesh with `incremental=True`, and the cache keys on
+    skill CONTENT. Upgrading schliff changes no file on the user's disk, so
+    without a version stamp the cached verdict from the old detectors is
+    returned forever and the fix is invisible to everyone who ran `doctor`
+    before installing it. Found by running `doctor` after the fix and reading
+    95/100 next to a fresh mesh run reporting 100/100.
+    """
+
+    def test_a_cache_from_older_logic_is_discarded(self, tmp_path, monkeypatch):
+        cache_path = tmp_path / "mesh-cache.json"
+        _write(tmp_path, "global", "deploy-helper")
+        _write(tmp_path, "project", "deploy-helper")
+        monkeypatch.setattr(skill_mesh, "_MESH_CACHE_PATH", cache_path)
+        skills = skill_mesh.discover_skills([str(tmp_path)])
+        stale = {
+            "_version": skill_mesh._MESH_CACHE_VERSION - 1,
+            "_issues": [{
+                "type": "scope_collision", "severity": "critical",
+                "skill_a": "deploy-helper", "skill_b": "deploy-helper",
+                "shared_domain": "skill", "overlap_score": 1.0,
+            }],
+        }
+        for skill in skills:
+            stale[skill["path"]] = {"content_hash": skill["content_hash"]}
+        cache_path.write_text(json.dumps(stale), encoding="utf-8")
+
+        result = skill_mesh.run_mesh_analysis([str(tmp_path)], incremental=True)
+
+        assert result["health"]["score"] == 100, "stale verdict survived the upgrade"
+        assert [i["type"] for i in result["issues"]] == ["duplicate_name"]
+
+    def test_a_current_cache_is_still_used(self, tmp_path, monkeypatch):
+        """The version stamp must not turn the cache off altogether."""
+        cache_path = tmp_path / "mesh-cache.json"
+        _write(tmp_path, "only", "deploy-helper")
+        monkeypatch.setattr(skill_mesh, "_MESH_CACHE_PATH", cache_path)
+
+        skill_mesh.run_mesh_analysis([str(tmp_path)], incremental=True)
+        second = skill_mesh.run_mesh_analysis([str(tmp_path)], incremental=True)
+
+        assert second.get("cache_hit") is True
+
+
+class TestTheHumanSeesIt:
+    """A finding that reaches the data and not the renderer is worse than none:
+    the header counts it, the list omits it, and the reader concludes the tool
+    is broken. The first cut of this fix did exactly that — "Issues found: 1"
+    above an empty list."""
+
+    def test_the_duplicate_is_printed_not_just_counted(self, tmp_path):
+        _write(tmp_path, "global", "deploy-helper")
+        _write(tmp_path, "project", "deploy-helper")
+
+        result = skill_mesh.run_mesh_analysis([str(tmp_path)])
+        rendered = skill_mesh.format_mesh_report(result)
+
+        assert result["health"]["score"] == 100
+        assert "deploy-helper" in rendered
+        assert "duplicate" in rendered.lower()
+        # Both paths, so the reader can tell which copy to remove.
+        assert rendered.count("SKILL.md") >= 2
+
+    def test_a_clean_mesh_still_says_so(self, tmp_path):
+        _write(tmp_path, "only", "deploy-helper")
+
+        result = skill_mesh.run_mesh_analysis([str(tmp_path)])
+
+        assert result["issues"] == []
+        assert "healthy" in skill_mesh.format_mesh_report(result).lower()


### PR DESCRIPTION
`schliff doctor` reported **Mesh Health 95/100** on this repo, with `Scope collision: schliff <-> schliff (overlap: 40.0%)`. schliff producing a false positive about itself is the one class of bug this project cannot ship.

## Why not "skip test fixtures"

That was the obvious fix and it is the wrong one. It repairs the symptom in this repo and leaves the defect standing in the case that actually matters to users: **the same skill installed in `~/.claude/skills` and again inside a project** — the shape schliff itself is distributed in. Reproduced with a synthetic pair before writing anything:

```
scope_collision  severity=critical  deploy-helper <-> deploy-helper  overlap 1.0
trigger_overlap  severity=critical  deploy-helper <-> deploy-helper
```

Two critical findings, −27 health points, on a perfectly normal install.

## What the defect actually is

The pair is not two skills. It is one skill found at two paths. The proof that the finding is *structurally* wrong rather than merely noisy is the remediation the mesh generates for it:

> Narrow scope: **deploy-helper** should own 'skill' for its specific use case… to disambiguate from **deploy-helper**

An instruction nobody can carry out is not a finding.

So the invariant belongs in the comparison, not in discovery: **a pair sharing a declared name is never compared.** Applied at all three comparison sites — brute-force overlap, the LSH path taken at ≥50 skills, and scope collisions. Fixing only the brute-force path would have made the verdict depend on how many skills the machine happens to hold.

## What replaces it

Silence would be the wrong fix — the same name at two paths means one copy is shadowed, and which one wins is not visible in the file. `duplicate_name` reports it at `info` severity: visible, costing no health, naming both paths.

```
[INFO] Duplicate name: 'schliff' found at 2 paths — only one of them resolves
       skills/schliff/SKILL.md
       skills/schliff/tests/fixtures/self-skill-baseline/SKILL.md
```

## Two follow-on defects, both found by running it rather than reading it

**The renderer printed `Issues found: 1` above an empty list.** It knew only the two pair-shaped types. A finding that reaches the data and not the reader is worse than none.

**`doctor` still said 95/100 after the fix.** The incremental cache keys on skill *content*, and upgrading schliff changes no file on the user's disk — so every user who had ever run `doctor` would have kept the old verdict **forever** and never seen the fix. The cache now carries a version stamp, and a stale verdict is discarded rather than migrated: the verdict is the thing that changed.

`dashboard.py` filtered per-skill issues on `skill_a`/`skill_b`/`skill` and would have dropped the new single-skill shape silently. It reads `name` too now.

## Verification

`skill_mesh.py` had **no tests at all**. It has 11 now, each confirmed red first — including the discriminator: two *different* skills with identical descriptions must still collide. A fix that silenced the detectors would pass every other test in the file and destroy the module's purpose.

Whole suite: **2061 passed**. `doctor` on this repo now reads `Mesh Health: 100/100 (1 mesh finding)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
