### PR TITLE
chore(release): 8.11.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "schliff",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "description": "Deterministic quality scorer for AI instruction files (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md). 9 scorers incl. operational_coverage, anti-gaming detection, autoresearch-style autonomous improvement.",
   "author": {
     "name": "Zandereins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [8.11.1] - 2026-08-10
+
+### Fixed
+
+- **The skill mesh no longer reports a skill as colliding with itself.** Installing the
+  same skill in two places — `~/.claude/skills` plus a project-local copy, which is how
+  schliff itself is distributed — produced two *critical* findings and cost 27 mesh-health
+  points. The pair was never two skills competing; it is one skill at two paths, and the
+  remediation the mesh generated for it named the same skill on both sides. Pairs sharing a
+  declared name are no longer compared, at every comparison site.
+- **A duplicate skill name is now reported as what it is.** `duplicate_name` (severity
+  `info`, no health penalty) names every path the skill was found at, because only one of
+  them resolves and the file itself does not say which.
+- **`doctor` shows mesh findings again after an upgrade.** Its incremental cache keys on
+  skill *content*, so upgrading schliff — which changes no file on your disk — used to
+  return the verdict computed by the previous version indefinitely. The cache now carries a
+  version stamp and discards verdicts written by different analysis logic.
+
 ## [8.11.0] - 2026-08-10
 
 ### Added
@@ -1410,7 +1428,8 @@ measured, reported wrongly. Three of them were found by verifying the fourth.
 
 - Initial release — 6-dimension scoring, eval runner, progress tracking
 
-[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.11.0...HEAD
+[Unreleased]: https://github.com/Zandereins/schliff/compare/v8.11.1...HEAD
+[8.11.1]: https://github.com/Zandereins/schliff/compare/v8.11.0...v8.11.1
 [8.11.0]: https://github.com/Zandereins/schliff/compare/v8.10.1...v8.11.0
 [8.10.1]: https://github.com/Zandereins/schliff/compare/v8.10.0...v8.10.1
 [8.10.0]: https://github.com/Zandereins/schliff/compare/v8.9.0...v8.10.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **The Ruff for `AGENTS.md` — deterministic quality scores for the instruction files that drive your AI. Same input, same score, on every machine.**
 
-[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.11.0)](https://pypi.org/project/schliff/)
+[![PyPI](https://img.shields.io/pypi/v/schliff?color=blue&label=PyPI&v=8.11.1)](https://pypi.org/project/schliff/)
 [![Python](https://img.shields.io/pypi/pyversions/schliff)](https://pypi.org/project/schliff/)
 [![Tests](https://github.com/Zandereins/schliff/actions/workflows/test.yml/badge.svg)](https://github.com/Zandereins/schliff/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -30,7 +30,7 @@ This is the real, current output of `schliff score AGENTS.md` on this repo's own
 [`AGENTS.md`](AGENTS.md) — clone and run it yourself:
 
 ```text
-schliff v8.11.0
+schliff v8.11.1
 
   structure             ██████████  100/100  perfect
   operational_coverage  ██████████  100/100  perfect
@@ -46,7 +46,7 @@ schliff v8.11.0
 
 No model produced that number. Run it on another laptop and you get 95.6 again — **a score you can't reproduce isn't a measurement, it's a vibe.** And we hold *ourselves* to that: this repo's own badge (scored in isolation) once disagreed with its own CLI (scored in-repo) by ~15 points on the *same bytes*, because `structure` was crediting an on-disk `references/` neighbourhood instead of the file's content. We fixed the engine, not the file ([#129](https://github.com/Zandereins/schliff/pull/129)) — now `cp AGENTS.md /tmp && schliff score /tmp/AGENTS.md` returns the same number as CI and the badge. (The `agents.md` headline weights `structure`·`operational_coverage`·`efficiency` at 0.4/0.4/0.2; `composability` and `clarity` are shown for information, not counted.)
 
-*The quick-start and case-study numbers here are reproducible from released `schliff==8.11.0` (`pip install schliff==8.11.0` or `uvx schliff@8.11.0`); the hydra field run below is dated to the version it was measured on.*
+*The quick-start and case-study numbers here are reproducible from released `schliff==8.11.1` (`pip install schliff==8.11.1` or `uvx schliff@8.11.1`); the hydra field run below is dated to the version it was measured on.*
 
 ---
 
@@ -262,7 +262,7 @@ fails while the score still gates the PR.
 By default it scores `AGENTS.md` at the repo root; set `skill-path:` to lint a
 `SKILL.md`, `CLAUDE.md`, or `.cursorrules` instead. One caveat: the Action
 installs the latest released engine from PyPI, so after a release its scores can
-lead an older pinned install; pin it with `schliff-version: '8.11.0'` in the
+lead an older pinned install; pin it with `schliff-version: '8.11.1'` in the
 `with:` block if you need byte-stable gates.
 
 ### CI gate without the Action
@@ -286,7 +286,7 @@ files without an eval suite aren't auto-failed. Requires schliff ≥ 8.5.0 for
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Zandereins/schliff
-    rev: v8.11.0
+    rev: v8.11.1
     hooks:
       - id: schliff-verify
         args: ['--min-score', '75']

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ instruction files — the "Ruff for `SKILL.md`", now multi-format. Same input �
 same score, with zero core dependencies (stdlib-only, Python ≥ 3.9). For install
 and quick start, see the [project README](../README.md).
 
-**Current version: 8.11.0.**
+**Current version: 8.11.1.**
 
 ## Understand the tool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "schliff"
-version = "8.11.0"
+version = "8.11.1"
 description = "Deterministic quality scorer for AI agent instruction files. Multi-format (SKILL.md, CLAUDE.md, .cursorrules, AGENTS.md), 8-dimension scoring with security, anti-gaming detection, zero dependencies."
 license = "MIT"
 requires-python = ">=3.10"

--- a/skills/schliff/__init__.py
+++ b/skills/schliff/__init__.py
@@ -1,3 +1,3 @@
 """Schliff — deterministic SKILL.md linter and scoring engine."""
 
-__version__ = "8.11.0"
+__version__ = "8.11.1"


### PR DESCRIPTION
Patch release for the mesh fix in #184, which changes no score, no exit code and no surface — but needs a release to reach anyone, since `doctor` and `mesh` run from the installed package and 8.11.0 still reports a skill as colliding with itself.

Three gated constants in lockstep plus every secondary reference from RELEASING.md. The CHANGELOG gains an 8.11.1 section; the mesh fix shipped without one, which this corrects.

**Verified, not assumed:** `install.sh --help` and the CLI both report 8.11.1; the README hero is byte-identical to live `schliff score AGENTS.md` output; the built wheel was installed into a clean venv and run against a duplicate-name fixture, returning `health: 100 | issues: ['duplicate_name']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)