### PR TITLE
Test on Python 3.14 — and stop pinning a CPython detail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        # The top of the range is the point of this matrix. A parked project
+        # learns about a new CPython from its own CI or not at all — nobody
+        # files an issue against a repo with no watchers. 3.14 caught a real
+        # behaviour change on arrival: its json parser no longer recurses.
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
     "Environment :: Console",

--- a/skills/schliff/tests/unit/test_playground_score.py
+++ b/skills/schliff/tests/unit/test_playground_score.py
@@ -1,8 +1,15 @@
 """Regression guards for the playground/leaderboard JSON parse robustness (PG-1).
 
-Deeply-nested JSON makes json.loads raise RecursionError, which is NOT a subclass
-of ValueError/JSONDecodeError, so it escaped the parse `except` and surfaced as a
-Vercel 500 instead of a clean 400. Both internet-facing parse sites must catch it.
+Deeply-nested JSON makes json.loads raise RecursionError on CPython 3.10-3.13.
+RecursionError is NOT a subclass of ValueError/JSONDecodeError, so it escaped the
+parse `except` and surfaced as a Vercel 500 instead of a clean 400. Both
+internet-facing parse sites must catch it.
+
+CPython 3.14 changed the ground under this: its json parser no longer recurses,
+so the same input raises JSONDecodeError and 20 000-deep *valid* nesting parses
+successfully where it used to be rejected. The guard tuple stays as it is —
+half the supported range still needs it — and the tests below assert
+containment rather than which exception a given interpreter picks.
 """
 from __future__ import annotations
 
@@ -17,11 +24,39 @@ _SCORE_PY = _ROOT / "playground" / "api" / "score.py"
 _SUBMIT_PY = _ROOT / "web" / "leaderboard" / "api" / "submit.py"
 
 
-def test_json_loads_deep_nesting_raises_recursionerror_not_valueerror():
-    # Root-cause pin: confirms the broadened except is actually needed.
-    with pytest.raises(RecursionError):
+# The tuple the production parse sites catch. Named once so the test below
+# asserts against the same thing the code does.
+_PARSE_GUARD = (json.JSONDecodeError, ValueError, RecursionError)
+
+
+def test_deep_nesting_cannot_escape_the_parse_guard():
+    """Nothing thrown by deeply-nested input may fall outside the guard.
+
+    This used to pin `RecursionError` specifically, which made it a statement
+    about CPython rather than about the code under test — and CPython changed:
+    3.14's json parser no longer recurses, so the same 50 000-deep input raises
+    JSONDecodeError there while 3.10-3.13 raise RecursionError. Both are inside
+    the guard, which is the only property that ever mattered.
+    """
+    try:
         json.loads("[" * 50000)
-    # And that it is NOT already caught by the narrow tuple.
+    except _PARSE_GUARD:
+        pass
+    except BaseException as exc:  # noqa: BLE001 — the point is to name escapees
+        pytest.fail(
+            f"{type(exc).__name__} escapes the production except tuple on "
+            f"this interpreter"
+        )
+
+
+def test_recursion_error_must_be_named_explicitly():
+    """Why the tuple cannot shrink to (ValueError, JSONDecodeError).
+
+    Still load-bearing on every supported interpreter: `requires-python` is
+    >=3.10, and on 3.10-3.13 deeply-nested JSON does raise RecursionError.
+    Dropping it because 3.14 no longer needs it would break the older half of
+    the support range.
+    """
     assert not issubclass(RecursionError, (ValueError, json.JSONDecodeError))
 
 

--- a/skills/schliff/tests/unit/test_stress.py
+++ b/skills/schliff/tests/unit/test_stress.py
@@ -212,27 +212,38 @@ class TestBoundaryHeadersOnlyNoContent:
         assert isinstance(result["score"], (int, float))
 
 
+@pytest.fixture(scope="module")
+def large_skill_path(tmp_path_factory):
+    """Build a 10k-line skill once and reuse it across the tests below.
+
+    Module-level rather than a class-scoped method: pytest deprecates a
+    class-scoped fixture defined as an instance method (PytestRemovedIn10Warning,
+    an error in pytest 10) because it runs once while every test gets a fresh
+    instance. `@classmethod` silences that on the supported range but breaks
+    collection outright on 3.9 — `classmethod` objects gained `__name__` only in
+    3.10 — and 3.9 is what `/usr/bin/python3` is on this machine. The fixture
+    never touched `self`, so lifting it out of the class costs nothing and is
+    version-neutral.
+    """
+    tmp = tmp_path_factory.mktemp("large")
+    header = (
+        "---\nname: large-skill\n"
+        "description: Use when you need to process large amounts of content.\n"
+        "---\n\n# Large Skill\n\n"
+    )
+    # 5000 prose lines + 5000 instruction lines
+    body = ("This is content line.\n" * 5000) + ("Run the verification step.\n" * 5000)
+    content = header + body
+    assert len(content.encode()) <= MAX_SKILL_SIZE, (
+        f"Test fixture exceeds MAX_SKILL_SIZE ({MAX_SKILL_SIZE})"
+    )
+    p = tmp / "SKILL.md"
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
 class TestBoundaryLargeSkill:
     """Skill with 10,000 lines — well within the 1 MB limit."""
-
-    @pytest.fixture(scope="class")
-    def large_skill_path(self, tmp_path_factory):
-        """Build a 10k-line skill once and reuse across tests in this class."""
-        tmp = tmp_path_factory.mktemp("large")
-        header = (
-            "---\nname: large-skill\n"
-            "description: Use when you need to process large amounts of content.\n"
-            "---\n\n# Large Skill\n\n"
-        )
-        # 5000 prose lines + 5000 instruction lines
-        body = ("This is content line.\n" * 5000) + ("Run the verification step.\n" * 5000)
-        content = header + body
-        assert len(content.encode()) <= MAX_SKILL_SIZE, (
-            f"Test fixture exceeds MAX_SKILL_SIZE ({MAX_SKILL_SIZE})"
-        )
-        p = tmp / "SKILL.md"
-        p.write_text(content, encoding="utf-8")
-        return str(p)
 
     def test_structure_large_skill_does_not_crash(self, large_skill_path):
         result = score_structure(large_skill_path)


### PR DESCRIPTION
A parked project learns about a new interpreter from its own CI or not at all — with 0 watchers and 0 forks, nobody files that issue. The matrix stopped at 3.13 while 3.14 shipped and 3.15 is in alpha, which made the top of the supported range the one thing going quietly stale.

Adding 3.14 found a real behaviour change on the first run.

## CPython 3.14's json parser no longer recurses

Measured on both interpreters, not inferred:

| input | 3.9–3.13 | 3.14 |
| --- | --- | --- |
| `"[" * 50000` | `RecursionError` | `JSONDecodeError` |
| `'{"a":' * 20000` (valid, 20k deep) | `RecursionError` | **parses fine** |
| `"[" * 2000 + "]" * 2000` (valid) | `RecursionError` | **parses fine** |

**The production guard is unaffected.** `submit.py:438` and `command_resolution.py:185` catch `(JSONDecodeError, ValueError, RecursionError)`, and the new exception lands in the same tuple. Nothing in schliff behaves differently.

What broke was a *test*: it pinned **which** exception CPython raises, making it a statement about the interpreter rather than about the code under test. It now asserts containment — nothing thrown by deeply-nested input may fall outside the guard tuple — which is the only property that ever mattered and is true on every supported version.

The sibling assertion stays exactly as it was: `RecursionError` is not a `ValueError` subclass, so it must be named explicitly. `requires-python` is `>=3.10` and half that range still raises it. **Shrinking the tuple because 3.14 no longer needs it would break the older half** — that is the tidying-around-the-fix this repo has been bitten by before, and it is deliberately not done here.

## A pytest deprecation, and the fix that would have broken local dev

3.14's newer pytest surfaced `PytestRemovedIn10Warning`: a class-scoped fixture defined as an instance method, which becomes an error in pytest 10.

The obvious fix — `@classmethod` — silences it across the supported range and **breaks collection outright on 3.9**: `classmethod` objects gained `__name__` only in 3.10, and `/usr/bin/python3` on this machine is 3.9, which is how the suite is run locally. Caught by running both ends rather than trusting the green one. Lifting the fixture to module scope is version-neutral and costs nothing — it never touched `self`.

## Verification

Full suite on both ends of the range: **2062 passed on 3.9, 2062 passed on 3.14, zero warnings on either.** Lint findings on the touched test files are byte-identical to `main`'s baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
