### PR TITLE
Schedule the traffic collector

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -1,0 +1,67 @@
+name: Collect traffic
+
+# The plugin-channel experiment's measuring instrument, on a schedule.
+#
+# GitHub's traffic API serves a rolling 14-day window and nothing older. The
+# collector therefore has to run at least once every 14 days or the unsnapshotted
+# days are gone permanently — see "Operating the collector" in
+# docs/specs/2026-08-11-plugin-channel-experiment.md, which names that outcome
+# UNMEASURED-COLLECTOR-GAP and calls it worse than any RED, because a RED is a
+# finding and a gap is a mistake.
+#
+# Running it here rather than on the maintainer's machine is deliberate: it does
+# not depend on a laptop being awake, and it installs nothing on anyone's system.
+# Weekly, not daily — the window is 14 days, so weekly leaves a full missed run
+# of slack before data is actually lost.
+
+on:
+  schedule:
+    # Mondays 06:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
+    # under load at popular times, and a dropped run costs a week of slack.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: collect-traffic
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The traffic endpoints require push access. GITHUB_TOKEN has it via
+          # `contents: write` above — but the failure mode if it ever stops
+          # being true is a silent empty payload, so probe first and fail loudly
+          # rather than committing a line full of nulls.
+          if ! gh api "repos/${GITHUB_REPOSITORY}/traffic/views" --jq '.count' > /dev/null; then
+            echo "::error::GITHUB_TOKEN cannot read the traffic API for ${GITHUB_REPOSITORY}." >&2
+            echo "::error::The collector needs push-level access to /traffic/*." >&2
+            exit 1
+          fi
+          bash scripts/collect-traffic.sh
+
+      - name: Commit the observation
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/experiments/plugin-channel/traffic.jsonl; then
+            echo "No change to traffic.jsonl — already collected for this UTC day."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/experiments/plugin-channel/traffic.jsonl
+          git commit -m "chore(experiment): collect traffic observation
+
+          Automated by .github/workflows/collect-traffic.yml. One line per UTC
+          day; re-runs on the same day overwrite in place rather than appending."
+          git push


### PR DESCRIPTION
The experiment's one structural weakness was that nothing ran its instrument.

GitHub's traffic API serves a rolling 14-day window. Fifteen unattended days lose the data permanently and silently — the spec names that outcome `UNMEASURED-COLLECTOR-GAP` and calls it worse than any RED, because a RED is a finding and a gap is a mistake. A `make` target makes running it *possible*, not *likely*.

**Weekly, not daily.** The window is 14 days, so a weekly cadence leaves a full missed run of slack before anything is actually lost. Scheduled at 06:17 rather than on the hour, because GitHub sheds scheduled jobs under load at popular times and a dropped run costs a week of that slack.

**Here rather than on a laptop, deliberately.** No cron job and no LaunchAgent on anyone's machine, and no dependency on a machine being awake.

**The token question is probed, not assumed.** The traffic endpoints require push-level access. `GITHUB_TOKEN` should have it via `contents: write` — but if that ever stops holding, the failure mode is a silent empty payload rather than an error, so the job calls `/traffic/views` first and fails loudly instead of committing a line full of nulls. That probe is also how this PR proves the permission actually works: watch the dispatched run.

The commit step is a no-op when the day's line already exists, so a manual run followed by the scheduled one does not produce an empty commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)