### PR TITLE
The traffic collector needs a PAT, not the workflow token

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -36,16 +36,27 @@ jobs:
 
       - name: Collect
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOT GITHUB_TOKEN. Measured on 2026-08-11, run 31514201151:
+          # `gh api repos/OWNER/REPO/traffic/views` with the workflow token and
+          # `contents: write` returns HTTP 403 "Resource not accessible by
+          # integration". The traffic endpoints sit behind repository
+          # Administration permissions, which a workflow token cannot be granted
+          # — no combination of the `permissions:` block fixes it. A PAT is the
+          # only way, so the collector reads one from a repository secret.
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         run: |
           set -euo pipefail
-          # The traffic endpoints require push access. GITHUB_TOKEN has it via
-          # `contents: write` above — but the failure mode if it ever stops
-          # being true is a silent empty payload, so probe first and fail loudly
-          # rather than committing a line full of nulls.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::TRAFFIC_TOKEN is not configured — nothing collected."
+            echo "::notice::See 'Operating the collector' in docs/specs/2026-08-11-plugin-channel-experiment.md."
+            exit 0
+          fi
+          # Probe before collecting: a token without traffic access fails with
+          # an empty payload rather than an error, which would commit a line of
+          # nulls and look like a real observation.
           if ! gh api "repos/${GITHUB_REPOSITORY}/traffic/views" --jq '.count' > /dev/null; then
-            echo "::error::GITHUB_TOKEN cannot read the traffic API for ${GITHUB_REPOSITORY}." >&2
-            echo "::error::The collector needs push-level access to /traffic/*." >&2
+            echo "::error::TRAFFIC_TOKEN cannot read the traffic API for ${GITHUB_REPOSITORY}." >&2
+            echo "::error::It needs a fine-grained PAT with repository Administration: Read." >&2
             exit 1
           fi
           bash scripts/collect-traffic.sh

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -425,20 +425,38 @@ can be adjusted after the traffic or PR data comes in.
 
 Every quantitative reading in this document — Gate 2's branch and Observation R — is taken from a
 line in `docs/experiments/plugin-channel/traffic.jsonl`. That file only has lines in it because
-someone ran the collector. Nothing runs it automatically, by design: no cron job, LaunchAgent, or
-system scheduler is installed by this branch, because that would change the owner's machine.
+the collector ran.
 
-**The command:**
+**The command, by hand:**
 
 ```bash
 make collect-traffic     # or: bash scripts/collect-traffic.sh
 ```
 
+**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it weekly (Mondays
+06:17 UTC) so the record does not depend on anyone remembering. Nothing is installed on any
+machine — no cron job, no LaunchAgent.
+
+That workflow needs one secret, and it cannot use the default workflow token. Measured on
+2026-08-11 in run `31514201151`: `gh api repos/OWNER/REPO/traffic/views` with `GITHUB_TOKEN` and
+`contents: write` returns **HTTP 403, "Resource not accessible by integration"**. The traffic
+endpoints sit behind repository *Administration* permissions, which a workflow token cannot be
+granted through the `permissions:` block at all.
+
+So the workflow reads a `TRAFFIC_TOKEN` repository secret — a fine-grained personal access token
+scoped to this repository with **Administration: Read** (and Contents: Read and write, so it can
+commit the observation). Until that secret exists the job exits green with a notice and collects
+nothing: a scheduled job that fails every week teaches its owner to ignore it, which is a worse
+failure than a missing measurement. **A green run is therefore not evidence that an observation
+was taken** — check that `traffic.jsonl` grew.
+
 It needs an authenticated `gh` and nothing else, is idempotent per UTC day (a second run the same
 day overwrites that day's line rather than appending a duplicate), and never touches the seeded
 `"note":"baseline"` line.
 
-**The required cadence: at least once every 14 days, and on each reading date.** GitHub's traffic
+**The required cadence: at least once every 14 days, and on each reading date.** The weekly
+workflow satisfies this with a full missed run of slack — but only once `TRAFFIC_TOKEN` is set.
+Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
 


### PR DESCRIPTION
#190 assumed `GITHUB_TOKEN` could read the traffic API given `contents: write`. **It cannot.**

Dispatched run [31514201151](https://github.com/Zandereins/schliff/actions/runs/31514201151) returned:

```
gh: Resource not accessible by integration (HTTP 403)
```

The traffic endpoints sit behind repository *Administration* permissions, which a workflow token cannot be granted through the `permissions:` block at all. No combination of that block fixes it.

**The probe is what caught it.** Without the pre-flight `gh api .../traffic/views` check, the collector would have run against an empty payload, committed a line of nulls, and looked like a real observation — in the file that every quantitative reading of this experiment depends on.

**Left alone, this would have failed every Monday.** A scheduled job that fails weekly teaches its owner to ignore it, which is a worse failure than a missing measurement. So the job now:

- reads a `TRAFFIC_TOKEN` secret instead of the workflow token;
- exits **green with a notice** when that secret is absent, rather than red;
- keeps the probe, so a token that lacks traffic access still fails loudly instead of writing nulls.

Because green no longer means "collected", the spec says so explicitly and names the actual check: did `traffic.jsonl` grow.

**What this needs from the repository owner** — a fine-grained PAT scoped to this repository with **Administration: Read** (for the traffic endpoints) and **Contents: Read and write** (to commit the observation), stored as the `TRAFFIC_TOKEN` repository secret. Creating it is not something this PR can or should do.

Until that secret exists, the manual `make collect-traffic` remains the only thing producing lines — which is the state the experiment shipped in, so nothing regresses in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)