### PR TITLE
Collect onto a data branch, since main rejects the push

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -33,6 +33,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Switch to the data branch
+        run: |
+          set -euo pipefail
+          # Observations land on a data branch, not on main. main is protected
+          # (enforce_admins: true, six required checks), so a direct push is
+          # rejected with GH006 — measured on 2026-08-11 in run 31519738229,
+          # where collection succeeded and only the push failed. Opening a pull
+          # request per weekly line would trade that for a merge queue nobody
+          # asked for. The branch is created from main on first run.
+          if git ls-remote --exit-code --heads origin "${DATA_BRANCH}" > /dev/null 2>&1; then
+            git fetch origin "${DATA_BRANCH}"
+            git checkout "${DATA_BRANCH}"
+            # Take main's copy of the collector, so a fix to the script applies
+            # without having to also merge it into the data branch.
+            git checkout origin/main -- scripts/collect-traffic.sh
+          else
+            git checkout -b "${DATA_BRANCH}"
+          fi
+        env:
+          DATA_BRANCH: experiment/traffic-data
 
       - name: Collect
         env:
@@ -75,4 +98,4 @@ jobs:
 
           Automated by .github/workflows/collect-traffic.yml. One line per UTC
           day; re-runs on the same day overwrite in place rather than appending."
-          git push
+          git push origin HEAD:experiment/traffic-data

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -437,6 +437,27 @@ make collect-traffic     # or: bash scripts/collect-traffic.sh
 06:17 UTC) so the record does not depend on anyone remembering. Nothing is installed on any
 machine — no cron job, no LaunchAgent.
 
+**Where the scheduled observations land: the `experiment/traffic-data` branch, not `main`.**
+`main` is protected with `enforce_admins: true` and six required status checks, so a workflow
+push to it is rejected outright — measured on 2026-08-11 in run `31519738229`, where collection
+succeeded and only the push failed with `GH006: Protected branch update failed`. Opening a pull
+request for each weekly line would trade that for a merge queue nobody asked for. The scheduled
+job therefore appends to `docs/experiments/plugin-channel/traffic.jsonl` **on that branch**, and
+`main` keeps only the seeded baseline until a reading is taken.
+
+**Consequence for every reading in this document:** read the file from the data branch, not from
+a working copy of `main`:
+
+```bash
+git fetch origin experiment/traffic-data
+git show origin/experiment/traffic-data:docs/experiments/plugin-channel/traffic.jsonl
+```
+
+At each reading date the branch's state is merged into `main` in one pull request, so the record
+ends up where this document says it is. A reading taken from `main` before that merge sees only
+the baseline and would be wrong — that is the one operational mistake this arrangement makes
+possible, and it is named here so it is not made.
+
 That workflow needs one secret, and it cannot use the default workflow token. Measured on
 2026-08-11 in run `31514201151`: `gh api repos/OWNER/REPO/traffic/views` with `GITHUB_TOKEN` and
 `contents: write` returns **HTTP 403, "Resource not accessible by integration"**. The traffic


### PR DESCRIPTION
The collector works. The push did not.

Run [31519738229](https://github.com/Zandereins/schliff/actions/runs/31519738229) fetched the traffic payload with `TRAFFIC_TOKEN` and wrote its line — the Collect step is green. Then:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 6 of 6 required status checks are expected.
```

`main` is protected with `enforce_admins: true` and six required status checks. **No token fixes this** — an admin PAT is rejected the same way.

**This was avoidable.** This repo's branch protection had been queried an hour earlier, while diagnosing why a Dependabot PR would not merge, and the result was not applied to the workflow being written at the same time.

## The fix

Observations land on **`experiment/traffic-data`**, created from `main` on the first run. The rejected alternative — one pull request per weekly line — would trade a protected branch for a merge queue, and an unmerged queue is precisely how the record ends up with the holes this instrument exists to prevent.

The job pulls `scripts/collect-traffic.sh` from `origin/main` on every run, so fixing the script never requires also merging it into the data branch.

## What this changes for readings

The spec now states it with the command, because this introduces exactly one way to get a wrong answer:

```bash
git fetch origin experiment/traffic-data
git show origin/experiment/traffic-data:docs/experiments/plugin-channel/traffic.jsonl
```

Reading `traffic.jsonl` from `main` before the branch is merged shows only the seeded baseline. At each reading date the branch is merged into `main` in one pull request, so the record ends up where the spec says it lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
