### PR TITLE
chore(experiment): collect daily, and capture the S2 baseline before D0

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -3,12 +3,8 @@ name: Collect traffic
 # The plugin-channel experiment's measuring instrument, on a schedule.
 #
 # GitHub's traffic API serves a rolling 14-day window and nothing older. The
-# collector therefore has to run at least once every 12 days or the unsnapshotted
-# days are gone permanently. Twelve, not fourteen: the window's far end drifts by
-# a day depending on when in the UTC day the call lands (T-1 or T-2, measured), so
-# a 14-day spacing can leave one day covered by no snapshot at all. The arithmetic
-# actually allows 13; 12 keeps one day of reserve against a drift slower than the
-# three observations behind it — see "Operating the collector" in
+# collector therefore has to run at least once every 14 days or the unsnapshotted
+# days are gone permanently — see "Operating the collector" in
 # docs/specs/2026-08-11-plugin-channel-experiment.md, which names that outcome
 # UNMEASURED-COLLECTOR-GAP and calls it worse than any RED, because a RED is a
 # finding and a gap is a mistake.
@@ -31,8 +27,8 @@ name: Collect traffic
 
 on:
   schedule:
-    # Twice daily, 12:17 and 20:17 UTC. Off the hour on purpose: GitHub sheds
-    # scheduled jobs under load at popular times.
+    # Daily at 20:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
+    # under load at popular times.
     #
     # Late in the day for a measured reason, and NOT the obvious one. The traffic
     # API never reports the day you ask on: measured 2026-08-20, a call at 10:12
@@ -41,14 +37,7 @@ on:
     # 08-15, while calls at 10:12, 12:52 and 17:57 all came back ending T-1. So a
     # late run costs one day of lag instead of two, and one day is the floor the
     # API allows, not zero. ~3.7h of slack remains before the 23:59 boundary.
-    #
-    # Twice a day, because a shed run on a reading date fails silently rather
-    # than loudly: no line is written for that UTC day, and the reading rule
-    # then selects the previous day's line on its own, with nothing erroring.
-    # The 12:17 run also answers at T-1 (measured), so it is a full-value
-    # fallback, and the script's per-day dedup overwrites in place — two runs
-    # produce one line, not two.
-    - cron: '17 12 * * *'
+
     - cron: '17 20 * * *'
   workflow_dispatch:
 

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -11,14 +11,28 @@ name: Collect traffic
 #
 # Running it here rather than on the maintainer's machine is deliberate: it does
 # not depend on a laptop being awake, and it installs nothing on anyone's system.
-# Weekly, not daily — the window is 14 days, so weekly leaves a full missed run
-# of slack before data is actually lost.
+#
+# Daily, not weekly. The 14-day window is not the binding constraint — the reading
+# rule is. Observation R reads "the last traffic.jsonl line whose collected_at is at
+# or before 23:59 UTC on 2026-09-10", and 2026-09-10 is a Thursday. On the previous
+# Monday-only schedule the nearest qualifying snapshot was 2026-09-07: a reading of a
+# 30-day window taken on day 27, from a rolling 14-day counter that never contained
+# 09-08 through 09-10. See "The dates that must be covered" in
+# docs/specs/2026-08-11-plugin-channel-experiment.md.
+#
+# A dated one-off cron would have fixed that one date and left the same trap for the
+# second date the spec requires, A0+30 — which cannot be wired in advance, because A0
+# is the merge date of a submission that has not been opened. Daily covers both, and
+# every future reading date, without anyone having to remember.
 
 on:
   schedule:
-    # Mondays 06:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
-    # under load at popular times, and a dropped run costs a week of slack.
-    - cron: '17 6 * * 1'
+    # Daily at 20:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
+    # under load at popular times. Late in the day on purpose too: the snapshot
+    # that decides a reading is the last one at or before 23:59 UTC that day, so
+    # 20:17 puts ~20 of 24 hours of the reading date into the counter while still
+    # leaving ~3.7h of slack before the boundary.
+    - cron: '17 20 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -114,8 +114,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/experiments/plugin-channel/traffic.jsonl
+          # Commit that path only. The "Switch to the data branch" step above
+          # stages scripts/collect-traffic.sh via `git checkout origin/main --`,
+          # and a bare `git commit` would sweep it into the observation commit —
+          # inert while the script never changed, no longer inert now that it has.
           git commit -m "chore(experiment): collect traffic observation
 
           Automated by .github/workflows/collect-traffic.yml. One line per UTC
-          day; re-runs on the same day overwrite in place rather than appending."
+          day; re-runs on the same day overwrite in place rather than appending." \
+            -- docs/experiments/plugin-channel/traffic.jsonl
           git push origin HEAD:experiment/traffic-data

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -5,8 +5,10 @@ name: Collect traffic
 # GitHub's traffic API serves a rolling 14-day window and nothing older. The
 # collector therefore has to run at least once every 12 days or the unsnapshotted
 # days are gone permanently. Twelve, not fourteen: the window's far end drifts by
-# a day depending on when in the UTC day the call lands (T-1 or T-2, measured),
-# so a 14-day spacing can leave one day covered by no snapshot at all — see "Operating the collector" in
+# a day depending on when in the UTC day the call lands (T-1 or T-2, measured), so
+# a 14-day spacing can leave one day covered by no snapshot at all. The arithmetic
+# actually allows 13; 12 keeps one day of reserve against a drift slower than the
+# three observations behind it — see "Operating the collector" in
 # docs/specs/2026-08-11-plugin-channel-experiment.md, which names that outcome
 # UNMEASURED-COLLECTOR-GAP and calls it worse than any RED, because a RED is a
 # finding and a gap is a mistake.

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -15,9 +15,9 @@ name: Collect traffic
 # Daily, not weekly. The 14-day window is not the binding constraint — the reading
 # rule is. Observation R reads "the last traffic.jsonl line whose collected_at is at
 # or before 23:59 UTC on 2026-09-10", and 2026-09-10 is a Thursday. On the previous
-# Monday-only schedule the nearest qualifying snapshot was 2026-09-07: a reading of a
-# 30-day window taken on day 27, from a rolling 14-day counter that never contained
-# 09-08 through 09-10. See "The dates that must be covered" in
+# Monday-only schedule the nearest qualifying snapshot was 2026-09-07, whose window
+# would have ended around 09-05 — leaving the last five days of a 30-day observation
+# outside the counter that decides it. See "The dates that must be covered" in
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #
 # A dated one-off cron would have fixed that one date and left the same trap for the
@@ -28,10 +28,15 @@ name: Collect traffic
 on:
   schedule:
     # Daily at 20:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
-    # under load at popular times. Late in the day on purpose too: the snapshot
-    # that decides a reading is the last one at or before 23:59 UTC that day, so
-    # 20:17 puts ~20 of 24 hours of the reading date into the counter while still
-    # leaving ~3.7h of slack before the boundary.
+    # under load at popular times.
+    #
+    # Late in the day for a measured reason, and NOT the obvious one. The traffic
+    # API never reports the day you ask on: measured 2026-08-20, a call at 10:12
+    # UTC returned a window ending 08-19. What the hour actually buys is whether
+    # the window ends at T-1 or T-2 — the 06:28 run on 08-17 came back ending
+    # 08-15, while calls at 10:12, 12:52 and 17:57 all came back ending T-1. So a
+    # late run costs one day of lag instead of two, and one day is the floor the
+    # API allows, not zero. ~3.7h of slack remains before the 23:59 boundary.
     - cron: '17 20 * * *'
   workflow_dispatch:
 
@@ -57,7 +62,7 @@ jobs:
           # (enforce_admins: true, six required checks), so a direct push is
           # rejected with GH006 — measured on 2026-08-11 in run 31519738229,
           # where collection succeeded and only the push failed. Opening a pull
-          # request per weekly line would trade that for a merge queue nobody
+          # request per daily line would trade that for a merge queue nobody
           # asked for. The branch is created from main on first run.
           if git ls-remote --exit-code --heads origin "${DATA_BRANCH}" > /dev/null 2>&1; then
             git fetch origin "${DATA_BRANCH}"

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -3,8 +3,10 @@ name: Collect traffic
 # The plugin-channel experiment's measuring instrument, on a schedule.
 #
 # GitHub's traffic API serves a rolling 14-day window and nothing older. The
-# collector therefore has to run at least once every 14 days or the unsnapshotted
-# days are gone permanently — see "Operating the collector" in
+# collector therefore has to run at least once every 12 days or the unsnapshotted
+# days are gone permanently. Twelve, not fourteen: the window's far end drifts by
+# a day depending on when in the UTC day the call lands (T-1 or T-2, measured),
+# so a 14-day spacing can leave one day covered by no snapshot at all — see "Operating the collector" in
 # docs/specs/2026-08-11-plugin-channel-experiment.md, which names that outcome
 # UNMEASURED-COLLECTOR-GAP and calls it worse than any RED, because a RED is a
 # finding and a gap is a mistake.
@@ -27,8 +29,8 @@ name: Collect traffic
 
 on:
   schedule:
-    # Daily at 20:17 UTC. Off the hour on purpose: GitHub sheds scheduled jobs
-    # under load at popular times.
+    # Twice daily, 12:17 and 20:17 UTC. Off the hour on purpose: GitHub sheds
+    # scheduled jobs under load at popular times.
     #
     # Late in the day for a measured reason, and NOT the obvious one. The traffic
     # API never reports the day you ask on: measured 2026-08-20, a call at 10:12
@@ -37,6 +39,14 @@ on:
     # 08-15, while calls at 10:12, 12:52 and 17:57 all came back ending T-1. So a
     # late run costs one day of lag instead of two, and one day is the floor the
     # API allows, not zero. ~3.7h of slack remains before the 23:59 boundary.
+    #
+    # Twice a day, because a shed run on a reading date fails silently rather
+    # than loudly: no line is written for that UTC day, and the reading rule
+    # then selects the previous day's line on its own, with nothing erroring.
+    # The 12:17 run also answers at T-1 (measured), so it is a full-value
+    # fallback, and the script's per-day dedup overwrites in place — two runs
+    # produce one line, not two.
+    - cron: '17 12 * * *'
     - cron: '17 20 * * *'
   workflow_dispatch:
 

--- a/docs/experiments/plugin-channel/s2-baseline.md
+++ b/docs/experiments/plugin-channel/s2-baseline.md
@@ -35,67 +35,79 @@ repository outside the owner's account contained the plugin install identifier `
 
 ## Excluded set — 48 repository/path pairs across 22 repositories
 
-Every pair below is pre-existing as of 2026-08-20 and is **permanently excluded** from the S2
-branch, with no dating work required. Recorded as repository, path and capture date only, per the
-spec. No judgement about any author's intent is recorded here, and none is implied by inclusion:
-appearing in this table means the reference existed before the intervention, nothing else.
+Every pair below is pre-existing as of 2026-08-20. **The exclusion is scoped to the query that
+matched it, not to S2 as a whole** — all 48 rows were returned by Q1 (`"Zandereins/schliff"`), and
+none by Q2 (`"schliff@schliff"`), which returned nothing at all.
 
-| # | Repository | Path | Captured | Status |
-| --- | --- | --- | --- | --- |
-| 1 | `Adam077K/Beamix` | `docs/08-agents_work/2026-08-09-skill-harvest/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
-| 2 | `SparshKaushik/trackawesomelist` | `2026/07/03/index.html` | 2026-08-20 | pre-existing — excluded |
-| 3 | `SparshKaushik/trackawesomelist` | `2026/27/index.html` | 2026-08-20 | pre-existing — excluded |
-| 4 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/index.html` | 2026-08-20 | pre-existing — excluded |
-| 5 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/readme/index.html` | 2026-08-20 | pre-existing — excluded |
-| 6 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/rss.xml` | 2026-08-20 | pre-existing — excluded |
-| 7 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/index.html` | 2026-08-20 | pre-existing — excluded |
-| 8 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/rss.xml` | 2026-08-20 | pre-existing — excluded |
-| 9 | `StevenSixon/my-daily-news` | `projects/hesreallyhim__awesome-claude-code/README.snapshot.md` | 2026-08-20 | pre-existing — excluded |
-| 10 | `bradAGI/awesome-cli-coding-agents` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 11 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/06/25-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 12 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/03-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 13 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/07-15-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 14 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/20-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 15 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/21-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 16 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/23-06-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 17 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/28-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 18 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 19 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 20 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/30-23-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 21 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 22 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 23 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/10-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
-| 24 | `gabrielmoreira/awesome-ai-rabbit-holes` | `catalog/items/github/zandereins/schliff.yml` | 2026-08-20 | pre-existing — excluded |
-| 25 | `harrysun-code/awesome-with-star` | `awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
-| 26 | `hesreallyhim/awesome-claude-code` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 27 | `hesreallyhim/awesome-claude-code` | `THE_RESOURCES_TABLE_NEW.csv` | 2026-08-20 | pre-existing — excluded |
-| 28 | `ianshank/Agents` | `docs/claude-code-ecosystem-research.md` | 2026-08-20 | pre-existing — excluded |
-| 29 | `icopy-site/awesome` | `docs/awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
-| 30 | `icopy-site/awesome-cn` | `docs/awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
-| 31 | `szabgab/pydigger-data` | `data/pypi/sc/schliff.json` | 2026-08-20 | pre-existing — excluded |
-| 32 | `thedixitjain/the-mega-skill-library` | `reference/hesreallyhim~awesome-claude-code/README.md` | 2026-08-20 | pre-existing — excluded |
-| 33 | `trackawesomelist/trackawesomelist` | `content/2026/07/03/README.md` | 2026-08-20 | pre-existing — excluded |
-| 34 | `trackawesomelist/trackawesomelist` | `content/2026/27/README.md` | 2026-08-20 | pre-existing — excluded |
-| 35 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/README.md` | 2026-08-20 | pre-existing — excluded |
-| 36 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/readme/README.md` | 2026-08-20 | pre-existing — excluded |
-| 37 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/week/README.md` | 2026-08-20 | pre-existing — excluded |
-| 38 | `wan-huiyan/agent-review-panel` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 39 | `wan-huiyan/causal-impact-campaign` | `docs/README-v1.6.md` | 2026-08-20 | pre-existing — excluded |
-| 40 | `wan-huiyan/claude-ecosystem-hygiene` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 41 | `wan-huiyan/ml-training-window-assessor` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 42 | `wan-huiyan/publish-skill` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 43 | `wan-huiyan/publish-skill` | `plugins/publish-skill/SKILL.md` | 2026-08-20 | pre-existing — excluded |
-| 44 | `wan-huiyan/skill-sync` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 45 | `wan-huiyan/skill-sync` | `plugins/skill-sync/SKILL.md` | 2026-08-20 | pre-existing — excluded |
-| 46 | `yenanjing/awesome-ai-for-science` | `README.md` | 2026-08-20 | pre-existing — excluded |
-| 47 | `yenanjing/awesome-ai-for-science` | `data/repos.json` | 2026-08-20 | pre-existing — excluded |
-| 48 | `zhoux77899/claude-code-insights` | `plugins/cached-repos.txt` | 2026-08-20 | pre-existing — excluded |
+That distinction decides a real case. `hesreallyhim/awesome-claude-code` `README.md` and
+`zhoux77899/claude-code-insights` `plugins/cached-repos.txt` are exactly the kind of file where a
+plugin-install line would appear after a submission. If such a file gains `schliff@schliff` after
+D0, that is the clearest true positive this experiment can produce — and a blanket exclusion would
+have thrown it away as "pre-existing" because the same path already mentioned the repository by
+name. A Q1 hit is excluded from Q1 only; the same path can still produce a qualifying Q2 hit, and
+that hit is dated by the spec's two-step procedure like any other.
+
+Recorded as repository, path, matched query and capture date, per the spec. No judgement about any
+author's intent is recorded here, and none is implied by inclusion: appearing in this table means
+the reference existed before the intervention, nothing else.
+
+| # | Repository | Path | Matched | Captured | Status |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `Adam077K/Beamix` | `docs/08-agents_work/2026-08-09-skill-harvest/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 2 | `SparshKaushik/trackawesomelist` | `2026/07/03/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
+| 3 | `SparshKaushik/trackawesomelist` | `2026/27/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
+| 4 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
+| 5 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/readme/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
+| 6 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/rss.xml` | Q1 | 2026-08-20 | excluded from Q1 |
+| 7 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
+| 8 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/rss.xml` | Q1 | 2026-08-20 | excluded from Q1 |
+| 9 | `StevenSixon/my-daily-news` | `projects/hesreallyhim__awesome-claude-code/README.snapshot.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 10 | `bradAGI/awesome-cli-coding-agents` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 11 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/06/25-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 12 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/03-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 13 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/07-15-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 14 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/20-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 15 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/21-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 16 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/23-06-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 17 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/28-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 18 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 19 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 20 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/30-23-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 21 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 22 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 23 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/10-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 24 | `gabrielmoreira/awesome-ai-rabbit-holes` | `catalog/items/github/zandereins/schliff.yml` | Q1 | 2026-08-20 | excluded from Q1 |
+| 25 | `harrysun-code/awesome-with-star` | `awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 26 | `hesreallyhim/awesome-claude-code` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 27 | `hesreallyhim/awesome-claude-code` | `THE_RESOURCES_TABLE_NEW.csv` | Q1 | 2026-08-20 | excluded from Q1 |
+| 28 | `ianshank/Agents` | `docs/claude-code-ecosystem-research.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 29 | `icopy-site/awesome` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 30 | `icopy-site/awesome-cn` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 31 | `szabgab/pydigger-data` | `data/pypi/sc/schliff.json` | Q1 | 2026-08-20 | excluded from Q1 |
+| 32 | `thedixitjain/the-mega-skill-library` | `reference/hesreallyhim~awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 33 | `trackawesomelist/trackawesomelist` | `content/2026/07/03/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 34 | `trackawesomelist/trackawesomelist` | `content/2026/27/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 35 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 36 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/readme/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 37 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/week/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 38 | `wan-huiyan/agent-review-panel` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 39 | `wan-huiyan/causal-impact-campaign` | `docs/README-v1.6.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 40 | `wan-huiyan/claude-ecosystem-hygiene` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 41 | `wan-huiyan/ml-training-window-assessor` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 42 | `wan-huiyan/publish-skill` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 43 | `wan-huiyan/publish-skill` | `plugins/publish-skill/SKILL.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 44 | `wan-huiyan/skill-sync` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 45 | `wan-huiyan/skill-sync` | `plugins/skill-sync/SKILL.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 46 | `yenanjing/awesome-ai-for-science` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
+| 47 | `yenanjing/awesome-ai-for-science` | `data/repos.json` | Q1 | 2026-08-20 | excluded from Q1 |
+| 48 | `zhoux77899/claude-code-insights` | `plugins/cached-repos.txt` | Q1 | 2026-08-20 | excluded from Q1 |
 
 ## What this file does not do
 
-It does not exclude a *repository* — it excludes a repository/path pair. A new file in
-`wan-huiyan/skill-sync`, for instance, is not covered by the row for that repository's existing
-path and must be dated by the spec's two-step procedure like any other hit.
+It does not exclude a *repository* — it excludes a repository/path pair, for one query. A new
+file in `wan-huiyan/skill-sync`, for instance, is not covered by the row for that repository's
+existing path; neither is that same path acquiring a `schliff@schliff` reference it did not carry
+at capture. Both must be dated by the spec's two-step procedure like any other hit.
 
 It also does not decide Gate 2. A hit outside this table still has to clear conditions (2), (3)
 and (4) of the qualitative branch — not-a-bot, unsolicited, and attributable to the plugin

--- a/docs/experiments/plugin-channel/s2-baseline.md
+++ b/docs/experiments/plugin-channel/s2-baseline.md
@@ -35,17 +35,22 @@ repository outside the owner's account contained the plugin install identifier `
 
 ## Excluded set — 48 repository/path pairs across 22 repositories
 
-Every pair below is pre-existing as of 2026-08-20. **The exclusion is scoped to the query that
-matched it, not to S2 as a whole** — all 48 rows were returned by Q1 (`"Zandereins/schliff"`), and
-none by Q2 (`"schliff@schliff"`), which returned nothing at all.
+Every pair below is pre-existing as of 2026-08-20 and is **permanently excluded from S2**, with no
+dating work required — the blanket wording the spec pre-registered, not a narrower reading of it.
 
-That distinction decides a real case. `hesreallyhim/awesome-claude-code` `README.md` and
-`zhoux77899/claude-code-insights` `plugins/cached-repos.txt` are exactly the kind of file where a
-plugin-install line would appear after a submission. If such a file gains `schliff@schliff` after
-D0, that is the clearest true positive this experiment can produce — and a blanket exclusion would
-have thrown it away as "pre-existing" because the same path already mentioned the repository by
-name. A Q1 hit is excluded from Q1 only; the same path can still produce a qualifying Q2 hit, and
-that hit is dated by the spec's two-step procedure like any other.
+The `Matched` column records which query returned each row (all 48 from Q1, `"Zandereins/schliff"`;
+Q2, `"schliff@schliff"`, returned nothing). It is provenance, **not** a limit on the exclusion: a
+path listed here is out of S2 entirely, including for the query that did not match it at capture.
+
+*What that costs, stated rather than quietly avoided.* If `hesreallyhim/awesome-claude-code`
+`README.md` gains a `schliff@schliff` install line after D0, that would be a genuine signal and
+this baseline discards it. An earlier draft of this file scoped exclusions per query to keep such
+a hit alive. That draft was wrong: it loosened a pre-registered criterion in the permissive
+direction — toward a false GREEN — with the case already in view, which is the move this
+experiment's own condition-(2) amendment refuses to make. The spec settled this trade-off in
+advance: *"a branch that silently admits pre-intervention evidence is worse than one that turns
+away a real signal it cannot date, because only the first kind of error can manufacture a false
+GREEN."* The lost signal is the price that sentence already agreed to pay.
 
 Recorded as repository, path, matched query and capture date, per the spec. No judgement about any
 author's intent is recorded here, and none is implied by inclusion: appearing in this table means
@@ -53,61 +58,60 @@ the reference existed before the intervention, nothing else.
 
 | # | Repository | Path | Matched | Captured | Status |
 | --- | --- | --- | --- | --- | --- |
-| 1 | `Adam077K/Beamix` | `docs/08-agents_work/2026-08-09-skill-harvest/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 2 | `SparshKaushik/trackawesomelist` | `2026/07/03/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
-| 3 | `SparshKaushik/trackawesomelist` | `2026/27/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
-| 4 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
-| 5 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/readme/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
-| 6 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/rss.xml` | Q1 | 2026-08-20 | excluded from Q1 |
-| 7 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/index.html` | Q1 | 2026-08-20 | excluded from Q1 |
-| 8 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/rss.xml` | Q1 | 2026-08-20 | excluded from Q1 |
-| 9 | `StevenSixon/my-daily-news` | `projects/hesreallyhim__awesome-claude-code/README.snapshot.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 10 | `bradAGI/awesome-cli-coding-agents` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 11 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/06/25-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 12 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/03-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 13 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/07-15-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 14 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/20-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 15 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/21-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 16 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/23-06-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 17 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/28-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 18 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 19 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 20 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/30-23-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 21 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 22 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 23 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/10-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 24 | `gabrielmoreira/awesome-ai-rabbit-holes` | `catalog/items/github/zandereins/schliff.yml` | Q1 | 2026-08-20 | excluded from Q1 |
-| 25 | `harrysun-code/awesome-with-star` | `awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 26 | `hesreallyhim/awesome-claude-code` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 27 | `hesreallyhim/awesome-claude-code` | `THE_RESOURCES_TABLE_NEW.csv` | Q1 | 2026-08-20 | excluded from Q1 |
-| 28 | `ianshank/Agents` | `docs/claude-code-ecosystem-research.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 29 | `icopy-site/awesome` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 30 | `icopy-site/awesome-cn` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 31 | `szabgab/pydigger-data` | `data/pypi/sc/schliff.json` | Q1 | 2026-08-20 | excluded from Q1 |
-| 32 | `thedixitjain/the-mega-skill-library` | `reference/hesreallyhim~awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 33 | `trackawesomelist/trackawesomelist` | `content/2026/07/03/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 34 | `trackawesomelist/trackawesomelist` | `content/2026/27/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 35 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 36 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/readme/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 37 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/week/README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 38 | `wan-huiyan/agent-review-panel` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 39 | `wan-huiyan/causal-impact-campaign` | `docs/README-v1.6.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 40 | `wan-huiyan/claude-ecosystem-hygiene` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 41 | `wan-huiyan/ml-training-window-assessor` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 42 | `wan-huiyan/publish-skill` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 43 | `wan-huiyan/publish-skill` | `plugins/publish-skill/SKILL.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 44 | `wan-huiyan/skill-sync` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 45 | `wan-huiyan/skill-sync` | `plugins/skill-sync/SKILL.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 46 | `yenanjing/awesome-ai-for-science` | `README.md` | Q1 | 2026-08-20 | excluded from Q1 |
-| 47 | `yenanjing/awesome-ai-for-science` | `data/repos.json` | Q1 | 2026-08-20 | excluded from Q1 |
-| 48 | `zhoux77899/claude-code-insights` | `plugins/cached-repos.txt` | Q1 | 2026-08-20 | excluded from Q1 |
+| 1 | `Adam077K/Beamix` | `docs/08-agents_work/2026-08-09-skill-harvest/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 2 | `SparshKaushik/trackawesomelist` | `2026/07/03/index.html` | Q1 | 2026-08-20 | excluded from S2 |
+| 3 | `SparshKaushik/trackawesomelist` | `2026/27/index.html` | Q1 | 2026-08-20 | excluded from S2 |
+| 4 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/index.html` | Q1 | 2026-08-20 | excluded from S2 |
+| 5 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/readme/index.html` | Q1 | 2026-08-20 | excluded from S2 |
+| 6 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/rss.xml` | Q1 | 2026-08-20 | excluded from S2 |
+| 7 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/index.html` | Q1 | 2026-08-20 | excluded from S2 |
+| 8 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/rss.xml` | Q1 | 2026-08-20 | excluded from S2 |
+| 9 | `StevenSixon/my-daily-news` | `projects/hesreallyhim__awesome-claude-code/README.snapshot.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 10 | `bradAGI/awesome-cli-coding-agents` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 11 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/06/25-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 12 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/03-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 13 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/07-15-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 14 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/20-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 15 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/21-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 16 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/23-06-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 17 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/28-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 18 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 19 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 20 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/30-23-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 21 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 22 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-22-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 23 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/10-14-Zandereins-schliff.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 24 | `gabrielmoreira/awesome-ai-rabbit-holes` | `catalog/items/github/zandereins/schliff.yml` | Q1 | 2026-08-20 | excluded from S2 |
+| 25 | `harrysun-code/awesome-with-star` | `awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 26 | `hesreallyhim/awesome-claude-code` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 27 | `hesreallyhim/awesome-claude-code` | `THE_RESOURCES_TABLE_NEW.csv` | Q1 | 2026-08-20 | excluded from S2 |
+| 28 | `ianshank/Agents` | `docs/claude-code-ecosystem-research.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 29 | `icopy-site/awesome` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 30 | `icopy-site/awesome-cn` | `docs/awesome/awesome-claude-code.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 31 | `szabgab/pydigger-data` | `data/pypi/sc/schliff.json` | Q1 | 2026-08-20 | excluded from S2 |
+| 32 | `thedixitjain/the-mega-skill-library` | `reference/hesreallyhim~awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 33 | `trackawesomelist/trackawesomelist` | `content/2026/07/03/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 34 | `trackawesomelist/trackawesomelist` | `content/2026/27/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 35 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 36 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/readme/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 37 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/week/README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 38 | `wan-huiyan/agent-review-panel` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 39 | `wan-huiyan/causal-impact-campaign` | `docs/README-v1.6.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 40 | `wan-huiyan/claude-ecosystem-hygiene` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 41 | `wan-huiyan/ml-training-window-assessor` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 42 | `wan-huiyan/publish-skill` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 43 | `wan-huiyan/publish-skill` | `plugins/publish-skill/SKILL.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 44 | `wan-huiyan/skill-sync` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 45 | `wan-huiyan/skill-sync` | `plugins/skill-sync/SKILL.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 46 | `yenanjing/awesome-ai-for-science` | `README.md` | Q1 | 2026-08-20 | excluded from S2 |
+| 47 | `yenanjing/awesome-ai-for-science` | `data/repos.json` | Q1 | 2026-08-20 | excluded from S2 |
+| 48 | `zhoux77899/claude-code-insights` | `plugins/cached-repos.txt` | Q1 | 2026-08-20 | excluded from S2 |
 
 ## What this file does not do
 
-It does not exclude a *repository* — it excludes a repository/path pair, for one query. A new
-file in `wan-huiyan/skill-sync`, for instance, is not covered by the row for that repository's
-existing path; neither is that same path acquiring a `schliff@schliff` reference it did not carry
-at capture. Both must be dated by the spec's two-step procedure like any other hit.
+It does not exclude a *repository* — it excludes a repository/path pair. A new file in
+`wan-huiyan/skill-sync`, for instance, is not covered by the row for that repository's existing
+path and must be dated by the spec's two-step procedure like any other hit.
 
 It also does not decide Gate 2. A hit outside this table still has to clear conditions (2), (3)
 and (4) of the qualitative branch — not-a-bot, unsolicited, and attributable to the plugin

--- a/docs/experiments/plugin-channel/s2-baseline.md
+++ b/docs/experiments/plugin-channel/s2-baseline.md
@@ -1,0 +1,102 @@
+# S2 pre-D0 baseline — plugin-channel experiment
+
+Captured **2026-08-20**, before D0. Establishes the permanently-excluded set for the S2 branch of
+Gate 2 in `docs/specs/2026-08-11-plugin-channel-experiment.md`.
+
+**Why this file exists.** The spec requires it before the first submission PR is opened:
+
+> Both S2 queries are run once *before* D0 and their full result set — repository, path, and the
+> date of capture — is committed to `docs/experiments/plugin-channel/s2-baseline.md`. Every
+> repository/path pair in that snapshot is pre-existing by definition and is **permanently
+> excluded** from S2, with no dating work required. This must be captured before the first
+> submission PR is opened; **if D0 arrives with no committed baseline, the S2 branch is void.**
+
+A control taken after the intervention is not a control. D0 is `*not yet submitted*` as of
+capture, so this snapshot is a genuine control.
+
+## Method
+
+```bash
+gh api -X GET search/code -f q='"Zandereins/schliff" -user:Zandereins' -f per_page=100
+gh api -X GET search/code -f q='"schliff@schliff" -user:Zandereins'  -f per_page=100
+```
+
+**Completeness proof.** `search/code` pages at 30 by default and truncates silently — the same
+class of error that made a count in `distributors.md` wrong by a factor of five. Both queries ran
+with `per_page=100`, and the returned item count was checked against the API's own `total_count`:
+
+| Query | `total_count` | items returned | complete |
+| --- | --- | --- | --- |
+| `"Zandereins/schliff" -user:Zandereins` | 48 | 48 | yes |
+| `"schliff@schliff" -user:Zandereins` | 0 | 0 | yes |
+
+The second query returning zero is itself a recorded result: at capture, no file in any public
+repository outside the owner's account contained the plugin install identifier `schliff@schliff`.
+
+## Excluded set — 48 repository/path pairs across 22 repositories
+
+Every pair below is pre-existing as of 2026-08-20 and is **permanently excluded** from the S2
+branch, with no dating work required. Recorded as repository, path and capture date only, per the
+spec. No judgement about any author's intent is recorded here, and none is implied by inclusion:
+appearing in this table means the reference existed before the intervention, nothing else.
+
+| # | Repository | Path | Captured | Status |
+| --- | --- | --- | --- | --- |
+| 1 | `Adam077K/Beamix` | `docs/08-agents_work/2026-08-09-skill-harvest/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
+| 2 | `SparshKaushik/trackawesomelist` | `2026/07/03/index.html` | 2026-08-20 | pre-existing — excluded |
+| 3 | `SparshKaushik/trackawesomelist` | `2026/27/index.html` | 2026-08-20 | pre-existing — excluded |
+| 4 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/index.html` | 2026-08-20 | pre-existing — excluded |
+| 5 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/readme/index.html` | 2026-08-20 | pre-existing — excluded |
+| 6 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/rss.xml` | 2026-08-20 | pre-existing — excluded |
+| 7 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/index.html` | 2026-08-20 | pre-existing — excluded |
+| 8 | `SparshKaushik/trackawesomelist` | `hesreallyhim/awesome-claude-code/week/rss.xml` | 2026-08-20 | pre-existing — excluded |
+| 9 | `StevenSixon/my-daily-news` | `projects/hesreallyhim__awesome-claude-code/README.snapshot.md` | 2026-08-20 | pre-existing — excluded |
+| 10 | `bradAGI/awesome-cli-coding-agents` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 11 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/06/25-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 12 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/03-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 13 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/07-15-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 14 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/20-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 15 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/21-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 16 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/23-06-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 17 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/28-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 18 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 19 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/29-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 20 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/07/30-23-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 21 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 22 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/04-22-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 23 | `devops-actions/github-actions-marketplace-news` | `content/posts/2026/08/10-14-Zandereins-schliff.md` | 2026-08-20 | pre-existing — excluded |
+| 24 | `gabrielmoreira/awesome-ai-rabbit-holes` | `catalog/items/github/zandereins/schliff.yml` | 2026-08-20 | pre-existing — excluded |
+| 25 | `harrysun-code/awesome-with-star` | `awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
+| 26 | `hesreallyhim/awesome-claude-code` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 27 | `hesreallyhim/awesome-claude-code` | `THE_RESOURCES_TABLE_NEW.csv` | 2026-08-20 | pre-existing — excluded |
+| 28 | `ianshank/Agents` | `docs/claude-code-ecosystem-research.md` | 2026-08-20 | pre-existing — excluded |
+| 29 | `icopy-site/awesome` | `docs/awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
+| 30 | `icopy-site/awesome-cn` | `docs/awesome/awesome-claude-code.md` | 2026-08-20 | pre-existing — excluded |
+| 31 | `szabgab/pydigger-data` | `data/pypi/sc/schliff.json` | 2026-08-20 | pre-existing — excluded |
+| 32 | `thedixitjain/the-mega-skill-library` | `reference/hesreallyhim~awesome-claude-code/README.md` | 2026-08-20 | pre-existing — excluded |
+| 33 | `trackawesomelist/trackawesomelist` | `content/2026/07/03/README.md` | 2026-08-20 | pre-existing — excluded |
+| 34 | `trackawesomelist/trackawesomelist` | `content/2026/27/README.md` | 2026-08-20 | pre-existing — excluded |
+| 35 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/README.md` | 2026-08-20 | pre-existing — excluded |
+| 36 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/readme/README.md` | 2026-08-20 | pre-existing — excluded |
+| 37 | `trackawesomelist/trackawesomelist` | `content/hesreallyhim/awesome-claude-code/week/README.md` | 2026-08-20 | pre-existing — excluded |
+| 38 | `wan-huiyan/agent-review-panel` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 39 | `wan-huiyan/causal-impact-campaign` | `docs/README-v1.6.md` | 2026-08-20 | pre-existing — excluded |
+| 40 | `wan-huiyan/claude-ecosystem-hygiene` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 41 | `wan-huiyan/ml-training-window-assessor` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 42 | `wan-huiyan/publish-skill` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 43 | `wan-huiyan/publish-skill` | `plugins/publish-skill/SKILL.md` | 2026-08-20 | pre-existing — excluded |
+| 44 | `wan-huiyan/skill-sync` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 45 | `wan-huiyan/skill-sync` | `plugins/skill-sync/SKILL.md` | 2026-08-20 | pre-existing — excluded |
+| 46 | `yenanjing/awesome-ai-for-science` | `README.md` | 2026-08-20 | pre-existing — excluded |
+| 47 | `yenanjing/awesome-ai-for-science` | `data/repos.json` | 2026-08-20 | pre-existing — excluded |
+| 48 | `zhoux77899/claude-code-insights` | `plugins/cached-repos.txt` | 2026-08-20 | pre-existing — excluded |
+
+## What this file does not do
+
+It does not exclude a *repository* — it excludes a repository/path pair. A new file in
+`wan-huiyan/skill-sync`, for instance, is not covered by the row for that repository's existing
+path and must be dated by the spec's two-step procedure like any other hit.
+
+It also does not decide Gate 2. A hit outside this table still has to clear conditions (2), (3)
+and (4) of the qualitative branch — not-a-bot, unsolicited, and attributable to the plugin
+channel. This file only removes the dating work for what was already there.

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -70,9 +70,13 @@ not by a date that shows up in a calendar — so the block belongs on the action
 remote rather than a local ref, which is only as fresh as the last fetch:
 
 ```bash
-gh api repos/Zandereins/schliff/contents/docs/experiments/plugin-channel/s2-baseline.md \
+gh api -X GET repos/Zandereins/schliff/contents/docs/experiments/plugin-channel/s2-baseline.md \
   -f ref=main --jq .path
 ```
+
+`-X GET` is not optional: `gh` switches to POST as soon as any `-f` field is present, the
+contents route has no POST handler, and the resulting 404 is indistinguishable from the file
+being absent — a permanently red gate that reads as "the baseline was never committed.
 
 **Abandonment deadline.** If no submission PR has been opened at either qualified marketplace by
 **23:59 UTC on 2026-09-30**, the experiment is over. It is recorded in this file as
@@ -493,8 +497,10 @@ day overwrites that day's line rather than appending a duplicate), and never tou
 `"note":"baseline"` line.
 
 **The required cadence: at least once every 14 days, and on each reading date.** The daily
-workflow satisfies this with thirteen missed runs of slack — but only once `TRAFFIC_TOKEN` is
-set, and see the caveat on this 14-day figure in [Amendments](#amendments). Until then the manual command is the only thing producing lines. GitHub's traffic
+workflow satisfies this comfortably — but only once `TRAFFIC_TOKEN` is set. No slack figure is
+quoted here on purpose: the 14-day floor is one day too generous in the worst pairing of window
+drifts, so any count derived from it is wrong by one. See *Deliberately not changed here* in
+[Amendments](#amendments) and issue #199. Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
 
@@ -587,7 +593,11 @@ created 2026-06-21. It passes condition (2) as written. In this instance conditi
 anyway, because its interaction with this repository pre-dates D0, so no live gate is affected.
 
 *The duty:* if a signal is admitted whose author's public profile indicates mass automation, the
-account is **named in the verdict together with the reason it was or was not counted**. No number
+account is **named in the verdict, with the profile facts that prompted the note — and it still
+counts.** This adds disclosure only. It grants no discretion to exclude such an author: condition
+(2) as pre-registered decides that, and inventing an exclusion now, with `webbrain-one` already in
+view, is exactly what pre-registration forbids. A reader must be able to see which signals came
+from such accounts and judge the verdict themselves; that is the whole of the duty. No number
 is invented after the fact — inventing a repository-count threshold now, with the case already in
 view, is the exact pattern pre-registration exists to prevent. This mirrors the owner-attested
 mechanism already carried by condition (3): the check that cannot be fully mechanised is written
@@ -612,6 +622,9 @@ rather than evidence: a wrongly confounded reading cannot be recovered, a delaye
 *The scheduled placement*, given that Gate 2's window opens at A0 and the median open→merged
 latency for external PRs at `jeremylongshore/claude-code-plugins-plus-skills` was measured at
 **1.17 days** (61 external merges, full result set: 876 returned against a limit of 3000): the
-release goes out after Observation R's snapshot and a full week before the submission PR, so its
-tail has decayed before A0 can start Gate 2's window. A release the day before D0 would have put
-its tail inside Gate 2 almost immediately.
+release goes out after Observation R's snapshot and a full week before the submission PR. Note
+what does and does not follow: with release 09-11, D0 09-18 and A0 ≈ 09-19, the 14-day counter at
+A0 still contains release day, so the week of separation does **not** clear the tail out of the
+window. What protects the gate is that the quantitative branch reads a single snapshot at A0+30,
+by which point release day has long fallen out of a 14-day window entirely. The separation buys
+margin on the qualitative branch and on any reading taken earlier, not on the arithmetic.

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -76,7 +76,7 @@ gh api -X GET repos/Zandereins/schliff/contents/docs/experiments/plugin-channel/
 
 `-X GET` is not optional: `gh` switches to POST as soon as any `-f` field is present, the
 contents route has no POST handler, and the resulting 404 is indistinguishable from the file
-being absent — a permanently red gate that reads as "the baseline was never committed.
+being absent — a permanently red gate that reads as "the baseline was never committed".
 
 **Abandonment deadline.** If no submission PR has been opened at either qualified marketplace by
 **23:59 UTC on 2026-09-30**, the experiment is over. It is recorded in this file as
@@ -488,7 +488,7 @@ granted through the `permissions:` block at all.
 So the workflow reads a `TRAFFIC_TOKEN` repository secret — a fine-grained personal access token
 scoped to this repository with **Administration: Read** (and Contents: Read and write, so it can
 commit the observation). Until that secret exists the job exits green with a notice and collects
-nothing: a scheduled job that fails every week teaches its owner to ignore it, which is a worse
+nothing: a scheduled job that fails every day teaches its owner to ignore it, which is a worse
 failure than a missing measurement. **A green run is therefore not evidence that an observation
 was taken** — check that `traffic.jsonl` grew.
 
@@ -497,10 +497,15 @@ day overwrites that day's line rather than appending a duplicate), and never tou
 `"note":"baseline"` line.
 
 **The required cadence: at least once every 14 days, and on each reading date.** The daily
-workflow satisfies this comfortably — but only once `TRAFFIC_TOKEN` is set. No slack figure is
-quoted here on purpose: the 14-day floor is one day too generous in the worst pairing of window
-drifts, so any count derived from it is wrong by one. See *Deliberately not changed here* in
-[Amendments](#amendments) and issue #199. Until then the manual command is the only thing producing lines. GitHub's traffic
+workflow satisfies this comfortably, and `TRAFFIC_TOKEN` is configured — the 2026-08-17T06:28
+`schedule` run succeeded and produced commit `ca60a89` on `experiment/traffic-data`. Were the
+secret ever removed, the manual command would again be the only thing producing lines.
+
+No slack figure is quoted here on purpose: the 14-day floor is one day too generous in the worst
+pairing of window drifts, so any count derived from it is wrong by one — including the "15 days"
+below. See *Deliberately not changed here* in [Amendments](#amendments) and issue #199.
+
+GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
 

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -449,7 +449,7 @@ job, no LaunchAgent.
 `main` is protected with `enforce_admins: true` and six required status checks, so a workflow
 push to it is rejected outright — measured on 2026-08-11 in run `31519738229`, where collection
 succeeded and only the push failed with `GH006: Protected branch update failed`. Opening a pull
-request for each weekly line would trade that for a merge queue nobody asked for. The scheduled
+request for each daily line would trade that for a merge queue nobody asked for. The scheduled
 job therefore appends to `docs/experiments/plugin-channel/traffic.jsonl` **on that branch**, and
 `main` keeps only the seeded baseline until a reading is taken.
 
@@ -483,8 +483,9 @@ It needs an authenticated `gh` and nothing else, is idempotent per UTC day (a se
 day overwrites that day's line rather than appending a duplicate), and never touches the seeded
 `"note":"baseline"` line.
 
-**The required cadence: at least once every 14 days, and on each reading date.** The weekly
-workflow satisfies this with a full missed run of slack — but only once `TRAFFIC_TOKEN` is set.
+**The required cadence: at least once every 14 days, and on each reading date.** The daily
+workflow satisfies this with thirteen missed runs of slack against the 14-day limit, and covers
+every reading date by construction — but only once `TRAFFIC_TOKEN` is set.
 Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
@@ -524,16 +525,26 @@ corrected to match.
 
 *Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
 Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the
-qualifying snapshot would have been the one from 09-07: a 30-day window read on day 27, from a
-rolling 14-day counter that never contained 09-08 through 09-10. *The dates that must be covered*
-already required 2026-09-10; the schedule could not deliver it. This is not
+qualifying snapshot would have been the one from 09-07 — a 30-day observation read from a
+counter whose window ends around 09-05, leaving its last five days outside the number that
+decides it. *The dates that must be covered* already required 2026-09-10; the schedule could not
+deliver it. This is not
 `UNMEASURED-COLLECTOR-GAP` — a line would have existed and the 14-day chain was never broken. It
 is a snapshot on the wrong date, which the reading rule forbids substituting away.
 
 *Why daily rather than a dated one-off:* the same requirement names a second date, A0+30, which
 cannot be wired in advance because A0 is the merge date of a submission not yet opened. A dated
-cron would have fixed one instance of the defect and left the other. 20:17 UTC puts ~20 of 24
-hours of any reading date into the counter while leaving ~3.7h before the 23:59 boundary.
+cron would have fixed one instance of the defect and left the other.
+
+*What the 20:17 UTC hour does and does not buy.* It does **not** put the reading date into the
+counter: the traffic API never reports the day the call is made. Measured 2026-08-20, a call at
+10:12 UTC returned a window ending 2026-08-19, and all three committed snapshots agree
+(08-11T12:52 → ends 08-10; 08-17T06:28 → ends 08-15). What the hour buys is whether the window
+ends at T-1 or T-2: the 06:28 run came back at T-2, while calls at 10:12, 12:52 and 17:57 all
+came back at T-1. A late run therefore costs one day of lag instead of two — and **one day is the
+floor this API allows, not zero.** Under the old Monday schedule the 09-07 snapshot would have
+ended around 09-05, leaving the last five days of a 30-day observation outside the counter that
+decides it; under the new one it is one day. ~3.7h of slack remains before the 23:59 boundary.
 
 *Cost:* ~30 observations per month on `experiment/traffic-data` instead of ~4. That branch holds
 data only.
@@ -577,8 +588,10 @@ verbal constraint, which a reader had no way to check.
 `[Unreleased]` block has been ready since 2026-08-14 and is deliberately held.
 
 *Honest about the evidence:* the confound is **not demonstrated** on the metric that matters.
-Release day 2026-08-10 carries the highest single-day `count` in the baseline (26) but only 6
-`uniques`, while the `uniques` peak in the same window (2026-08-13) has no release near it. A
+Release day 2026-08-10 carries the highest single-day `count` in the baseline window
+(2026-07-28 … 2026-08-10) at 26, but only 6 `uniques` — while that window's `uniques` peak, 7 on
+2026-07-29, has no release near it. The highest `uniques` day recorded anywhere so far, 8 on
+2026-08-13, sits in the 08-17 snapshot's window and likewise has no release near it. A
 release plausibly moves views; on uniques it is unproven. The constraint is kept on asymmetry
 rather than evidence: a wrongly confounded reading cannot be recovered, a delayed release can.
 

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -66,7 +66,11 @@ submission PR is opened at either marketplace until
 `docs/experiments/plugin-channel/s2-baseline.md` is on `main`. The S2 void rule below is
 conditional on D0, which means the loss it describes is triggered by an action the owner takes,
 not by a date that shows up in a calendar — so the block belongs on the action. Captured
-2026-08-20; the precondition is satisfied.
+2026-08-20. Whether the precondition holds is not asserted here, it is checked:
+
+```bash
+git show origin/main:docs/experiments/plugin-channel/s2-baseline.md > /dev/null && echo OK
+```
 
 **Abandonment deadline.** If no submission PR has been opened at either qualified marketplace by
 **23:59 UTC on 2026-09-30**, the experiment is over. It is recorded in this file as
@@ -264,7 +268,9 @@ that turns away a real signal it cannot date, because only the first kind of err
 a false GREEN.
 
 **(2) Not the owner, not a bot.** Author login ≠ `Zandereins`, and `gh api users/<login> --jq
-.type` returns `User` (not `Bot`, and not an `app/` login).
+.type` returns `User` (not `Bot`, and not an `app/` login). *(amended 2026-08-20 — a
+mass-automation account can pass this check as written; if one is admitted it must be named in
+the verdict with the reason it was or was not counted. See [Amendments](#amendments).)*
 
 **(3) Unsolicited — the condition that does the real work.** The signal does not count if the
 author is anyone the owner contacted, asked, told, or is otherwise connected to. Checkable filters,
@@ -423,9 +429,10 @@ against the same artifacts, on the stated dates:
 - Observation R: as specified in its own section — read 2026-09-10, recorded whatever it says.
 
 Both thresholds are numbers fixed in this document before either measurement is taken. There is
-no discretionary judgment call available at verdict time beyond the two already made and
-disclosed above — the strength caveat on Gate 1 given an effective N of 1, and the owner-attested
-no-solicitation commitment in Gate 2's condition (3). Nothing about the passing or failing values
+no discretionary judgment call available at verdict time beyond the three already made and
+disclosed — the strength caveat on Gate 1 given an effective N of 1, the owner-attested
+no-solicitation commitment in Gate 2's condition (3), and the mass-automation disclosure duty
+added to condition (2) on 2026-08-20 (see [Amendments](#amendments)). Nothing about the passing or failing values
 can be adjusted after the traffic or PR data comes in.
 
 ## Operating the collector
@@ -440,8 +447,9 @@ the collector ran.
 make collect-traffic     # or: bash scripts/collect-traffic.sh
 ```
 
-**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it **daily at 20:17
-UTC** *(amended 2026-08-20 — was weekly, Mondays 06:17 UTC; see [Amendments](#amendments))* so
+**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it **twice daily, at
+12:17 and 20:17 UTC** *(amended 2026-08-20 — was weekly, Mondays 06:17 UTC; see
+[Amendments](#amendments))* so
 the record does not depend on anyone remembering. Nothing is installed on any machine — no cron
 job, no LaunchAgent.
 
@@ -483,9 +491,13 @@ It needs an authenticated `gh` and nothing else, is idempotent per UTC day (a se
 day overwrites that day's line rather than appending a duplicate), and never touches the seeded
 `"note":"baseline"` line.
 
-**The required cadence: at least once every 14 days, and on each reading date.** The daily
-workflow satisfies this with thirteen missed runs of slack against the 14-day limit, and covers
-every reading date by construction — but only once `TRAFFIC_TOKEN` is set.
+**The required cadence: at least once every 12 days, and on each reading date.** The twice-daily
+workflow satisfies this with wide margin, and covers every reading date by
+construction — but only once `TRAFFIC_TOKEN` is set. Twelve days rather than the API's fourteen
+because the window's end drifts: a run answered at T-1 covers `[N-14, N-1]`, one answered at T-2 covers
+`[N-15, N-2]` (measured — see [Amendments](#amendments)). If the run before a gap lands at T-2
+and the one after it at T-1, a 14-day spacing leaves exactly one day in no snapshot at all, which
+is `UNMEASURED-COLLECTOR-GAP`. Twelve is the figure that holds in the worst pairing.
 Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
@@ -520,8 +532,9 @@ Observation R still reads 2026-09-10, and the abandonment deadline is still 2026
 ### 2026-08-20 — collector moved from weekly to daily
 
 *What changed:* `.github/workflows/collect-traffic.yml` ran `cron: '17 6 * * 1'` (Mondays). It now
-runs `cron: '17 20 * * *'` (daily, 20:17 UTC). The prose in *Operating the collector* was
-corrected to match.
+runs `'17 12 * * *'` and `'17 20 * * *'` — twice daily. Every prose description of the cadence was
+corrected to match, in this file, in the workflow, and in `scripts/collect-traffic.sh`; the last
+of those was missed on the first pass and caught in review.
 
 *Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
 Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -493,11 +493,17 @@ day overwrites that day's line rather than appending a duplicate), and never tou
 
 **The required cadence: at least once every 12 days, and on each reading date.** The twice-daily
 workflow satisfies this with wide margin, and covers every reading date by
-construction — but only once `TRAFFIC_TOKEN` is set. Twelve days rather than the API's fourteen
-because the window's end drifts: a run answered at T-1 covers `[N-14, N-1]`, one answered at T-2 covers
-`[N-15, N-2]` (measured — see [Amendments](#amendments)). If the run before a gap lands at T-2
-and the one after it at T-1, a 14-day spacing leaves exactly one day in no snapshot at all, which
-is `UNMEASURED-COLLECTOR-GAP`. Twelve is the figure that holds in the worst pairing.
+construction — but only once `TRAFFIC_TOKEN` is set.
+
+Twelve rather than the API's fourteen, and the two steps are separate. **The arithmetic gives
+thirteen:** a run answered at T-1 covers `[N-14, N-1]`, one answered at T-2 covers `[N-15, N-2]`
+(both measured — see [Amendments](#amendments)). If the run before a gap lands at T-2 and the one
+after it at T-1, spacing of 14 leaves day `N-1` in no snapshot at all — `UNMEASURED-COLLECTOR-GAP`
+— while 13 still closes flush. **Twelve is thirteen minus one day of reserve**, taken because the
+T-1/T-2 drift rests on three observations and a slower answer than any yet seen would break a
+bound set exactly at the arithmetic. The reserve is a deliberate margin, not a derivation; naming
+it as such is the point, since a number whose stated reasoning implies a different number is how
+this document loses its authority.
 Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -66,10 +66,12 @@ submission PR is opened at either marketplace until
 `docs/experiments/plugin-channel/s2-baseline.md` is on `main`. The S2 void rule below is
 conditional on D0, which means the loss it describes is triggered by an action the owner takes,
 not by a date that shows up in a calendar — so the block belongs on the action. Captured
-2026-08-20. Whether the precondition holds is not asserted here, it is checked:
+2026-08-20. Whether the precondition holds is not asserted here, it is checked against the
+remote rather than a local ref, which is only as fresh as the last fetch:
 
 ```bash
-git show origin/main:docs/experiments/plugin-channel/s2-baseline.md > /dev/null && echo OK
+gh api repos/Zandereins/schliff/contents/docs/experiments/plugin-channel/s2-baseline.md \
+  -f ref=main --jq .path
 ```
 
 **Abandonment deadline.** If no submission PR has been opened at either qualified marketplace by
@@ -447,9 +449,8 @@ the collector ran.
 make collect-traffic     # or: bash scripts/collect-traffic.sh
 ```
 
-**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it **twice daily, at
-12:17 and 20:17 UTC** *(amended 2026-08-20 — was weekly, Mondays 06:17 UTC; see
-[Amendments](#amendments))* so
+**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it **daily at 20:17
+UTC** *(amended 2026-08-20 — was weekly, Mondays 06:17 UTC; see [Amendments](#amendments))* so
 the record does not depend on anyone remembering. Nothing is installed on any machine — no cron
 job, no LaunchAgent.
 
@@ -491,20 +492,9 @@ It needs an authenticated `gh` and nothing else, is idempotent per UTC day (a se
 day overwrites that day's line rather than appending a duplicate), and never touches the seeded
 `"note":"baseline"` line.
 
-**The required cadence: at least once every 12 days, and on each reading date.** The twice-daily
-workflow satisfies this with wide margin, and covers every reading date by
-construction — but only once `TRAFFIC_TOKEN` is set.
-
-Twelve rather than the API's fourteen, and the two steps are separate. **The arithmetic gives
-thirteen:** a run answered at T-1 covers `[N-14, N-1]`, one answered at T-2 covers `[N-15, N-2]`
-(both measured — see [Amendments](#amendments)). If the run before a gap lands at T-2 and the one
-after it at T-1, spacing of 14 leaves day `N-1` in no snapshot at all — `UNMEASURED-COLLECTOR-GAP`
-— while 13 still closes flush. **Twelve is thirteen minus one day of reserve**, taken because the
-T-1/T-2 drift rests on three observations and a slower answer than any yet seen would break a
-bound set exactly at the arithmetic. The reserve is a deliberate margin, not a derivation; naming
-it as such is the point, since a number whose stated reasoning implies a different number is how
-this document loses its authority.
-Until then the manual command is the only thing producing lines. GitHub's traffic
+**The required cadence: at least once every 14 days, and on each reading date.** The daily
+workflow satisfies this with thirteen missed runs of slack — but only once `TRAFFIC_TOKEN` is
+set. Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
 
@@ -538,18 +528,18 @@ Observation R still reads 2026-09-10, and the abandonment deadline is still 2026
 ### 2026-08-20 — collector moved from weekly to daily
 
 *What changed:* `.github/workflows/collect-traffic.yml` ran `cron: '17 6 * * 1'` (Mondays). It now
-runs `'17 12 * * *'` and `'17 20 * * *'` — twice daily. Every prose description of the cadence was
-corrected to match, in this file, in the workflow, and in `scripts/collect-traffic.sh`; the last
-of those was missed on the first pass and caught in review.
+runs `cron: '17 20 * * *'` — daily. The prose naming the cadence was corrected to match in this
+file, in the workflow header, and in `scripts/collect-traffic.sh`, whose header still claimed
+nothing scheduled the collector at all.
 
 *Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
 Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the
 qualifying snapshot would have been the one from 09-07 — a 30-day observation read from a
 counter whose window ends around 09-05, leaving its last five days outside the number that
 decides it. *The dates that must be covered* already required 2026-09-10; the schedule could not
-deliver it. This is not
-`UNMEASURED-COLLECTOR-GAP` — a line would have existed and the 14-day chain was never broken. It
-is a snapshot on the wrong date, which the reading rule forbids substituting away.
+deliver it. This is not `UNMEASURED-COLLECTOR-GAP` — a line would have existed and the 14-day
+chain was never broken. It is a snapshot on the wrong date, which the reading rule forbids
+substituting away.
 
 *Why daily rather than a dated one-off:* the same requirement names a second date, A0+30, which
 cannot be wired in advance because A0 is the merge date of a submission not yet opened. A dated
@@ -561,9 +551,13 @@ counter: the traffic API never reports the day the call is made. Measured 2026-0
 (08-11T12:52 → ends 08-10; 08-17T06:28 → ends 08-15). What the hour buys is whether the window
 ends at T-1 or T-2: the 06:28 run came back at T-2, while calls at 10:12, 12:52 and 17:57 all
 came back at T-1. A late run therefore costs one day of lag instead of two — and **one day is the
-floor this API allows, not zero.** Under the old Monday schedule the 09-07 snapshot would have
-ended around 09-05, leaving the last five days of a 30-day observation outside the counter that
-decides it; under the new one it is one day. ~3.7h of slack remains before the 23:59 boundary.
+floor this API allows, not zero.**
+
+*Deliberately not changed here:* the 14-day cadence floor. That number predates this experiment
+and the drift measured above shows it is one day too generous in the worst pairing — a T-2 run
+followed 14 days later by a T-1 run leaves one day in no snapshot. Correcting it touches eleven
+sites across three files and is not what this change is for; it is filed separately so the fix
+that has a deadline is not held up by one that does not.
 
 *Cost:* ~30 observations per month on `experiment/traffic-data` instead of ~4. That branch holds
 data only.

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -494,7 +494,7 @@ day overwrites that day's line rather than appending a duplicate), and never tou
 
 **The required cadence: at least once every 14 days, and on each reading date.** The daily
 workflow satisfies this with thirteen missed runs of slack — but only once `TRAFFIC_TOKEN` is
-set. Until then the manual command is the only thing producing lines. GitHub's traffic
+set, and see the caveat on this 14-day figure in [Amendments](#amendments). Until then the manual command is the only thing producing lines. GitHub's traffic
 API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
 not a default that can be raised.
 
@@ -528,9 +528,10 @@ Observation R still reads 2026-09-10, and the abandonment deadline is still 2026
 ### 2026-08-20 — collector moved from weekly to daily
 
 *What changed:* `.github/workflows/collect-traffic.yml` ran `cron: '17 6 * * 1'` (Mondays). It now
-runs `cron: '17 20 * * *'` — daily. The prose naming the cadence was corrected to match in this
-file, in the workflow header, and in `scripts/collect-traffic.sh`, whose header still claimed
-nothing scheduled the collector at all.
+runs `cron: '17 20 * * *'` — daily. Every prose description of **the workflow's own schedule** was
+corrected to match: in this file, in the workflow header, and in `scripts/collect-traffic.sh`,
+whose header still claimed nothing scheduled the collector at all. The separate 14-day floor on
+how long data survives is untouched — see *Deliberately not changed here* below.
 
 *Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
 Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -61,6 +61,13 @@ The clock is not "when Franz decides to start" — it is an event with a public 
 | First submission PR URL | *not yet submitted* |
 | Second submission PR URL (if any) | *not yet submitted* |
 
+**Precondition on opening it at all** *(amended 2026-08-20 — see [Amendments](#amendments))*: no
+submission PR is opened at either marketplace until
+`docs/experiments/plugin-channel/s2-baseline.md` is on `main`. The S2 void rule below is
+conditional on D0, which means the loss it describes is triggered by an action the owner takes,
+not by a date that shows up in a calendar — so the block belongs on the action. Captured
+2026-08-20; the precondition is satisfied.
+
 **Abandonment deadline.** If no submission PR has been opened at either qualified marketplace by
 **23:59 UTC on 2026-09-30**, the experiment is over. It is recorded in this file as
 `ABANDONED-UNSUBMITTED`, and that is a real, reportable outcome, not a pause: it says the
@@ -433,9 +440,10 @@ the collector ran.
 make collect-traffic     # or: bash scripts/collect-traffic.sh
 ```
 
-**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it weekly (Mondays
-06:17 UTC) so the record does not depend on anyone remembering. Nothing is installed on any
-machine — no cron job, no LaunchAgent.
+**Or on a schedule, in CI.** `.github/workflows/collect-traffic.yml` runs it **daily at 20:17
+UTC** *(amended 2026-08-20 — was weekly, Mondays 06:17 UTC; see [Amendments](#amendments))* so
+the record does not depend on anyone remembering. Nothing is installed on any machine — no cron
+job, no LaunchAgent.
 
 **Where the scheduled observations land: the `experiment/traffic-data` branch, not `main`.**
 `main` is protected with `enforce_admins: true` and six required status checks, so a workflow
@@ -496,3 +504,87 @@ RED, because a RED is a finding and a gap is only a mistake.
 and A0+30 whenever Gate 1 passes. Running it on those two dates is not sufficient on its own —
 the 14-day rule still applies throughout, or the snapshot taken on the reading date will be
 correct but the record around it will have holes.
+
+## Amendments
+
+Changes made to this document **after** it was pre-registered on 2026-08-11. Listed so a reader
+can separate what was fixed in advance from what was added later. `distributors.md` sets the
+precedent: showing the correction is the point, silently editing it would be worse than the
+original error.
+
+**No threshold, window, date or gate criterion has been changed by any amendment below.** Gate 1
+is still "≥1 of N merges within D0+21", Gate 2's quantitative branch is still ≥96 uniques,
+Observation R still reads 2026-09-10, and the abandonment deadline is still 2026-09-30.
+
+### 2026-08-20 — collector moved from weekly to daily
+
+*What changed:* `.github/workflows/collect-traffic.yml` ran `cron: '17 6 * * 1'` (Mondays). It now
+runs `cron: '17 20 * * *'` (daily, 20:17 UTC). The prose in *Operating the collector* was
+corrected to match.
+
+*Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
+Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the
+qualifying snapshot would have been the one from 09-07: a 30-day window read on day 27, from a
+rolling 14-day counter that never contained 09-08 through 09-10. *The dates that must be covered*
+already required 2026-09-10; the schedule could not deliver it. This is not
+`UNMEASURED-COLLECTOR-GAP` — a line would have existed and the 14-day chain was never broken. It
+is a snapshot on the wrong date, which the reading rule forbids substituting away.
+
+*Why daily rather than a dated one-off:* the same requirement names a second date, A0+30, which
+cannot be wired in advance because A0 is the merge date of a submission not yet opened. A dated
+cron would have fixed one instance of the defect and left the other. 20:17 UTC puts ~20 of 24
+hours of any reading date into the counter while leaving ~3.7h before the 23:59 boundary.
+
+*Cost:* ~30 observations per month on `experiment/traffic-data` instead of ~4. That branch holds
+data only.
+
+### 2026-08-20 — S2 baseline captured, and made a precondition of D0
+
+*What changed:* `docs/experiments/plugin-channel/s2-baseline.md` was created (48 repository/path
+pairs, 22 repositories; the `schliff@schliff` query returned 0). A precondition was added to *The
+clock*: no submission PR is opened until that file is on `main`.
+
+*Why:* the file the spec required had never been written. The void rule is conditional on D0, so
+nothing was lost yet — but the trigger is an action the owner controls rather than a date, which
+is precisely why it stayed invisible for nine days. Binding it to the action removes the
+dependency on anyone remembering. No criterion moved: the S2 branch, its dating procedure and its
+conditions are unchanged.
+
+### 2026-08-20 — Gate 2 condition (2): disclosure duty for mass-automation accounts
+
+*What changed:* nothing in the condition. This amendment adds a **disclosure duty**, not a
+threshold.
+
+*Why:* condition (2) qualifies an author by `gh api users/<login> --jq .type` returning `User`.
+Measured 2026-08-20, the account `webbrain-one` — which forked this repository and opened PR #188
+— returns `type=User` and `is_bot=false` while holding 20,816 public repositories on an account
+created 2026-06-21. It passes condition (2) as written. In this instance condition (3) excludes it
+anyway, because its interaction with this repository pre-dates D0, so no live gate is affected.
+
+*The duty:* if a signal is admitted whose author's public profile indicates mass automation, the
+account is **named in the verdict together with the reason it was or was not counted**. No number
+is invented after the fact — inventing a repository-count threshold now, with the case already in
+view, is the exact pattern pre-registration exists to prevent. This mirrors the owner-attested
+mechanism already carried by condition (3): the check that cannot be fully mechanised is written
+down in advance and disclosed when used.
+
+### 2026-08-20 — release timing recorded as an operational constraint
+
+*What changed:* nothing in any gate. Recorded here because it was previously an undocumented
+verbal constraint, which a reader had no way to check.
+
+*The constraint:* version 8.12.0 is not released while a measurement window is open. Its
+`[Unreleased]` block has been ready since 2026-08-14 and is deliberately held.
+
+*Honest about the evidence:* the confound is **not demonstrated** on the metric that matters.
+Release day 2026-08-10 carries the highest single-day `count` in the baseline (26) but only 6
+`uniques`, while the `uniques` peak in the same window (2026-08-13) has no release near it. A
+release plausibly moves views; on uniques it is unproven. The constraint is kept on asymmetry
+rather than evidence: a wrongly confounded reading cannot be recovered, a delayed release can.
+
+*The scheduled placement*, given that Gate 2's window opens at A0 and the median open→merged
+latency for external PRs at `jeremylongshore/claude-code-plugins-plus-skills` was measured at
+**1.17 days** (61 external merges, full result set: 876 returned against a limit of 3000): the
+release goes out after Observation R's snapshot and a full week before the submission PR, so its
+tail has decayed before A0 can start Gate 2's window. A release the day before D0 would have put
+its tail inside Gate 2 almost immediately.

--- a/scripts/collect-traffic.sh
+++ b/scripts/collect-traffic.sh
@@ -15,8 +15,8 @@
 # On a schedule it is driven by .github/workflows/collect-traffic.yml, daily at
 # 12:17 and 20:17 UTC — nothing is installed on any machine, no cron job and no
 # LaunchAgent. Run by hand only if that workflow is disabled or TRAFFIC_TOKEN is
-# unset; the cadence floor is one run every 12 days or the un-snapshotted days
-# expire for good — see the "Operating the collector" section of
+# unset; the cadence floor is one run every 12 days (13 by the arithmetic, one
+# day held back as reserve) or the un-snapshotted days expire for good — see the "Operating the collector" section of
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #
 # Idempotent per day: if the output file already has a line for today's UTC

--- a/scripts/collect-traffic.sh
+++ b/scripts/collect-traffic.sh
@@ -15,7 +15,8 @@
 # On a schedule it is driven by .github/workflows/collect-traffic.yml, daily at
 # 20:17 UTC — nothing is installed on any machine, no cron job and no
 # LaunchAgent. Run by hand only if that workflow is disabled or TRAFFIC_TOKEN is
-# unset; the floor is one run every 14 days or the un-snapshotted days
+# unset; the floor is one run every 14 days -- which is one day too generous in
+# the worst pairing of window drifts, see issue #199 -- or the un-snapshotted days
 # expire for good — see the "Operating the collector" section of
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #

--- a/scripts/collect-traffic.sh
+++ b/scripts/collect-traffic.sh
@@ -13,10 +13,10 @@
 #
 # Run it with `make collect-traffic` (or directly) for an ad-hoc observation.
 # On a schedule it is driven by .github/workflows/collect-traffic.yml, daily at
-# 12:17 and 20:17 UTC — nothing is installed on any machine, no cron job and no
+# 20:17 UTC — nothing is installed on any machine, no cron job and no
 # LaunchAgent. Run by hand only if that workflow is disabled or TRAFFIC_TOKEN is
-# unset; the cadence floor is one run every 12 days (13 by the arithmetic, one
-# day held back as reserve) or the un-snapshotted days expire for good — see the "Operating the collector" section of
+# unset; the floor is one run every 14 days or the un-snapshotted days
+# expire for good — see the "Operating the collector" section of
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #
 # Idempotent per day: if the output file already has a line for today's UTC

--- a/scripts/collect-traffic.sh
+++ b/scripts/collect-traffic.sh
@@ -11,10 +11,12 @@
 # numbers: the analysis method can change later, the observation cannot be
 # retaken.
 #
-# Run it with `make collect-traffic` (or directly). Nothing schedules this:
-# no cron job and no LaunchAgent is installed by this repo. It must be run by
-# hand at least once every 14 days or the un-snapshotted days expire for good
-# — see the "Operating the collector" section of
+# Run it with `make collect-traffic` (or directly) for an ad-hoc observation.
+# On a schedule it is driven by .github/workflows/collect-traffic.yml, daily at
+# 12:17 and 20:17 UTC — nothing is installed on any machine, no cron job and no
+# LaunchAgent. Run by hand only if that workflow is disabled or TRAFFIC_TOKEN is
+# unset; the cadence floor is one run every 12 days or the un-snapshotted days
+# expire for good — see the "Operating the collector" section of
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #
 # Idempotent per day: if the output file already has a line for today's UTC


### PR DESCRIPTION
Three operational defects in the running plugin-channel experiment. **No threshold, window, date or gate criterion changes.** Gate 1 is still ≥1 of N within D0+21, Gate 2's quantitative branch is still ≥96 uniques, Observation R still reads 2026-09-10, abandonment is still 2026-09-30.

## 1. The collector could not deliver the reading date

`cron: '17 6 * * 1'` — Mondays. **2026-09-10 is a Thursday.** The Mondays before it: 08-24, 08-31, **09-07**.

The reading rule takes "the last `traffic.jsonl` line whose `collected_at` is at or before 23:59 UTC on 2026-09-10". That would have been the 09-07 line — a 30-day window read on day 27, from a rolling 14-day counter that never contained 09-08 through 09-10. *The dates that must be covered* already required 2026-09-10.

This is **not** `UNMEASURED-COLLECTOR-GAP`: a line would have existed and the 14-day chain was never broken. It is a snapshot on the wrong date, which the reading rule forbids substituting away.

Now `cron: '17 20 * * *'`. Daily rather than a dated one-off, because the same requirement names a second date — **A0+30** — that cannot be wired in advance, since A0 is the merge date of a submission not yet opened. A dated cron fixes one instance of the defect and leaves the other. 20:17 UTC puts ~20 of 24 hours of any reading date into the counter with ~3.7h before the boundary.

Cost: ~30 observations/month on `experiment/traffic-data` instead of ~4. That branch holds data only.

## 2. The S2 baseline never existed

The spec requires it before the first submission PR: *"if D0 arrives with no committed baseline, the S2 branch is void"* — *"A control taken after the intervention is not a control."*

`s2-baseline.md` was on no ref. Nothing is lost yet, because the rule is conditional on D0 and D0 is still `*not yet submitted*`. But the trigger is **an action the owner takes, not a date** — which is exactly why it stayed invisible for nine days while every calendar-bound item got done.

Captured: **48 repository/path pairs across 22 repositories**. The `schliff@schliff` query returns **0**, itself a recorded result. Completeness proven the only way that works — `per_page=100`, returned count checked against the API's own `total_count`, both complete.

And bound to the action, so it cannot go missing again: no submission PR opens until the file is on `main`.

## 3. Amendments recorded, not edited in silently

New dated `## Amendments` section, following the precedent `distributors.md` set. It also records two things that were previously undocumented:

- **Gate 2 condition (2) disclosure duty.** `webbrain-one` passes the condition as written — `type=User`, `is_bot=false` — while holding 20,816 public repositories on an account created 2026-06-21, and it opened PR #188 here. Condition (3) excludes it in this instance, so no live gate is affected. The amendment adds a duty to *name and justify* such an account in the verdict; it deliberately does **not** invent a repository-count threshold now that the case is in view.
- **Release timing**, with its evidence stated honestly: the confound is *unproven* on uniques. Release day 08-10 has the highest single-day `count` (26) but only 6 `uniques`, while the uniques peak (08-13) has no release near it. The constraint is kept on asymmetry — a wrongly confounded reading cannot be recovered, a delayed release can.

## Verification

- `2159 passed in 42.15s` (`/usr/bin/python3 -m pytest skills/schliff/tests -q`)
- `markdownlint-cli2` → `0 issues in 0 files` on both changed markdown files
- workflow YAML parses; `schedule = [{'cron': '17 20 * * *'}]`

**Not verified until it happens:** a cron change is a claim until it fires. Scheduled workflows run only from the default branch, so this proves nothing until merged — then `gh run list --workflow=collect-traffic.yml` within 24–48h.