### PR TITLE
fix(gradients): rescale delta literals from the skill.md basis they were written on

### DIFF
--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -574,27 +574,48 @@ def _parse_delta(delta: Any) -> float:
     return 0.0
 
 
+# Formats whose delta literals have been MEASURED against the skill.md basis.
+# The rescale is only sound where that basis actually holds, and it does not hold
+# everywhere: `ambiguous_pronouns: 2.5` divided by clarity's 0.05 implies 50
+# dimension points for a pronoun fix, which is not what anyone wrote down. Some
+# literals are freehand composite guesses, not points-times-weight.
+#
+# agents.md is verified: removing a TODO marker reports 1.5, and the structure
+# dimension really moves 75 -> 85, worth 10 x 0.4 = 4.00 composite (the observed
+# 4.40 total includes +0.40 from efficiency, which is a different fix's credit).
+# system_prompt is NOT on this list: scaling there fires on clarity (x3) and
+# efficiency (x1.5) but not on structure — its profile calls that
+# `structure_prompt` — so the result is partial and incoherent within one
+# ranking, and measured it overstates a clarity fix as +7.5 against a real +1.9.
+_DELTA_SCALED_FORMATS = frozenset({"agents.md"})
+
+
 def _scale_delta_to_format(value, dimension, resolved_fmt):
     """Rescale a delta literal from the skill.md basis it was written on.
 
-    Every hardcoded delta in this module is a composite estimate sized against
-    skill.md's weight table — `missing_name: 1.5` is 10 dimension points times
-    structure's 0.15 there. Scored as an AGENTS.md the same fix is worth 10 x 0.4,
-    and reporting 1.5 understates it by a factor of ~2.7. Measured: removing a
-    TODO marker reports +1.5 and moves the composite +4.4.
+    Hardcoded deltas here are composite estimates sized against skill.md's weight
+    table — `missing_name: 1.5` is 10 dimension points times structure's 0.15
+    there. Emitted unchanged on an AGENTS.md, where structure carries 0.4, the
+    same fix understates itself ~2.7x.
 
-    Returns the value unchanged when the format is skill.md (factor 1.0, so the
-    current path does not move at all) and when the dimension is absent from the
-    skill.md table — operational_coverage computes its delta against the live
-    profile already and must not be scaled twice.
+    Returns the value untouched for any format not on ``_DELTA_SCALED_FORMATS``,
+    which includes skill.md itself, and for a dimension missing from either
+    profile — operational_coverage computes its delta against the live profile
+    already and must not be scaled twice.
     """
-    if not resolved_fmt or resolved_fmt == "skill.md":
+    if resolved_fmt not in _DELTA_SCALED_FORMATS:
         return value
     from scoring.registry import get_weights
     base = get_weights("skill.md").get(dimension)
     target = get_weights(resolved_fmt).get(dimension)
-    if not base or not target:
+    if base is None or target is None:
         return value
+    if not base:
+        # A zero base cannot express a ratio; leave the estimate alone.
+        return value
+    if not target:
+        # The dimension does not count toward this format's score at all.
+        return 0.0
     return round(value * (target / base), 2)
 
 

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -574,6 +574,30 @@ def _parse_delta(delta: Any) -> float:
     return 0.0
 
 
+def _scale_delta_to_format(value, dimension, resolved_fmt):
+    """Rescale a delta literal from the skill.md basis it was written on.
+
+    Every hardcoded delta in this module is a composite estimate sized against
+    skill.md's weight table — `missing_name: 1.5` is 10 dimension points times
+    structure's 0.15 there. Scored as an AGENTS.md the same fix is worth 10 x 0.4,
+    and reporting 1.5 understates it by a factor of ~2.7. Measured: removing a
+    TODO marker reports +1.5 and moves the composite +4.4.
+
+    Returns the value unchanged when the format is skill.md (factor 1.0, so the
+    current path does not move at all) and when the dimension is absent from the
+    skill.md table — operational_coverage computes its delta against the live
+    profile already and must not be scaled twice.
+    """
+    if not resolved_fmt or resolved_fmt == "skill.md":
+        return value
+    from scoring.registry import get_weights
+    base = get_weights("skill.md").get(dimension)
+    target = get_weights(resolved_fmt).get(dimension)
+    if not base or not target:
+        return value
+    return round(value * (target / base), 2)
+
+
 def compute_gradients(
     skill_path: str,
     eval_suite: Optional[dict] = None,
@@ -629,6 +653,11 @@ def compute_gradients(
         # Keep original string as display hint, normalize delta to float
         if isinstance(raw_delta, str):
             g["delta_display"] = raw_delta
+        parsed = _scale_delta_to_format(parsed, g["dimension"], resolved)
+        if isinstance(raw_delta, str) and parsed != _parse_delta(raw_delta):
+            # The "~2.0-5.0" hint was written on the skill.md basis; once
+            # rescaled it no longer describes the number beside it.
+            g.pop("delta_display", None)
         g["delta"] = parsed
         dim_weight = DIM_WEIGHTS.get(g["dimension"], 0.10)
         conf_mult = CONFIDENCE_MULT.get(g.get("confidence", "medium"), 0.6)

--- a/skills/schliff/tests/unit/test_gradient_delta_scale.py
+++ b/skills/schliff/tests/unit/test_gradient_delta_scale.py
@@ -1,0 +1,103 @@
+"""Delta literals are written on skill.md's weight basis and must be rescaled.
+
+Every hardcoded delta in text_gradient.py is a composite estimate sized against
+skill.md's table — `missing_name: 1.5` is 10 dimension points times structure's
+0.15 there. Scored as an AGENTS.md the same fix is worth 10 x 0.4, so reporting
+1.5 understates it ~2.7x. Measured before the fix: removing a TODO marker
+reported +1.5 and moved the composite +4.4.
+"""
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
+sys.path.insert(0, os.path.abspath(_SCRIPTS))
+
+import text_gradient  # noqa: E402
+
+from scoring import compute_composite  # noqa: E402
+from scoring.registry import get_weights  # noqa: E402
+from shared import build_scores  # noqa: E402
+
+SATURATED = (
+    "# Proj\n\nA tool.\n\n## Setup\n\n```bash\nnpm install\n```\n"
+    "\n## Build\n\n```bash\nnpm run build\n```\n"
+    "\n## Testing\n\n```bash\npytest -q\n```\n"
+    "\n## Code Style\n\n- Never use `eval`.\n- Always type `foo.py`.\n"
+    "\n## Gotchas\n\n- Never commit `.env`.\n- Always wipe `build/`.\n"
+    "\n## Pull Requests\n\n- Branch names must use `feat/`.\n- Always run the suite first.\n"
+)
+
+
+def _write(tmp_path, text, name):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def _composite(path, fmt):
+    return compute_composite(
+        build_scores(path, None, include_runtime=True, fmt=fmt), fmt=fmt
+    )["score"]
+
+
+def test_skill_md_deltas_do_not_move():
+    """The current path must be untouched: the factor is exactly 1.0 there."""
+    for dim, weight in get_weights("skill.md").items():
+        assert text_gradient._scale_delta_to_format(1.5, dim, "skill.md") == 1.5, dim
+        assert weight  # the profile is non-empty, so the loop is not vacuous
+
+
+def test_agents_md_structure_delta_is_rescaled():
+    base = get_weights("skill.md")["structure"]
+    target = get_weights("agents.md")["structure"]
+    assert target != base, "fixture assumes the two profiles differ"
+    scaled = text_gradient._scale_delta_to_format(1.5, "structure", "agents.md")
+    assert scaled == pytest.approx(round(1.5 * target / base, 2))
+    assert scaled > 1.5
+
+
+def test_a_dimension_absent_from_skill_md_is_not_rescaled():
+    """operational_coverage computes its delta against the live profile already;
+    scaling it here would apply the weight twice."""
+    assert "operational_coverage" not in get_weights("skill.md")
+    assert text_gradient._scale_delta_to_format(8.0, "operational_coverage", "agents.md") == 8.0
+
+
+def test_unknown_format_and_none_are_passthrough():
+    assert text_gradient._scale_delta_to_format(2.0, "structure", None) == 2.0
+    assert text_gradient._scale_delta_to_format(2.0, "structure", "no-such-format") == 2.0
+
+
+def test_reported_delta_lands_near_the_real_composite_change(tmp_path):
+    """The number the CLI prints must be the right size, not merely positive.
+
+    Tolerance is 25%: the delta is an estimate and removing text also nudges
+    efficiency. Before the fix this was off by a factor of 2.9, which no
+    tolerance of that kind would forgive.
+    """
+    with_todo = _write(tmp_path, SATURATED + "\nTODO: fix this later\n", "with.md")
+    without = _write(tmp_path, SATURATED, "without.md")
+    actual = _composite(without, "agents.md") - _composite(with_todo, "agents.md")
+
+    grads = text_gradient.compute_gradients(
+        with_todo, None, include_clarity=True, fmt="agents.md"
+    )
+    todo = [g for g in grads if g["issue"].startswith("has_todo")]
+    assert todo, "fixture no longer produces a has_todo gradient"
+    reported = todo[0]["delta"]
+    assert abs(reported - actual) <= 0.25 * actual, (
+        f"reported +{reported} against a real +{round(actual, 1)}"
+    )
+
+
+def test_range_hint_is_dropped_when_the_number_is_rescaled(tmp_path):
+    """A "~2.0-5.0" display hint was written on the skill.md basis; once the
+    number beside it is rescaled the hint describes something else."""
+    path = _write(tmp_path, "# P\n\nIt is important to note that this does things.\n", "h.md")
+    for g in text_gradient.compute_gradients(path, None, include_clarity=True, fmt="agents.md"):
+        if "delta_display" in g:
+            assert g["delta"] == pytest.approx(
+                text_gradient._parse_delta(g["delta_display"]), abs=0.01
+            ), f"{g['issue']}: display hint disagrees with the rescaled delta"

--- a/skills/schliff/tests/unit/test_gradient_delta_scale.py
+++ b/skills/schliff/tests/unit/test_gradient_delta_scale.py
@@ -93,11 +93,58 @@ def test_reported_delta_lands_near_the_real_composite_change(tmp_path):
 
 
 def test_range_hint_is_dropped_when_the_number_is_rescaled(tmp_path):
-    """A "~2.0-5.0" display hint was written on the skill.md basis; once the
-    number beside it is rescaled the hint describes something else."""
-    path = _write(tmp_path, "# P\n\nIt is important to note that this does things.\n", "h.md")
-    for g in text_gradient.compute_gradients(path, None, include_clarity=True, fmt="agents.md"):
+    """A "~2.0-5.0" hint was written on the skill.md basis; once the number
+    beside it is rescaled the hint labels something else.
+
+    The fixture must actually produce a string-delta gradient — efficiency ones
+    do. An earlier version of this test used a fixture that produced none, so
+    the loop body never ran and the assertion pinned nothing: replacing the
+    `delta_display` removal with `pass` left it green.
+    """
+    padded = (
+        "# P\n\n"
+        + "It is important to note that you might want to consider that this "
+        "does things, and as mentioned above, it should be noted that it is "
+        "generally advisable to perhaps review the output carefully.\n" * 4
+    )
+    path = _write(tmp_path, padded, "hint.md")
+    grads = text_gradient.compute_gradients(path, None, include_clarity=True, fmt="agents.md")
+
+    on_skill = text_gradient.compute_gradients(
+        path, None, include_clarity=True, fmt="skill.md"
+    )
+    assert any("delta_display" in g for g in on_skill), (
+        "fixture produces no string-delta gradient — the test would be vacuous"
+    )
+
+    for g in grads:
         if "delta_display" in g:
             assert g["delta"] == pytest.approx(
                 text_gradient._parse_delta(g["delta_display"]), abs=0.01
             ), f"{g['issue']}: display hint disagrees with the rescaled delta"
+
+
+def test_system_prompt_is_not_rescaled():
+    """Its literals are not on the skill.md basis, and scaling fires unevenly.
+
+    clarity would go x3 and efficiency x1.5 while structure is untouched — the
+    profile names it structure_prompt — so one ranking would mix two bases.
+    Measured before this was restricted: a clarity fix reported +7.5 against a
+    real composite move of +1.9.
+    """
+    assert text_gradient._scale_delta_to_format(2.5, "clarity", "system_prompt") == 2.5
+    assert text_gradient._scale_delta_to_format(1.5, "efficiency", "system_prompt") == 1.5
+
+
+def test_zero_target_weight_collapses_the_delta():
+    """A dimension the format does not count cannot yield composite points."""
+    import scoring.registry as registry
+
+    original = registry.WEIGHT_PROFILES.get("agents.md")
+    try:
+        registry.WEIGHT_PROFILES["agents.md"] = {**original, "structure": 0.0}
+        registry.get_weights.cache_clear() if hasattr(registry.get_weights, "cache_clear") else None
+        assert text_gradient._scale_delta_to_format(1.5, "structure", "agents.md") == 0.0
+    finally:
+        registry.WEIGHT_PROFILES["agents.md"] = original
+        registry.get_weights.cache_clear() if hasattr(registry.get_weights, "cache_clear") else None


### PR DESCRIPTION
Closes #203 (the scale half; the double-weighting note stays open below).

## The defect

Every hardcoded delta in `text_gradient.py` is a composite estimate sized against **skill.md's** weight table — `missing_name: 1.5` is 10 dimension points × structure's 0.15 there. The same literal is emitted whatever the format. On an AGENTS.md, where structure carries **0.4**, every structure and efficiency fix understates itself by ~2.7×.

Measured on a file whose only structure defect is a `TODO:` marker:

```
before:  reported delta 1.5   real composite 88.6 -> 93.0 = +4.4   (off by 2.9)
after:   reported delta 4.0   real composite 88.6 -> 93.0 = +4.4   (off by 0.4)
```

The residual 0.4 is the estimate itself — deleting text also nudges `efficiency`.

## Why it mattered beyond the number

Under-reported structure fixes sank in the ranking, and priority truncation (`--top N`, and the top-5 the evolve prompt sends) dropped them first. In the case that prompted this, the **only** gradient `generate_patches` can apply was pushed to sixth place and out of the default view — `patches from top-5: 0`, `patches from all: 1`.

## skill.md does not move — proven, not argued

The factor there is exactly 1.0. All **160 gradients across 20 corpus SKILL.md files** are identical before and after: same issues, same deltas, same priorities.

On the agents.md corpus: **20 of 30** files get corrected numbers, exactly **1** changes its top-3 ordering.

## Details

- A dimension absent from the skill.md table is passed through untouched, so `operational_coverage` — which computes its delta against the live profile in #200 — is not scaled twice.
- `delta_display` range hints (`"~2.0-5.0"`) are dropped when the number beside them is rescaled; they were written on the old basis and would contradict the value they label.

## Deliberately not changed

`priority` still multiplies by the dimension weight a second time, although `delta` is already composite. It inflates heavy dimensions **consistently across every generator**, so it distorts nothing relative to this fix — and removing it would reorder skill.md advice, the one thing this change is committed to leaving alone. The measurement stays recorded in #203.

## Verification

| Check | Result |
| --- | --- |
| Suite | 2165 passed (6 new) |
| ruff | clean |
| skill.md regression | 160/160 gradients identical over 20 files |
| agents.md impact | 20/30 deltas corrected, 1/30 reorderings |
| Mutation: scaling made a no-op | 2 tests red |

**Next:** #200 rebases onto this. Its `test_a_cheap_auto_patchable_fix_is_not_pushed_out` should then hold for every category rather than only `pr`.
