### PR TITLE
fix(callers): resolve the format once per caller and pass it to both halves

### DIFF
--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -120,7 +120,8 @@ def _append_state(skill_path: str, entry: dict) -> None:
 
 # --- Scoring ---
 
-def _score_skill(skill_path: str, eval_suite: Optional[dict] = None) -> dict:
+def _score_skill(skill_path: str, eval_suite: Optional[dict] = None,
+                 fmt: Optional[str] = None) -> dict:
     """Score a skill and return composite + dimensions."""
     # The registry decides which dimensions a format has. Hand-listing them here
     # scored an AGENTS.md without operational_coverage — weight 0.4 — and the
@@ -128,7 +129,13 @@ def _score_skill(skill_path: str, eval_suite: Optional[dict] = None) -> dict:
     # that ignored the file's heaviest dimension.
     from scoring.formats import detect_format
     from shared import build_scores
-    fmt = detect_format(skill_path)
+    # `fmt` is passed in by --dry-run, which scores a sibling temp file: the real
+    # AGENTS.md becomes AGENTS.dryrun.tmp, detect_format says "unknown", and the
+    # candidate would be scored under skill.md weights while the baseline uses
+    # agents.md. Measured on one file: 35.0 baseline vs 23.4 candidate, which
+    # inverts every keep/discard verdict — a +4.0 improvement reported as -11.3.
+    if fmt is None:
+        fmt = detect_format(skill_path)
     scores = build_scores(skill_path, eval_suite, include_runtime=False, fmt=fmt)
 
     # Runtime is opt-in (expensive, invokes claude CLI)
@@ -154,11 +161,13 @@ def _score_content(
     sibling lookups still resolve), score it, then remove it. Returns the same
     shape as _score_skill.
     """
+    from scoring.formats import detect_format
+    real_fmt = detect_format(skill_path)      # from the REAL name, not the temp one
     tmp_path = Path(skill_path).with_suffix(".dryrun.tmp")
     try:
         tmp_path.write_text(content, encoding="utf-8")
         scorer.invalidate_cache(str(tmp_path))
-        result = _score_skill(str(tmp_path), eval_suite)
+        result = _score_skill(str(tmp_path), eval_suite, fmt=real_fmt)
     finally:
         try:
             tmp_path.unlink()

--- a/skills/schliff/scripts/auto-improve.py
+++ b/skills/schliff/scripts/auto-improve.py
@@ -122,20 +122,19 @@ def _append_state(skill_path: str, entry: dict) -> None:
 
 def _score_skill(skill_path: str, eval_suite: Optional[dict] = None) -> dict:
     """Score a skill and return composite + dimensions."""
-    scores = {
-        "structure": scorer.score_structure(skill_path),
-        "triggers": scorer.score_triggers(skill_path, eval_suite),
-        "quality": scorer.score_quality(skill_path, eval_suite),
-        "edges": scorer.score_edges(skill_path, eval_suite),
-        "efficiency": scorer.score_efficiency(skill_path),
-        "composability": scorer.score_composability(skill_path),
-        "clarity": scorer.score_clarity(skill_path),
-    }
+    # The registry decides which dimensions a format has. Hand-listing them here
+    # scored an AGENTS.md without operational_coverage — weight 0.4 — and the
+    # composite counted the gap as zero, so the loop optimised against a number
+    # that ignored the file's heaviest dimension.
+    from scoring.formats import detect_format
+    from shared import build_scores
+    fmt = detect_format(skill_path)
+    scores = build_scores(skill_path, eval_suite, include_runtime=False, fmt=fmt)
 
     # Runtime is opt-in (expensive, invokes claude CLI)
     scores["runtime"] = scorer.score_runtime(skill_path, eval_suite, enabled=False)
 
-    composite_result = scorer.compute_composite(scores)
+    composite_result = scorer.compute_composite(scores, fmt=fmt)
     dimensions = {k: v["score"] for k, v in scores.items()}
 
     return {
@@ -462,8 +461,10 @@ def run_auto_improve(
 
         # Clear cache and compute gradients
         scorer.invalidate_cache(skill_path)
+        from scoring.formats import detect_format as _detect_fmt
         gradients = gradient_mod.compute_gradients(
-            skill_path, eval_suite=train_suite, include_clarity=True
+            skill_path, eval_suite=train_suite, include_clarity=True,
+            fmt=_detect_fmt(skill_path),
         )
 
         if not gradients:

--- a/skills/schliff/scripts/dashboard.py
+++ b/skills/schliff/scripts/dashboard.py
@@ -78,20 +78,32 @@ def generate_dashboard(
             print(f"Warning: failed to parse eval-suite.json: {e}", file=sys.stderr)
 
     _na = {"score": -1, "issues": [], "details": {}}
-    fmt = None
+    # Resolved OUTSIDE the scorer branch: _try_import only warns, so if
+    # score_skill fails to import while text_gradient does not, a None fmt sends
+    # an AGENTS.md back down the SKILL-only advice path this function just fixed.
+    from scoring.formats import detect_format
+    try:
+        fmt = detect_format(skill_path)
+    except Exception:
+        fmt = None
     if scorer is not None:
         # Resolve the format once and pass it everywhere. Hand-listing dimensions
         # here meant an AGENTS.md was scored without operational_coverage — its
         # heaviest dimension, weight 0.4 — which the composite then counted as
         # zero: 27.0 where build_scores gives 39.0. The registry knows which
         # dimensions a format has; this file should not carry a second opinion.
-        from scoring.formats import detect_format
         from shared import build_scores
-        fmt = detect_format(skill_path)
         scores = build_scores(skill_path, eval_suite, include_runtime=False, fmt=fmt)
-        if not include_clarity:
+        if not include_clarity and fmt in ("skill.md", "claude.md", "cursorrules"):
             # --no-clarity is an opt-OUT; build_scores follows the registry, where
             # clarity is in the default set.
+            #
+            # Only for the skill.md family, where clarity carries 0.05 and dropping
+            # it is the long-standing behaviour. The composite uses a full
+            # denominator, so a popped dimension counts as ZERO rather than being
+            # renormalized away — on system_prompt, where clarity weighs 0.15, the
+            # flag turned 51.4 into 36.4 and added a warning telling the user to
+            # run /schliff:init to "score: clarity".
             scores.pop("clarity", None)
         composite = scorer.compute_composite(scores, fmt=fmt)
     else:

--- a/skills/schliff/scripts/dashboard.py
+++ b/skills/schliff/scripts/dashboard.py
@@ -78,18 +78,22 @@ def generate_dashboard(
             print(f"Warning: failed to parse eval-suite.json: {e}", file=sys.stderr)
 
     _na = {"score": -1, "issues": [], "details": {}}
+    fmt = None
     if scorer is not None:
-        scores = {
-            "structure": scorer.score_structure(skill_path),
-            "triggers": scorer.score_triggers(skill_path, eval_suite),
-            "quality": scorer.score_quality(skill_path, eval_suite),
-            "edges": scorer.score_edges(skill_path, eval_suite),
-            "efficiency": scorer.score_efficiency(skill_path),
-            "composability": scorer.score_composability(skill_path),
-        }
-        if include_clarity:
-            scores["clarity"] = scorer.score_clarity(skill_path)
-        composite = scorer.compute_composite(scores)
+        # Resolve the format once and pass it everywhere. Hand-listing dimensions
+        # here meant an AGENTS.md was scored without operational_coverage — its
+        # heaviest dimension, weight 0.4 — which the composite then counted as
+        # zero: 27.0 where build_scores gives 39.0. The registry knows which
+        # dimensions a format has; this file should not carry a second opinion.
+        from scoring.formats import detect_format
+        from shared import build_scores
+        fmt = detect_format(skill_path)
+        scores = build_scores(skill_path, eval_suite, include_runtime=False, fmt=fmt)
+        if not include_clarity:
+            # --no-clarity is an opt-OUT; build_scores follows the registry, where
+            # clarity is in the default set.
+            scores.pop("clarity", None)
+        composite = scorer.compute_composite(scores, fmt=fmt)
     else:
         scores = {
             "structure": _na, "triggers": _na, "quality": _na,
@@ -103,7 +107,7 @@ def generate_dashboard(
     if gradient_engine is not None:
         gradients = gradient_engine.compute_gradients(
             skill_path, eval_suite=eval_suite,
-            include_clarity=include_clarity, top_n=5,
+            include_clarity=include_clarity, top_n=5, fmt=fmt,
         )
     else:
         gradients = []

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -1226,6 +1226,11 @@ def main():
     parser.add_argument("--patch", action="store_true", help="Generate concrete patches for deterministic fixes")
     parser.add_argument("--apply", action="store_true", help="Apply deterministic patches directly to file")
     parser.add_argument("--dry-run", action="store_true", help="Show what --apply would do without writing")
+    parser.add_argument(
+        "--format", dest="fmt", default=None,
+        help="Instruction-file format (skill.md, agents.md, claude.md, cursorrules, "
+             "system_prompt). Detected from the file when omitted.",
+    )
     args = parser.parse_args()
 
     eval_suite = None
@@ -1261,11 +1266,18 @@ def main():
             )
             eval_suite = None
 
+    # Without a format this CLI advised an AGENTS.md to add YAML frontmatter and
+    # to create an eval-suite.json worth 25 points — neither exists for that
+    # format — and never mentioned operational_coverage, its heaviest dimension.
+    from scoring.formats import detect_format
+    fmt = args.fmt or detect_format(args.skill_path)
+
     gradients = compute_gradients(
         args.skill_path,
         eval_suite=eval_suite,
         include_clarity=args.clarity,
         top_n=args.top,
+        fmt=fmt,
     )
 
     if args.apply or (args.patch and args.dry_run):

--- a/skills/schliff/scripts/text_gradient.py
+++ b/skills/schliff/scripts/text_gradient.py
@@ -795,7 +795,13 @@ def compute_gradients(
     gradients = []
 
     structure_grads = _compute_structure_gradients(skill_path)
-    if agents_only:
+    # build_scores normalizes EVERY format except skill.md, synthesizing the
+    # frontmatter before scoring — so `no_frontmatter` is already credited there
+    # and a patch for it is worth exactly 0.0. auto-improve keeps zero-delta
+    # patches (its gate is `>= 0`), so a CLAUDE.md came back with an invented
+    # `---\nname: …\n---` block for no gain. The suppression therefore has to
+    # follow normalization, not just agents.md.
+    if resolved is not None and resolved != "skill.md":
         # AGENTS.md uses no SKILL-style YAML name/description frontmatter; the engine
         # synthesizes it before scoring (so the score is not penalized), and the fix-path
         # must not advise adding it. Suppress the frontmatter-family structure issues. (R2)
@@ -1226,10 +1232,18 @@ def main():
     parser.add_argument("--patch", action="store_true", help="Generate concrete patches for deterministic fixes")
     parser.add_argument("--apply", action="store_true", help="Apply deterministic patches directly to file")
     parser.add_argument("--dry-run", action="store_true", help="Show what --apply would do without writing")
+    # `choices` is not optional here. Without it a typo (`--format agentsmd`)
+    # falls through FORMAT_ALIASES.get(fmt, fmt) unrecognised, takes the
+    # not-agents.md branch, exits 0 and prints exactly the SKILL-only advice this
+    # flag exists to prevent — with no signal that the flag was ignored. cli.py
+    # guards the same flag this way.
+    #
+    # system_prompt is deliberately absent: compute_gradients has no branch for
+    # it, so offering it would advertise a format that gets SKILL.md advice.
+    _FORMAT_CHOICES = ["skill.md", "agents.md", "claude.md", "cursorrules"]
     parser.add_argument(
-        "--format", dest="fmt", default=None,
-        help="Instruction-file format (skill.md, agents.md, claude.md, cursorrules, "
-             "system_prompt). Detected from the file when omitted.",
+        "--format", dest="fmt", default=None, choices=_FORMAT_CHOICES,
+        help="Instruction-file format (%(choices)s). Detected from the file when omitted.",
     )
     args = parser.parse_args()
 

--- a/skills/schliff/tests/unit/test_callers_pass_format.py
+++ b/skills/schliff/tests/unit/test_callers_pass_format.py
@@ -1,0 +1,127 @@
+"""Every caller must resolve the format and pass it to BOTH halves.
+
+compute_gradients uses `fmt` to decide which fixes apply; compute_composite uses
+it to decide which dimensions count. A caller that passes it to neither scored an
+AGENTS.md without operational_coverage — its heaviest dimension at weight 0.4 —
+and the composite counted the gap as zero: 27.0 where build_scores gives 39.0.
+
+The advice was wrong in the same breath: `text_gradient.py AGENTS.md` told the
+user to add YAML frontmatter and to create an eval-suite.json worth 25 points,
+neither of which exists for that format.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+sys.path.insert(0, _SCRIPTS)
+sys.path.insert(0, os.path.join(_SCRIPTS, "scoring"))
+
+BARE_AGENTS = "# Proj\n\nA tool.\n\n## Overview\n\nIt reads.\n\nTODO: fix this later\n"
+SKILL_ONLY_ISSUES = {"no_frontmatter", "missing_name", "missing_description",
+                     "no_trigger_eval_suite", "no_eval_suite_test_cases"}
+
+
+def _load(name, filename):
+    """Import a script whose filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_SCRIPTS, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def agents_md(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text(BARE_AGENTS, encoding="utf-8")
+    return str(p)
+
+
+def test_dashboard_scores_the_dimensions_the_format_actually_has(agents_md):
+    dashboard = _load("dashboard_mod", "dashboard.py")
+    data = dashboard.generate_dashboard(agents_md)
+    assert "operational_coverage" in data["dimensions"], (
+        "dashboard scores an AGENTS.md without its heaviest dimension"
+    )
+    assert not (set(g["issue"] for g in data["top_gradients"]) & SKILL_ONLY_ISSUES), (
+        "dashboard shows SKILL-only advice for an AGENTS.md"
+    )
+
+
+def test_dashboard_composite_uses_the_format_profile(agents_md):
+    """The other half. Passing fmt to build_scores but not to compute_composite
+    leaves the dimensions right and the headline number wrong, which reads as a
+    low score rather than a bug — so `dimensions` alone cannot pin this."""
+    import score_skill as scorer
+
+    from shared import build_scores
+
+    dashboard = _load("dashboard_mod2", "dashboard.py")
+    reported = dashboard.generate_dashboard(agents_md)["composite_score"]
+
+    scores = build_scores(agents_md, None, include_runtime=False, fmt="agents.md")
+    expected = scorer.compute_composite(scores, fmt="agents.md")["score"]
+    wrong = scorer.compute_composite(scores)["score"]
+    assert expected != wrong, "fixture no longer distinguishes the two profiles"
+    assert reported == pytest.approx(expected, abs=0.05), (
+        f"dashboard reports {reported}; the agents.md profile gives {expected}"
+    )
+
+
+def test_auto_improve_scores_the_dimensions_the_format_actually_has(agents_md):
+    auto = _load("auto_improve_mod", "auto-improve.py")
+    result = auto._score_skill(agents_md)
+    assert "operational_coverage" in result["dimensions"], (
+        "the improvement loop optimises against a composite missing weight 0.4"
+    )
+
+
+def test_text_gradient_cli_gives_format_appropriate_advice(agents_md):
+    """The module's own CLI had no --format flag at all."""
+    out = subprocess.run(
+        [sys.executable, os.path.join(_SCRIPTS, "text_gradient.py"), agents_md, "--json"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert out.returncode == 0, out.stderr[-500:]
+    import json
+    gradients = json.loads(out.stdout)["gradients"]
+    issues = {g["issue"] for g in gradients}
+    assert not (issues & SKILL_ONLY_ISSUES), (
+        f"SKILL-only advice on an AGENTS.md: {sorted(issues & SKILL_ONLY_ISSUES)}"
+    )
+    assert any(g["dimension"] == "operational_coverage" for g in gradients)
+
+
+def test_text_gradient_cli_accepts_an_explicit_format(agents_md):
+    out = subprocess.run(
+        [sys.executable, os.path.join(_SCRIPTS, "text_gradient.py"),
+         agents_md, "--json", "--format", "agents.md"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert out.returncode == 0, out.stderr[-500:]
+
+
+def test_incomplete_score_dict_would_understate_the_composite(agents_md):
+    """Pins WHY the fix is build_scores rather than just passing fmt along.
+
+    Passing the format to compute_composite while still hand-listing dimensions
+    leaves the missing one counted as zero, which looks like a low score rather
+    than a bug.
+    """
+    import score_skill as scorer
+
+    from shared import build_scores
+
+    hand_listed = {
+        "structure": scorer.score_structure(agents_md),
+        "efficiency": scorer.score_efficiency(agents_md),
+    }
+    partial = scorer.compute_composite(hand_listed, fmt="agents.md")["score"]
+    full = scorer.compute_composite(
+        build_scores(agents_md, None, include_runtime=False, fmt="agents.md"),
+        fmt="agents.md",
+    )["score"]
+    assert partial < full, "fixture no longer demonstrates the gap"

--- a/skills/schliff/tests/unit/test_callers_pass_format.py
+++ b/skills/schliff/tests/unit/test_callers_pass_format.py
@@ -20,6 +20,8 @@ _SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "
 sys.path.insert(0, _SCRIPTS)
 sys.path.insert(0, os.path.join(_SCRIPTS, "scoring"))
 
+import text_gradient  # noqa: E402
+
 BARE_AGENTS = "# Proj\n\nA tool.\n\n## Overview\n\nIt reads.\n\nTODO: fix this later\n"
 SKILL_ONLY_ISSUES = {"no_frontmatter", "missing_name", "missing_description",
                      "no_trigger_eval_suite", "no_eval_suite_test_cases"}
@@ -125,3 +127,88 @@ def test_incomplete_score_dict_would_understate_the_composite(agents_md):
         fmt="agents.md",
     )["score"]
     assert partial < full, "fixture no longer demonstrates the gap"
+
+def test_dry_run_scores_under_the_same_format_as_the_baseline(tmp_path):
+    """--dry-run writes a sibling temp file, and its NAME decided the format.
+
+    `AGENTS.md` becomes `AGENTS.dryrun.tmp`, which detect_format calls "unknown",
+    so the candidate was scored with skill.md weights while the baseline used
+    agents.md. Measured on one file: 35.0 vs 23.4 — every keep/discard verdict
+    inverted, a +4.0 improvement reported as -11.3.
+    """
+    auto = _load("auto_improve_fmt", "auto-improve.py")
+    for name in ("AGENTS.md", "SKILL.md", "CLAUDE.md"):
+        p = tmp_path / name
+        p.write_text(BARE_AGENTS, encoding="utf-8")
+        baseline = auto._score_skill(str(p))["composite"]
+        candidate = auto._score_content(BARE_AGENTS, str(p))["composite"]
+        assert candidate == pytest.approx(baseline, abs=0.05), (
+            f"{name}: dry-run scores {candidate} against a baseline of {baseline}"
+        )
+
+
+@pytest.mark.parametrize("name,fmt", [
+    ("CLAUDE.md", "claude.md"),
+    ("AGENTS.md", "agents.md"),
+    (".cursorrules", "cursorrules"),
+])
+def test_no_frontmatter_is_not_advised_where_scoring_synthesises_it(tmp_path, name, fmt):
+    """build_scores normalizes every format except skill.md, so the frontmatter
+    is already credited and a patch for it is worth exactly 0.0 — which
+    auto-improve keeps, because its gate is `>= 0`. A CLAUDE.md came back with an
+    invented `---\nname: …\n---` block for no gain."""
+    p = tmp_path / name
+    p.write_text("# cm\n\nRun `make build` to build.\n", encoding="utf-8")
+    issues = {
+        g["issue"]
+        for g in text_gradient.compute_gradients(str(p), None, include_clarity=True, fmt=fmt)
+    }
+    assert not (issues & {"no_frontmatter", "missing_name", "missing_description"}), (
+        f"{fmt}: advises adding frontmatter that scoring already synthesises"
+    )
+
+
+def test_skill_md_still_gets_the_frontmatter_advice(tmp_path):
+    """The counter-case: skill.md is NOT normalized, so there the gradient is real."""
+    p = tmp_path / "SKILL.md"
+    p.write_text("# s\n\nRun `make build` to build.\n", encoding="utf-8")
+    issues = {
+        g["issue"]
+        for g in text_gradient.compute_gradients(str(p), None, include_clarity=True, fmt="skill.md")
+    }
+    assert "no_frontmatter" in issues
+
+
+def test_no_clarity_does_not_zero_a_headline_dimension(tmp_path):
+    """The composite uses a full denominator, so a popped dimension counts as
+    ZERO rather than being renormalized away. On system_prompt clarity weighs
+    0.15, and the opt-out turned 51.4 into 36.4."""
+    from scoring.registry import get_weights
+
+    dashboard = _load("dashboard_clarity", "dashboard.py")
+    p = tmp_path / "sys.prompt"
+    p.write_text(
+        "You are a helpful assistant.\n\nAlways cite sources.\n"
+        "Never invent a citation.\n\nReturn JSON with a `result` key.\n",
+        encoding="utf-8",
+    )
+    weight = get_weights("system_prompt").get("clarity")
+    assert weight and weight > 0.05, "fixture assumes clarity is a headline dim here"
+
+    full = dashboard.generate_dashboard(str(p))["composite_score"]
+    opted_out = dashboard.generate_dashboard(str(p), include_clarity=False)["composite_score"]
+    assert opted_out == pytest.approx(full, abs=0.05), (
+        f"--no-clarity dropped a 0.15-weight dimension to zero: {full} -> {opted_out}"
+    )
+
+
+def test_format_flag_rejects_a_typo():
+    """Without `choices`, `--format agentsmd` exited 0 and printed SKILL-only
+    advice, with no signal the flag had been ignored."""
+    out = subprocess.run(
+        [sys.executable, os.path.join(_SCRIPTS, "text_gradient.py"),
+         "x.md", "--format", "agentsmd"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert out.returncode != 0
+    assert "invalid choice" in out.stderr


### PR DESCRIPTION
Closes #202. Also closes the second half of #205 (deltas diverging per caller).

## The defect

Three callers passed no format — `dashboard.py`, `auto-improve.py`, and `text_gradient.py`'s own CLI, whose argparse had no `--format` flag at all. `compute_gradients` uses `fmt` to decide which fixes apply; `compute_composite` uses it to decide which dimensions count. Omitting it broke both halves at once.

Measured on a bare AGENTS.md:

| | with `fmt` | without `fmt` |
| --- | --- | --- |
| 1. | `has_todo` (4.0) | `no_frontmatter` (6.0) |
| 2. | `opcov_missing_build` (8.0) | **`no_trigger_eval_suite` (25.0)** |
| 3. | `opcov_missing_setup` (8.0) | `no_eval_suite_test_cases` (7.5) |
| opcov gradients | 6 | **0** |

`/schliff:auto` was telling an AGENTS.md to create an `eval-suite.json` worth 25 points. That format has no eval suite.

## Why passing `fmt` alone was not enough

Both scripts hand-listed their dimensions. `compute_composite(scores, fmt="agents.md")` over a dict without `operational_coverage` counts the gap as **zero** — `27.0` where `build_scores` gives `39.0`. That reads as a low score, not as a bug, which is the worst kind of wrong number.

They now use `build_scores`, which takes the dimension set from the registry. Three hand-maintained copies become one source of truth.

`--no-clarity` is preserved as the opt-**out** it is: the flag defaults to `True`, and `score_clarity`'s docstring explicitly corrects an earlier claim that it was opt-in. `build_scores` follows the registry; clarity is popped afterwards when the flag is off.

## Deliberately not changed

`compute_gradients` still does not detect the format when a caller omits it. That was tried in #200 and reverted — it makes one half of the loop format-aware while `compute_composite` beside it stays on skill.md weights, and `test_no_gradients_when_the_caller_omits_the_format` pins the revert. Resolving at the call site fixes both halves together, which is the point.

## Verification

| Check | Result |
| --- | --- |
| Suite | 2194 passed (6 new) |
| ruff | clean |
| Mutation: `compute_composite` without `fmt` | red |
| Mutation: `build_scores` → hand-listed dict | red |
| Mutation: CLI format detection removed | red |

Two of these tests were wrong on the first attempt — they asserted against APIs I had guessed rather than read (`collect_dashboard_data`, a bare list from `--json`). A third passed while the dashboard's composite half was mutated, because it only inspected `dimensions`; that half now has its own test.
