### PR TITLE
fix(efficiency): credit documented commands in tables and indented bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Documented commands in tables and indented bullets now count.** `efficiency`
+  credited a documented command only as a top-level bullet, so an indented
+  sub-bullet or a markdown command table scored nothing. Measured over 1732
+  markdown files: 79 hits before, 155 after, and **no previously credited
+  command lost**. The widening carries a filter — a table's `|` is structure,
+  not an assertion that the cell explains the command, so without one
+  `dynamic = 'force-dynamic'` and `new App(...)` were credited as commands.
+  Precision on the new shapes is 53/55.
+
 - **A line that *is* a command now counts as actionable content.** `efficiency` recognised
   English imperatives at line start, so `- \`tool score <file>\` — score one file` scored
   nothing while "Run the score command" scored. Only commands that carry their explanation

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -375,3 +375,44 @@ real signature is positional. And `doctor`'s "Total context cost" sums SKILL.md 
 `references/*.md` (`shared.py:142`) while the score beside it measures only the SKILL.md, so the
 same file reads 7,748 tokens in one output and 1,044 in the other. That one is a labelling
 question, not an arithmetic error.
+
+## Amendment 2026-08-21 — the documented-command detector sees three shapes, not one
+
+This spec defined `_RE_DOCUMENTED_COMMAND` as a list-marker shape. It anchored on `^` plus a
+list marker, so it saw only top-level bullets — an indented sub-bullet and a markdown table row
+scored nothing, and the issue this closes (#194) measured that as roughly 40% of the documented
+commands in a 299-file corpus.
+
+**Contract change.** Production callers no longer use the pattern. They call
+`find_documented_commands(content)`, which covers all recognised shapes, so a fourth shape added
+later cannot leave a consumer behind. `test_no_production_caller_reaches_past_the_contract`
+enforces this by walking the whole scripts tree, not one hardcoded path.
+
+**The widening needed a filter, and that is the substantive part.** The two shapes do not carry
+the same evidence. In a list, the `—` asserts that what follows explains what precedes. In a
+table, `|` is only structure — so the row shape alone credits any two-column code reference. A
+first version without a filter admitted 9 non-commands against 2 real ones:
+`dynamic = 'force-dynamic'`, `app.ontoolresult = fn`, `new App(info, caps, {autoResize: true})`.
+
+`_RE_NOT_A_COMMAND` rejects a spaced assignment, a call, and a `new` expression. Spaced on
+purpose: `docker run -e FOO=bar` and `--limit=50` are real command text. The table shape also
+carries the same 10-character explanation floor as the list shape, without which
+a table row with a one-character cell counted while its list-form twin correctly did not.
+
+**Measurement log, corpus named.** Three different counts were quoted for this detector before
+anyone said which files they came from — 39/39 over "186 real files", 29/15/4 over 299 installed
+SKILL.md, 10/8/2 over 184. They are not reconcilable because they are different corpora.
+
+```text
+corpus: every *.md under ~/.claude and ~/Projects, excluding node_modules,
+        .venv and .git — 1732 files, 2026-08-21
+before: 79 hits      after: 155 hits      lost: 0
+new:    55 distinct, each classified rather than sampled —
+        53 genuine, 2 not commands (both rows of one error table)
+```
+
+Precision on the new shapes is 53/55. The two misses are accepted rather than filtered: the
+obvious discriminator would be the `...`, and `go test ./...` is a real command.
+
+**Score effect:** no file's score falls. Only credit is added, never withdrawn — the same
+monotonicity property this spec's §4 relies on.

--- a/skills/schliff/scripts/scoring/efficiency.py
+++ b/skills/schliff/scripts/scoring/efficiency.py
@@ -9,7 +9,6 @@ from nlp import RE_WORD_TOKEN, STOPWORDS
 from scoring.patterns import (
     _RE_ACTIONABLE_LINES,
     _RE_CODE_BLOCK_REGION,
-    _RE_DOCUMENTED_COMMAND,
     _RE_FILLER_PHRASES,
     _RE_HEDGING,
     _RE_OBVIOUS_INSTRUCTIONS,
@@ -17,6 +16,7 @@ from scoring.patterns import (
     _RE_SCOPE_BOUNDARY,
     _RE_VERIFICATION_CMDS,
     _RE_WHY_COUNT,
+    find_documented_commands,
     normalize_command,
 )
 from shared import read_skill_safe, strip_frontmatter
@@ -91,8 +91,8 @@ def score_efficiency(skill_path: str) -> dict:
     # pattern above cannot see it. Deduplicate on the normalized command rather than
     # on line text, so the same command in a command table, an example and a workflow
     # contributes once. See docs/specs/2026-08-13-structural-signal-detection.md.
-    for match in _RE_DOCUMENTED_COMMAND.finditer(content):
-        identity = normalize_command(match.group(1))
+    for command in find_documented_commands(content):
+        identity = normalize_command(command)
         if identity:
             seen_actions.add(f"cmd:{identity.lower()}")
     actionable_lines = len(seen_actions)

--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -4,6 +4,10 @@ import re
 __all__ = [
     # Efficiency
     "_RE_ACTIONABLE_LINES",
+    # The raw patterns stay exported for tests that probe them directly. The
+    # contract for PRODUCTION callers is find_documented_commands, and
+    # test_documented_command_forms enforces that by grepping the scripts tree —
+    # __all__ cannot express "importable by tests, not by consumers".
     "_RE_DOCUMENTED_COMMAND",
     "_RE_DOCUMENTED_COMMAND_TABLE",
     "find_documented_commands",
@@ -86,14 +90,26 @@ _RE_ACTIONABLE_LINES = re.compile(
 # entry in the same shape is credited — `- `max_tokens int` — the maximum number of
 # tokens`. There is no structural signal that separates that from `- `make test` — run
 # the suite`, and inventing one would mean a wordlist of tool names, which is the design
-# this detector replaced. Measured over 186 real files: 39 hits, 39 of them genuine
-# commands, 0 option-list false positives — the two-token minimum already excludes the
-# common single-token option form (`- `max_tokens` — …`). Revisit if a field hit appears.
-# A documented command — a backticked command with its explanation beside it —
-# appears in three shapes in the field, and the original pattern saw only one.
-# Measured over 184 installed SKILL.md files: 10 top-level bullets were credited
-# while 8 table rows and 2 indented sub-bullets scored nothing, so half the
-# documented commands in the field went uncounted.
+# this detector replaced. The two-token minimum already excludes the common
+# single-token option form (`- `max_tokens` — …`).
+#
+# A documented command appears in three shapes, and the original pattern saw only
+# the first. MEASUREMENT LOG — corpus named, because three different counts were
+# quoted for this detector before anyone said which files they came from:
+#
+#   corpus: every *.md under ~/.claude and ~/Projects, excluding node_modules,
+#           .venv and .git — 1732 files, 2026-08-21
+#   before: 79 hits (top-level bullets only)
+#   after:  155 hits
+#   lost:   0 — no previously credited command stopped being credited
+#   new:    55 distinct, classified individually rather than sampled:
+#           53 genuine (`bun run test`, `vercel env pull`, `gh pr create`, …)
+#            2 not commands — both rows of one error table
+#           (`tls handshake failed ... bad certificate`)
+#
+# Precision on the new shapes is 53/55. The two misses are accepted rather than
+# filtered: the obvious discriminator would be the `...`, and `go test ./...` is a
+# real command.
 #
 # The command half is identical in all three: program-like head plus at least one
 # REAL argument. The `[^\s`]` is load-bearing — a dependency list aligns its
@@ -120,7 +136,12 @@ _RE_DOCUMENTED_COMMAND_TABLE = re.compile(
     r"^[ \t]*\|[ \t]*"
     + _CMD +
     r"[ \t]*\|[ \t]*"
-    r"(?:[^|\n]*\S[^|\n]*)",           # explanation cell, non-empty
+    # Same bar as the list shape: an explanation, not merely a non-empty cell.
+    # Without the length floor `| `git add` | x |` was credited while the list
+    # form `- `git add` — x` was correctly rejected, and a two-column error table
+    # ("| `tls handshake failed` | unknown certificate authority |") reads as a
+    # documented command.
+    r"(?:[^|\n]*\S[^|\n]{9,})",       # explanation cell, 10+ chars like the list form
     re.MULTILINE,
 )
 
@@ -136,7 +157,13 @@ _RE_NOT_A_COMMAND = re.compile(
     r"^[\w.\[\]]+[ \t]*=[ \t]"          # `dynamic = \'x\'` — spaced assignment.
                                         # Spaced on purpose: `docker run -e FOO=bar`
                                         # and `--flag=value` are real command text.
-    r"|^[A-Za-z_][\w.]*\("               # `fn(...)` — a call, not an invocation
+    r"|^[A-Za-z_][\w.]*[ \t]*\("          # `fn(...)` / `fn (...)` — a call.
+                                        # The `[ \t]*` is what makes this reachable:
+                                        # _CMD only yields a head followed by
+                                        # whitespace, so requiring `(` immediately
+                                        # after the head was dead code, and
+                                        # `app (x, y)` and `foo.bar (x)` were both
+                                        # credited as commands.
     r"|^new[ \t]"                        # `new App(...)`
 )
 

--- a/skills/schliff/scripts/scoring/patterns/base.py
+++ b/skills/schliff/scripts/scoring/patterns/base.py
@@ -5,6 +5,8 @@ __all__ = [
     # Efficiency
     "_RE_ACTIONABLE_LINES",
     "_RE_DOCUMENTED_COMMAND",
+    "_RE_DOCUMENTED_COMMAND_TABLE",
+    "find_documented_commands",
     "normalize_command",
     "_RE_WHY_COUNT",
     "_RE_VERIFICATION_CMDS",
@@ -87,21 +89,73 @@ _RE_ACTIONABLE_LINES = re.compile(
 # this detector replaced. Measured over 186 real files: 39 hits, 39 of them genuine
 # commands, 0 option-list false positives — the two-token minimum already excludes the
 # common single-token option form (`- `max_tokens` — …`). Revisit if a field hit appears.
+# A documented command — a backticked command with its explanation beside it —
+# appears in three shapes in the field, and the original pattern saw only one.
+# Measured over 184 installed SKILL.md files: 10 top-level bullets were credited
+# while 8 table rows and 2 indented sub-bullets scored nothing, so half the
+# documented commands in the field went uncounted.
+#
+# The command half is identical in all three: program-like head plus at least one
+# REAL argument. The `[^\s`]` is load-bearing — a dependency list aligns its
+# entries with trailing spaces (`` `coverlet.collector     ` : Coverlet is a …
+# library ``), which otherwise reads as "program + argument" and credits a
+# package name as a command.
+_CMD = r"`([a-z][\w.@/-]*[ \t]+[^\s`][^`\n]*)`"
+
+# `[ \t]` not `\s` throughout — `\s` crosses a newline, so a bare "1." on its own
+# line would credit the backticked command on the NEXT line as documented.
 _RE_DOCUMENTED_COMMAND = re.compile(
-    # `[ \t]` not `\s` — third instance of the same class in this changeset. It was
-    # swept out of _RE_ERROR_BEHAVIOR and _RE_DEPENDENCY_DECL and then reintroduced
-    # here: `\s` after the list marker crosses a newline, so a bare "1." on its own
-    # line credited the backticked command on the NEXT line as documented.
-    r"^(?:\d+\.[ \t]*|[-*+][ \t]+)"     # list marker — a documented command is a list item
-    # Backticked: program-like head + at least one REAL argument. The `[^\s`]` is
-    # load-bearing — a dependency list aligns its entries with trailing spaces
-    # (`` `coverlet.collector     ` : Coverlet is a … library ``), which otherwise
-    # reads as "program + argument" and credits a package name as a command.
-    r"`([a-z][\w.@/-]*[ \t]+[^\s`][^`\n]*)`"
+    r"^[ \t]*"                          # indentation: sub-bullets count too
+    r"(?:\d+\.[ \t]*|[-*+][ \t]+)"      # list marker
+    + _CMD +
     r"[ \t]*[—–:-][ \t]+"               # separator between command and explanation
-    r"(\S[^\n]{9,})",                   # the explanation itself, on the same line
+    r"(?:\S[^\n]{9,})",                 # the explanation itself, on the same line
     re.MULTILINE,
 )
+
+# Table row: `| \`tool sub\` | what it does |`. The separator is the cell wall, not
+# a dash, so this cannot be folded into the pattern above as one alternation
+# without giving the command two different group numbers.
+_RE_DOCUMENTED_COMMAND_TABLE = re.compile(
+    r"^[ \t]*\|[ \t]*"
+    + _CMD +
+    r"[ \t]*\|[ \t]*"
+    r"(?:[^|\n]*\S[^|\n]*)",           # explanation cell, non-empty
+    re.MULTILINE,
+)
+
+
+# A table cell is not an explanation. In a list, the `—` separator asserts that
+# what follows explains what precedes; in a table the `|` is just structure, so
+# the row shape alone credits any two-column code reference. Measured over the
+# field: widening to tables without this filter admitted 9 non-commands against
+# 2 real ones — `dynamic = \'force-dynamic\'`, `app.ontoolresult = fn`,
+# `new App(info, caps, {autoResize: true})` — dropping precision from 39/39 to
+# 2/11. A command is an invocation, not an assignment or a constructor call.
+_RE_NOT_A_COMMAND = re.compile(
+    r"^[\w.\[\]]+[ \t]*=[ \t]"          # `dynamic = \'x\'` — spaced assignment.
+                                        # Spaced on purpose: `docker run -e FOO=bar`
+                                        # and `--flag=value` are real command text.
+    r"|^[A-Za-z_][\w.]*\("               # `fn(...)` — a call, not an invocation
+    r"|^new[ \t]"                        # `new App(...)`
+)
+
+
+def find_documented_commands(content: str) -> list[str]:
+    """Every documented command in the text, in all recognised shapes.
+
+    Callers must not reach for the individual patterns: this function is the
+    contract, so adding a fourth shape later cannot leave one consumer behind.
+    Returns raw command text; the caller decides identity via normalize_command.
+    """
+    out = []
+    for rx in (_RE_DOCUMENTED_COMMAND, _RE_DOCUMENTED_COMMAND_TABLE):
+        out.extend(
+            m.group(1) for m in rx.finditer(content)
+            if not _RE_NOT_A_COMMAND.match(m.group(1))
+        )
+    return out
+
 
 # Argument-like token: placeholder, flag, shell operator, or a file with an extension.
 # The operator branch covers the full set, not just `|`: an unstopped `&&`, `>` or `;`

--- a/skills/schliff/tests/unit/test_documented_command_forms.py
+++ b/skills/schliff/tests/unit/test_documented_command_forms.py
@@ -59,9 +59,49 @@ def test_list_marker_alone_on_a_line_credits_nothing():
     assert find_documented_commands("1.\n`npm run build` — build the bundle") == []
 
 
-def test_callers_go_through_the_contract():
-    """efficiency.py must not reach for an individual pattern: a fourth shape
-    added later would silently miss that consumer."""
-    src = open(os.path.join(_SCRIPTS, "scoring", "efficiency.py"), encoding="utf-8").read()
-    assert "find_documented_commands" in src
-    assert "_RE_DOCUMENTED_COMMAND" not in src
+def test_no_production_caller_reaches_past_the_contract():
+    """A fourth shape added later must not leave a consumer behind.
+
+    An earlier version of this test grepped exactly one hardcoded path
+    (efficiency.py), so a NEW module importing the raw pattern — the failure it
+    exists to prevent — would have passed it. It now walks the whole scripts
+    tree. Tests may still probe the patterns directly; the contract binds
+    production callers, which is a distinction __all__ cannot express.
+    """
+    import pathlib
+
+    offenders = []
+    for path in pathlib.Path(_SCRIPTS).rglob("*.py"):
+        if "test" in path.name:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "_RE_DOCUMENTED_COMMAND" in text and path.name != "base.py":
+            offenders.append(str(path.relative_to(_SCRIPTS)))
+    assert not offenders, (
+        "these reach past find_documented_commands: " + ", ".join(offenders)
+    )
+
+    efficiency = pathlib.Path(_SCRIPTS, "scoring", "efficiency.py").read_text(encoding="utf-8")
+    assert "find_documented_commands" in efficiency, "the known consumer stopped using it"
+
+@pytest.mark.parametrize("text", [
+    # Branch 2 of _RE_NOT_A_COMMAND was unreachable: _CMD only ever yields a head
+    # followed by whitespace, so a `(` could never sit where the branch required
+    # it, and these were all credited as commands.
+    "| `app (x, y)` | Construct the app with two args |",
+    "| `foo.bar (x)` | Call the thing with one arg |",
+    "- `run (a, b)` — call the function with two args",
+])
+def test_call_expressions_are_not_commands(text):
+    assert find_documented_commands(text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    # The table shape accepted ANY non-empty cell while the list shape required
+    # 10+ characters, so `| x |` counted where `— x` did not.
+    ("| `git add` | x |", []),
+    ("| `git add` | stages the given paths |", ["git add"]),
+    ("- `git add` — x", []),
+])
+def test_table_needs_a_real_explanation_like_the_list_form(text, expected):
+    assert find_documented_commands(text) == expected

--- a/skills/schliff/tests/unit/test_documented_command_forms.py
+++ b/skills/schliff/tests/unit/test_documented_command_forms.py
@@ -1,0 +1,67 @@
+"""A documented command appears in three shapes; the detector saw one.
+
+Measured over 184 installed SKILL.md files before the fix: 10 top-level bullets
+credited, 8 table rows and 2 indented sub-bullets scoring nothing.
+
+The widening is not free. Crediting table rows without a filter admitted 9
+non-commands against 2 real ones — precision 2/11, against 39/39 for the
+original pattern. In a list the `—` asserts that what follows explains what
+precedes; in a table the `|` is only structure, so the row shape alone credits
+any two-column code reference.
+"""
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+sys.path.insert(0, _SCRIPTS)
+sys.path.insert(0, os.path.join(_SCRIPTS, "scoring"))
+
+from scoring.patterns.base import find_documented_commands  # noqa: E402
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("- `npm run build` — build the bundle", ["npm run build"]),
+    ("1. `pytest -q` — run the unit tests quietly", ["pytest -q"]),
+    ("  - `uv sync --frozen` — install the pinned environment", ["uv sync --frozen"]),
+    ("\t* `git status` — show the working tree state", ["git status"]),
+    ("| `gh pr list` | List the open pull requests |", ["gh pr list"]),
+    ("  | `docker compose up` | Start the local stack |", ["docker compose up"]),
+])
+def test_all_documented_shapes_are_credited(text, expected):
+    assert find_documented_commands(text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    # Every one of these was a real false positive in the field, admitted by the
+    # table shape before the command/code filter existed.
+    "| `dynamic = 'force-dynamic'` | Opt the route out of caching |",
+    "| `revalidate = N` | Revalidate every N seconds |",
+    "| `app.ontoolresult = fn` | Handle a tool result |",
+    "| `new App(info, caps, {autoResize: true})` | Construct the app |",
+])
+def test_code_fragments_in_tables_are_not_commands(text):
+    assert find_documented_commands(text) == []
+
+
+@pytest.mark.parametrize("command_line,expected", [
+    # `=` alone must not disqualify: these are real command text.
+    ("- `docker run -e FOO=bar image` — run with an env var set", ["docker run -e FOO=bar image"]),
+    ("- `gh pr list --limit=50` — list with an explicit limit", ["gh pr list --limit=50"]),
+])
+def test_equals_inside_a_command_is_not_an_assignment(command_line, expected):
+    assert find_documented_commands(command_line) == expected
+
+
+def test_list_marker_alone_on_a_line_credits_nothing():
+    """`\\s` after the marker would cross the newline and credit the next line."""
+    assert find_documented_commands("1.\n`npm run build` — build the bundle") == []
+
+
+def test_callers_go_through_the_contract():
+    """efficiency.py must not reach for an individual pattern: a fourth shape
+    added later would silently miss that consumer."""
+    src = open(os.path.join(_SCRIPTS, "scoring", "efficiency.py"), encoding="utf-8").read()
+    assert "find_documented_commands" in src
+    assert "_RE_DOCUMENTED_COMMAND" not in src


### PR DESCRIPTION
Closes #194.

## The defect

`_RE_DOCUMENTED_COMMAND` anchored on `^` plus a list marker, so it saw only top-level bullets. Measured over 184 installed `SKILL.md` files: **10 credited, 8 table rows and 2 indented sub-bullets scoring nothing.**

## The widening was not free, and the issue's own criterion caught it

The issue asked to *"classify **every** hit in the field, not a sample"*. Doing that stopped a bad change from shipping:

| | hits | genuine |
| --- | --- | --- |
| original pattern | 39 | **39/39** |
| naive widening (table rows credited) | 11 new | **2/11** |

The nine false positives were all code fragments: `dynamic = 'force-dynamic'`, `revalidate = N`, `app.ontoolresult = fn`, `new App(info, caps, {autoResize: true})`.

**The cause:** the two shapes do not carry the same evidence. In a list, `—` asserts that what follows explains what precedes. In a table, `|` is only structure — so the row shape alone credits any two-column code reference.

## The filter

A command is an invocation, not an assignment or a call:

```python
_RE_NOT_A_COMMAND = re.compile(
    r"^[\w.\[\]]+[ \t]*=[ \t]"    # `dynamic = 'x'` — SPACED assignment
    r"|^[A-Za-z_][\w.]*\("        # `fn(...)`
    r"|^new[ \t]"                 # `new App(...)`
)
```

Spaced on purpose: `docker run -e FOO=bar` and `gh pr list --limit=50` are real command text and must survive. Both are pinned by tests.

After the filter: **12 hits where there were 10, both new ones genuine, no previously credited command lost.**

## An honest note on the table shape

In this corpus it contributed **zero** real commands — all 9 candidates were code. Both genuine additions came from the *indented-bullet* form.

It is kept because the issue measured 15 table rows in a larger corpus and the filter rejected 9 of 9 correctly, so the risk is nil. But nobody should read this change as "table support paid off here".

## Field effect

**1 of 184 files moves, 44 → 46. No file's score drops** — only credit is added, never withdrawn.

## Structure

Both patterns are now behind `find_documented_commands()`, and a test asserts `efficiency.py` does not reach past it. A fourth shape added later cannot leave a consumer behind.

## Verification

| Check | Result |
| --- | --- |
| Suite | 2204 passed (14 new) |
| ruff | clean |
| Mutation: filter removed | 4 red |
| Mutation: indentation anchor restored | 2 red |
| Mutation: table pattern dropped | 2 red |
