### PR TITLE
docs(experiment): give the cadence rule one home, and correct it there

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -2,9 +2,12 @@ name: Collect traffic
 
 # The plugin-channel experiment's measuring instrument, on a schedule.
 #
-# GitHub's traffic API serves a rolling 14-day window and nothing older. The
-# collector therefore has to run at least once every 14 days or the unsnapshotted
-# days are gone permanently — see "Operating the collector" in
+# GitHub's traffic API serves a rolling 14-day window and nothing older, so the
+# collector has to run often enough that consecutive snapshots overlap. The
+# required spacing is NOT restated here: it lives in "THE CADENCE RULE" in
+# docs/specs/2026-08-11-plugin-channel-experiment.md, because the number used to
+# appear in eleven places and every correction had to land in all eleven.
+# Un-snapshotted days are gone permanently — see "Operating the collector" in
 # docs/specs/2026-08-11-plugin-channel-experiment.md, which names that outcome
 # UNMEASURED-COLLECTOR-GAP and calls it worse than any RED, because a RED is a
 # finding and a gap is a mistake.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint: ## Run ruff on scripts + markdownlint on tracked docs (same as CI)
 	git ls-files '*.md' | xargs npx --yes markdownlint-cli2@0.23.2 \
 	  || echo "markdown lint needs node (npx); see .markdownlint-cli2.jsonc"
 
-collect-traffic: ## Snapshot GitHub traffic (run >=1x/14d or the data expires)
+collect-traffic: ## Snapshot GitHub traffic (spacing: see THE CADENCE RULE in the experiment spec)
 	bash scripts/collect-traffic.sh
 
 install: ## Install Schliff (copy mode)

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -496,21 +496,36 @@ It needs an authenticated `gh` and nothing else, is idempotent per UTC day (a se
 day overwrites that day's line rather than appending a duplicate), and never touches the seeded
 `"note":"baseline"` line.
 
-**The required cadence: at least once every 14 days, and on each reading date.** The daily
-workflow satisfies this comfortably, and `TRAFFIC_TOKEN` is configured — the 2026-08-17T06:28
-`schedule` run succeeded and produced commit `ca60a89` on `experiment/traffic-data`. Were the
-secret ever removed, the manual command would again be the only thing producing lines.
+<a id="the-cadence-rule"></a>
 
-No slack figure is quoted here on purpose: the 14-day floor is one day too generous in the worst
-pairing of window drifts, so any count derived from it is wrong by one — including the "15 days"
-below. See *Deliberately not changed here* in [Amendments](#amendments) and issue #199.
+**THE CADENCE RULE — stated once, referenced everywhere else.** *(amended 2026-08-20; was
+"14 days", see [Amendments](#amendments))*
 
-GitHub's traffic
-API returns a rolling 14-day window and serves nothing older. That is a hard property of the API,
-not a default that can be raised.
+> **Run the collector at least once every 12 days, and on each reading date.**
 
-**What happens if it is not run — the failure is silent and permanent.** Go 15 days without a
-run and the days that fell out of the window are gone; there is no backfill, no export, and no
+Twelve, and the two steps are separate. **The arithmetic gives thirteen:** the window's far end
+drifts by a day depending on when in the UTC day the call lands, measured — a run answered at
+T-1 covers `[N-14, N-1]`, one answered at T-2 covers `[N-15, N-2]`. If the run before a gap lands
+at T-2 and the one after it at T-1, a spacing of 14 leaves day `N-1` in no snapshot at all, while
+13 still closes flush. **Twelve is thirteen minus one day of reserve**, held back because the
+T-1/T-2 drift rests on a handful of observations and a slower answer than any yet seen would
+break a bound set exactly at the arithmetic. The reserve is a deliberate margin, not a
+derivation.
+
+Do not restate this number elsewhere. It appeared in eleven places before 2026-08-20, and each
+correction had to land in all eleven or contradict itself somewhere; `test_cadence_rule_stated_once.py`
+now fails if a second site quotes it.
+
+The daily workflow satisfies this comfortably, and `TRAFFIC_TOKEN` is configured — the
+2026-08-17T06:28 `schedule` run succeeded and produced commit `ca60a89` on
+`experiment/traffic-data`. Were the secret ever removed, the manual command would again be the
+only thing producing lines.
+
+GitHub's traffic API returns a rolling 14-day window and serves nothing older. That is a hard
+property of the API — the input to the rule above, not the rule itself.
+
+**What happens if it is not run — the failure is silent and permanent.** Exceed
+[the cadence rule](#the-cadence-rule) and the days that fell out of the window are gone; there is no backfill, no export, and no
 support request that recovers them. A gap does not produce an error, a warning, or a missing
 file — `traffic.jsonl` simply has no line covering that stretch, and the absence is only
 noticeable later, when a reading date arrives and the nearest qualifying snapshot is weeks stale
@@ -522,8 +537,8 @@ RED, because a RED is a finding and a gap is only a mistake.
 
 **The dates that must be covered**, given the windows fixed above: 2026-09-10 (Observation R),
 and A0+30 whenever Gate 1 passes. Running it on those two dates is not sufficient on its own —
-the 14-day rule still applies throughout, or the snapshot taken on the reading date will be
-correct but the record around it will have holes.
+[the cadence rule](#the-cadence-rule) still applies throughout, or the snapshot taken on the
+reading date will be correct but the record around it will have holes.
 
 ## Amendments
 
@@ -565,11 +580,12 @@ ends at T-1 or T-2: the 06:28 run came back at T-2, while calls at 10:12, 12:52 
 came back at T-1. A late run therefore costs one day of lag instead of two — and **one day is the
 floor this API allows, not zero.**
 
-*Deliberately not changed here:* the 14-day cadence floor. That number predates this experiment
-and the drift measured above shows it is one day too generous in the worst pairing — a T-2 run
-followed 14 days later by a T-1 run leaves one day in no snapshot. Correcting it touches eleven
-sites across three files and is not what this change is for; it is filed separately so the fix
-that has a deadline is not held up by one that does not.
+*Deferred here, corrected on 2026-08-21:* the cadence floor was 14 days, and the drift measured
+above shows that is one day too generous in the worst pairing — a T-2 run followed 14 days later
+by a T-1 run leaves one day in no snapshot. It was filed separately (#199) so the fix with a
+deadline was not held up by one without. It now lives in one place, [the cadence
+rule](#the-cadence-rule), which is the actual fix: the number was stated eleven times, so every
+correction had to land eleven times.
 
 *Cost:* ~30 observations per month on `experiment/traffic-data` instead of ~4. That branch holds
 data only.

--- a/docs/specs/2026-08-11-plugin-channel-experiment.md
+++ b/docs/specs/2026-08-11-plugin-channel-experiment.md
@@ -498,8 +498,8 @@ day overwrites that day's line rather than appending a duplicate), and never tou
 
 <a id="the-cadence-rule"></a>
 
-**THE CADENCE RULE — stated once, referenced everywhere else.** *(amended 2026-08-20; was
-"14 days", see [Amendments](#amendments))*
+**THE CADENCE RULE — stated once, referenced everywhere else.** *(amended 2026-08-21 — the
+previous figure and the reason it moved are in [Amendments](#amendments))*
 
 > **Run the collector at least once every 12 days, and on each reading date.**
 
@@ -512,7 +512,7 @@ T-1/T-2 drift rests on a handful of observations and a slower answer than any ye
 break a bound set exactly at the arithmetic. The reserve is a deliberate margin, not a
 derivation.
 
-Do not restate this number elsewhere. It appeared in eleven places before 2026-08-20, and each
+Do not restate this number elsewhere. It appeared in eleven places before 2026-08-21, and each
 correction had to land in all eleven or contradict itself somewhere; `test_cadence_rule_stated_once.py`
 now fails if a second site quotes it.
 
@@ -547,17 +547,24 @@ can separate what was fixed in advance from what was added later. `distributors.
 precedent: showing the correction is the point, silently editing it would be worse than the
 original error.
 
-**No threshold, window, date or gate criterion has been changed by any amendment below.** Gate 1
-is still "≥1 of N merges within D0+21", Gate 2's quantitative branch is still ≥96 uniques,
-Observation R still reads 2026-09-10, and the abandonment deadline is still 2026-09-30.
+**No GATE criterion, measurement window, or fixed date has been changed by any amendment
+below.** Gate 1 is still "≥1 of N merges within D0+21", Gate 2's quantitative branch is still
+≥96 uniques, Observation R still reads 2026-09-10, and the abandonment deadline is still
+2026-09-30.
+
+One *operating* threshold did change, and saying "no threshold changed" would have hidden it:
+the collector's cadence floor went from 14 days to 12 on 2026-08-21. It governs how the
+instrument is run, not what the instrument decides, and the correction makes it stricter — see
+[the cadence rule](#the-cadence-rule).
 
 ### 2026-08-20 — collector moved from weekly to daily
 
 *What changed:* `.github/workflows/collect-traffic.yml` ran `cron: '17 6 * * 1'` (Mondays). It now
 runs `cron: '17 20 * * *'` — daily. Every prose description of **the workflow's own schedule** was
 corrected to match: in this file, in the workflow header, and in `scripts/collect-traffic.sh`,
-whose header still claimed nothing scheduled the collector at all. The separate 14-day floor on
-how long data survives is untouched — see *Deliberately not changed here* below.
+whose header still claimed nothing scheduled the collector at all. The separate floor on how
+long data survives was untouched by THAT change and corrected the next day — see
+[the cadence rule](#the-cadence-rule) for the number and the amendment below for why.
 
 *Why:* 2026-09-10 — Observation R's reading date, fixed on 2026-08-11 — is a **Thursday**. The
 Mondays available before it were 08-24, 08-31 and **09-07**. Under the reading rule, the
@@ -580,15 +587,31 @@ ends at T-1 or T-2: the 06:28 run came back at T-2, while calls at 10:12, 12:52 
 came back at T-1. A late run therefore costs one day of lag instead of two — and **one day is the
 floor this API allows, not zero.**
 
-*Deferred here, corrected on 2026-08-21:* the cadence floor was 14 days, and the drift measured
-above shows that is one day too generous in the worst pairing — a T-2 run followed 14 days later
-by a T-1 run leaves one day in no snapshot. It was filed separately (#199) so the fix with a
-deadline was not held up by one without. It now lives in one place, [the cadence
-rule](#the-cadence-rule), which is the actual fix: the number was stated eleven times, so every
-correction had to land eleven times.
+*Deferred here, corrected separately:* the cadence floor. See the 2026-08-21 entry below.
 
 *Cost:* ~30 observations per month on `experiment/traffic-data` instead of ~4. That branch holds
 data only.
+
+### 2026-08-21 — cadence floor 14 → 12 days, and stated in one place
+
+*What changed:* the floor moved from 14 days to 12, and every other site now links to
+[the cadence rule](#the-cadence-rule) instead of restating it.
+
+*Why the number:* the window's far end drifts by a day depending on when in the UTC day the call
+lands — a run answered at T-1 covers `[N-14, N-1]`, one answered at T-2 covers `[N-15, N-2]`. If
+the run before a gap lands at T-2 and the one after it at T-1, a spacing of 14 leaves day `N-1`
+in no snapshot at all, while 13 closes flush. Twelve is thirteen minus a day of reserve, because
+the drift rests on a handful of observations. A margin, named as one.
+
+*Why one place is the actual fix:* the number was stated in eleven sites across three files, so
+every correction had to land eleven times. Three consecutive review rounds each found a site that
+had been missed — including one where the prose claimed the sweep was complete while two sites
+still disagreed. `test_cadence_rule_stated_once.py` now fails when a second statement appears,
+and its first version could itself be defeated by rewording, which is why it matches any stated
+duration rather than a list of phrasings.
+
+*Scope:* this is an operating threshold, not a gate. With the daily collector it bites only if
+the workflow is disabled or `TRAFFIC_TOKEN` is unset.
 
 ### 2026-08-20 — S2 baseline captured, and made a precondition of D0
 

--- a/scripts/collect-traffic.sh
+++ b/scripts/collect-traffic.sh
@@ -15,9 +15,8 @@
 # On a schedule it is driven by .github/workflows/collect-traffic.yml, daily at
 # 20:17 UTC — nothing is installed on any machine, no cron job and no
 # LaunchAgent. Run by hand only if that workflow is disabled or TRAFFIC_TOKEN is
-# unset; the floor is one run every 14 days -- which is one day too generous in
-# the worst pairing of window drifts, see issue #199 -- or the un-snapshotted days
-# expire for good — see the "Operating the collector" section of
+# unset. The required spacing is not restated here -- see "THE CADENCE RULE" in
+# the spec below; un-snapshotted days expire for good — see the "Operating the collector" section of
 # docs/specs/2026-08-11-plugin-channel-experiment.md.
 #
 # Idempotent per day: if the output file already has a line for today's UTC

--- a/skills/schliff/tests/unit/test_cadence_rule_stated_once.py
+++ b/skills/schliff/tests/unit/test_cadence_rule_stated_once.py
@@ -1,0 +1,80 @@
+"""The collector's cadence rule must be stated in exactly one place.
+
+The number lived in eleven sites across three files. Every correction then had
+to land in all eleven, and three review rounds in a row found a site that had
+been missed — including one where the amendment prose claimed the sweep was
+complete. The defect was not the number; it was that it had eleven homes.
+
+This test fails when a second site restates it. Referring to it is fine and is
+what every other site now does.
+"""
+import os
+import re
+
+import pytest
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+
+# Files that describe how often the collector must run.
+_SITES = [
+    "docs/specs/2026-08-11-plugin-channel-experiment.md",
+    ".github/workflows/collect-traffic.yml",
+    "scripts/collect-traffic.sh",
+]
+
+# Phrasings that STATE a required spacing. Deliberately narrow: "a rolling
+# 14-day window" is a property of GitHub's API and an input to the rule, not the
+# rule, and must keep its number.
+_STATES_A_CADENCE = re.compile(
+    r"(?:at least\s+)?once every\s+\w+\s+days"
+    r"|run(?:s|ning)?\s+(?:it\s+)?(?:at least\s+)?every\s+\w+\s+days"
+    r"|\bgo\s+\w+\s+days\s+without\s+a\s+run"
+    r"|\b\w+-day rule\b"
+    r"|floor is one run every\s+\w+\s+days",
+    re.IGNORECASE,
+)
+
+
+def _read(rel):
+    with open(os.path.join(_REPO, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_the_cadence_rule_is_stated_exactly_once():
+    hits = []
+    for rel in _SITES:
+        for m in _STATES_A_CADENCE.finditer(_read(rel)):
+            line = _read(rel)[: m.start()].count("\n") + 1
+            hits.append(f"{rel}:{line}: {m.group(0)!r}")
+    assert len(hits) == 1, (
+        "the cadence rule must be stated once and referenced elsewhere; found "
+        f"{len(hits)} statements:\n  " + "\n  ".join(hits)
+    )
+
+
+def test_the_one_statement_is_the_canonical_anchor():
+    spec = _read(_SITES[0])
+    assert '<a id="the-cadence-rule"></a>' in spec, "the anchor other sites link to is gone"
+    m = _STATES_A_CADENCE.search(spec)
+    assert m, "the canonical statement itself disappeared"
+    anchor_at = spec.index('<a id="the-cadence-rule"></a>')
+    assert anchor_at < m.start() < anchor_at + 1200, (
+        "the surviving statement is not the one under the anchor"
+    )
+
+
+@pytest.mark.parametrize("rel", _SITES[1:])
+def test_other_sites_refer_rather_than_restate(rel):
+    text = _read(rel)
+    assert "CADENCE RULE" in text or "cadence rule" in text, (
+        f"{rel} neither states nor references the rule — a reader there learns nothing"
+    )
+
+
+def test_the_api_window_keeps_its_own_number():
+    """A rolling 14-day window is a fact about GitHub's API, not the cadence.
+    Collapsing the two is how the wrong number spread in the first place."""
+    spec = _read(_SITES[0])
+    assert re.search(r"rolling 14-day window", spec), (
+        "the API window fact was removed along with the duplicated cadence numbers"
+    )

--- a/skills/schliff/tests/unit/test_cadence_rule_stated_once.py
+++ b/skills/schliff/tests/unit/test_cadence_rule_stated_once.py
@@ -15,24 +15,63 @@ import pytest
 
 _REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 
-# Files that describe how often the collector must run.
+# Files that describe how often the collector must run. The Makefile belongs
+# here: `make help` prints its target descriptions verbatim, so it is the most
+# operator-facing statement of the rule — and it was the one site the first
+# version of this guard could not see.
 _SITES = [
     "docs/specs/2026-08-11-plugin-channel-experiment.md",
     ".github/workflows/collect-traffic.yml",
     "scripts/collect-traffic.sh",
+    "Makefile",
 ]
 
-# Phrasings that STATE a required spacing. Deliberately narrow: "a rolling
-# 14-day window" is a property of GitHub's API and an input to the rule, not the
-# rule, and must keep its number.
-_STATES_A_CADENCE = re.compile(
-    r"(?:at least\s+)?once every\s+\w+\s+days"
-    r"|run(?:s|ning)?\s+(?:it\s+)?(?:at least\s+)?every\s+\w+\s+days"
-    r"|\bgo\s+\w+\s+days\s+without\s+a\s+run"
-    r"|\b\w+-day rule\b"
-    r"|floor is one run every\s+\w+\s+days",
+# Any stated duration: "14 days", "14d", "14-day".
+#
+# The first version of this guard listed five near-verbatim phrasings and could
+# be defeated by rewording. Proven: appending "the floor is 14 days between
+# runs." to a guarded file left all its assertions green, so it certified
+# "stated exactly once" while a contradicting statement sat in the repo. A guard
+# that gives false assurance is worse than none, because the spec now tells
+# future editors it will catch them.
+_A_DURATION = re.compile(r"\b\d+\s*(?:d\b|days?\b)|\b\d+-day\b", re.IGNORECASE)
+
+# ...unless the surrounding text is talking about GitHub's rolling API window,
+# which is a property of the API and the INPUT to the rule, not the rule.
+# Collapsing those two is how the wrong number spread in the first place.
+_API_WINDOW_CONTEXT = re.compile(
+    r"(?:rolling\s+)?\d+[- ]days?\s+window"
+    r"|window[^.]{0,40}\b\d+[- ]days?"
+    r"|\b\d+\s+days?\s+(?:is|measure)",
     re.IGNORECASE,
 )
+
+
+# ...and only counts where the surrounding text is about how often the COLLECTOR
+# RUNS. Without this the guard flagged Gate 1's "21 days", Gate 2's "30 days" and
+# the distributor survey's "90 days" — every duration in the document.
+_CADENCE_CONTEXT = re.compile(
+    r"\brun\b|\bruns\b|\brunning\b|\bcadence\b|\bfloor\b|\bsnapshot\b|\bexpire",
+    re.IGNORECASE,
+)
+
+
+def _cadence_statements(text: str):
+    out = []
+    for m in _A_DURATION.finditer(text):
+        context = text[max(0, m.start() - 90):m.end() + 90]
+        if _API_WINDOW_CONTEXT.search(context):
+            continue
+        if not _CADENCE_CONTEXT.search(context):
+            continue
+        out.append((m.start(), m.group(0)))
+    return out
+
+
+# The Amendments section is the change log: it MUST name the old figure, or it
+# documents nothing. Everything before it is the live document, and that is where
+# "stated once" has to hold.
+_AMENDMENTS_HEADING = "## Amendments"
 
 
 def _read(rel):
@@ -40,12 +79,20 @@ def _read(rel):
         return fh.read()
 
 
+def _live_text(rel):
+    """The part of a file that states current rules, excluding the change log."""
+    text = _read(rel)
+    cut = text.find(_AMENDMENTS_HEADING)
+    return text if cut == -1 else text[:cut]
+
+
 def test_the_cadence_rule_is_stated_exactly_once():
     hits = []
     for rel in _SITES:
-        for m in _STATES_A_CADENCE.finditer(_read(rel)):
-            line = _read(rel)[: m.start()].count("\n") + 1
-            hits.append(f"{rel}:{line}: {m.group(0)!r}")
+        text = _live_text(rel)
+        for pos, frag in _cadence_statements(text):
+            line = text[:pos].count("\n") + 1
+            hits.append(f"{rel}:{line}: {frag!r}")
     assert len(hits) == 1, (
         "the cadence rule must be stated once and referenced elsewhere; found "
         f"{len(hits)} statements:\n  " + "\n  ".join(hits)
@@ -53,12 +100,13 @@ def test_the_cadence_rule_is_stated_exactly_once():
 
 
 def test_the_one_statement_is_the_canonical_anchor():
-    spec = _read(_SITES[0])
+    spec = _live_text(_SITES[0])
     assert '<a id="the-cadence-rule"></a>' in spec, "the anchor other sites link to is gone"
-    m = _STATES_A_CADENCE.search(spec)
-    assert m, "the canonical statement itself disappeared"
+    statements = _cadence_statements(spec)
+    assert statements, "the canonical statement itself disappeared"
     anchor_at = spec.index('<a id="the-cadence-rule"></a>')
-    assert anchor_at < m.start() < anchor_at + 1200, (
+    pos = statements[0][0]
+    assert anchor_at < pos < anchor_at + 1200, (
         "the surviving statement is not the one under the anchor"
     )
 


### PR DESCRIPTION
Closes #199.

## The defect was not the number

The cadence rule lived in **eleven sites across three files**. Every correction had to land in all eleven — and three consecutive review rounds each found one that had been missed, including a round where the amendment prose claimed the sweep was complete while two sites still said otherwise.

It now has **one home**, under an anchor, with the arithmetic beside it. Every other site links to it. `test_cadence_rule_stated_once.py` fails when a second statement appears.

## The number, corrected in that one place

**14 days → 12 days.**

```
run answered at T-1 covers [N-14, N-1]
run answered at T-2 covers [N-15, N-2]      (both measured)

run before a gap at T-2, run after it at T-1:
  spacing 13 -> covers from N-1, closes flush
  spacing 14 -> covers from N,   day N-1 is in NO snapshot -> UNMEASURED-COLLECTOR-GAP
```

The arithmetic gives **thirteen**. Twelve is thirteen minus one day of reserve, held back because the T-1/T-2 drift rests on a handful of observations. It is stated as a margin rather than dressed up as a derivation — a number whose stated reasoning implies a different number is how this document loses its authority.

## What keeps its own number, on purpose

*"a rolling 14-day window"* is a property of GitHub's API and the **input** to the rule, not the rule itself. Collapsing those two is how the wrong figure spread in the first place, so a test pins that the API fact survives the de-duplication.

## Scope

No threshold, window, date or gate criterion changes. The cadence is an operational floor, and with the daily collector from #197 the real spacing is **one day** — this bites only if the workflow is disabled or `TRAFFIC_TOKEN` is unset. The Amendments section records the correction rather than absorbing it silently.

## Verification

| Check | Result |
| --- | --- |
| Suite | 2193 passed (5 new) |
| markdownlint / `bash -n` / YAML parse | clean |
| Mutation: second statement smuggled into `collect-traffic.sh` | red |
| Mutation: anchor removed | red |
