### PR TITLE
docs(changelog): name the three user-visible changes 8.12.0 ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - **`operational_coverage` now produces fixes.** On an AGENTS.md the heaviest dimension —
   weight 0.4, tied with `structure` — had no fix path at all: a file scoring 0/100 there was
-  told to "add 2+ concrete examples" for +2 while forty composite points went unmentioned.
+  told to "add 2+ concrete examples" for +1.5 — the only applicable fix among eight, the
+  other seven being SKILL-only noise — while forty composite points went unmentioned.
   `text_gradient` now emits a ranked fix for every missing category (setup, build, test,
   code_style, gotchas, pr). Field evidence, 30 real AGENTS.md files: median
   `operational_coverage` 35/100, 17 of 30 below 40.
@@ -58,7 +59,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   still give 23.0 where the registry's set gives 35.0, which reads as a weak file rather
   than a bug. The dimension set now comes from the registry, so three hand-maintained
   copies become one source of truth. End to end on that file, the dashboard moves from
-  12.1 to 35.0. `text_gradient` also has a `--format` flag now, with `choices` — a typo
+  17.4 to 35.0. `text_gradient` also has a `--format` flag now, with `choices` — a typo
   used to exit 0 and print exactly the SKILL-only advice the flag exists to prevent.
 
 - **A line that *is* a command now counts as actionable content.** `efficiency` recognised
@@ -90,7 +91,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - The composite `dashboard.py` and `auto-improve.py` print **changes for non-SKILL
   formats**, because they now resolve the format and score through the registry. On an
   AGENTS.md it goes up, and by a lot — the dimension they never listed counted as zero
-  (a bare AGENTS.md: 12.1 -> 35.0).
+  (a bare AGENTS.md: 17.4 -> 35.0).
   On a CLAUDE.md or a `.cursorrules` the dimension set was already right, but the format
   now reaches the scorers and the weight table, so the number can still move (measured on
   a small CLAUDE.md: 25.3 -> 30.0). A SKILL.md is unaffected, byte for byte. Readings you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`operational_coverage` now produces fixes.** On an AGENTS.md the heaviest dimension —
+  weight 0.4, tied with `structure` — had no fix path at all: a file scoring 0/100 there was
+  told to "add 2+ concrete examples" for +2 while forty composite points went unmentioned.
+  `text_gradient` now emits a ranked fix for every missing category (setup, build, test,
+  code_style, gotchas, pr). Field evidence, 30 real AGENTS.md files: median
+  `operational_coverage` 35/100, 17 of 30 below 40.
+  The stated delta is exact for the dimension and approximate for the composite — on a
+  saturated file the `pr` fix states +4.0 and delivers +2.8, because the added prose dilutes
+  `efficiency`; on a bare file it undershoots instead. Confidence is `medium`, and these are
+  advice, not auto-applied patches. Each instruction carries a canonical example that the
+  tests score, so advice and fixture cannot drift apart — but the examples illustrate, they
+  are not a recipe: pasted verbatim they earn a Node repo full test credit for a `pytest` it
+  does not have. That is why every command instruction says *your* repo's command and points
+  at `schliff check-commands`, which resolves a documented command against the repository.
+
 ### Fixed
 
 - **Documented commands in tables and indented bullets now count.** `efficiency`
@@ -15,6 +32,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   not an assertion that the cell explains the command, so without one
   `dynamic = 'force-dynamic'` and `new App(...)` were credited as commands.
   Precision on the new shapes is 53/55.
+
+- **Fix deltas on an AGENTS.md no longer understate themselves by ~2.7x.** Every hardcoded
+  delta in `text_gradient.py` is a composite estimate sized against **skill.md's** weight
+  table — `missing_name: 1.5` is 10 dimension points times structure's 0.15 there — and the
+  same literal was emitted whatever the format. On an AGENTS.md, where `structure` carries
+  0.4, a file whose only defect was a TODO marker reported delta 1.5 while removing it moved
+  the composite 88.6 -> 93.0. Decomposed, structure contributes 10 x 0.4 = +4.00 and
+  `efficiency` the remaining +0.40; the gradient now reports exactly that 4.0. The wrong
+  number was not the only cost: under-reported structure fixes sank in the ranking, and
+  top-N truncation dropped the cheap auto-applicable ones first. The rescale applies to
+  `agents.md` alone, because that is the only basis that was measured — `skill.md`,
+  `claude.md` and `cursorrules` are unchanged, verified over 494 gradients across 60 corpus
+  files: issue for issue, delta for delta, priority for priority.
+
+- **`/schliff:auto` and the dashboard no longer advise an AGENTS.md as if it were a
+  SKILL.md.** Three callers resolved no format — `auto-improve.py`, `dashboard.py`, and
+  `text_gradient.py`'s own CLI, whose argparse had no `--format` flag at all.
+  `compute_gradients` uses the format to decide which fixes apply and `compute_composite`
+  to decide which dimensions count, so omitting it broke both halves at once: an AGENTS.md
+  was told to create an `eval-suite.json` worth 25 points, and never heard about
+  `operational_coverage`. Passing the format alone would not have been enough: both scripts
+  hand-listed their dimensions, and the composite counts a dimension missing from that list
+  as ZERO — on a bare AGENTS.md, `structure` and `efficiency` under the correct weights
+  still give 23.0 where the registry's set gives 35.0, which reads as a weak file rather
+  than a bug. The dimension set now comes from the registry, so three hand-maintained
+  copies become one source of truth. End to end on that file, the dashboard moves from
+  12.1 to 35.0. `text_gradient` also has a `--format` flag now, with `choices` — a typo
+  used to exit 0 and print exactly the SKILL-only advice the flag exists to prevent.
 
 - **A line that *is* a command now counts as actionable content.** `efficiency` recognised
   English imperatives at line start, so `- \`tool score <file>\` — score one file` scored
@@ -41,6 +86,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   instruction. A test now checks every documented invocation against the real parser.
 
 ### Notes
+
+- The composite `dashboard.py` and `auto-improve.py` print **changes for non-SKILL
+  formats**, because they now resolve the format and score through the registry. On an
+  AGENTS.md it goes up, and by a lot — the dimension they never listed counted as zero
+  (a bare AGENTS.md: 12.1 -> 35.0).
+  On a CLAUDE.md or a `.cursorrules` the dimension set was already right, but the format
+  now reaches the scorers and the weight table, so the number can still move (measured on
+  a small CLAUDE.md: 25.3 -> 30.0). A SKILL.md is unaffected, byte for byte. Readings you
+  recorded from an earlier version are not comparable for the non-SKILL formats.
 
 - Scores for files that document their commands or state an error contract go **up**; no
   file's score goes down. If you gate CI with `verify --min-score`, nothing you pass today


### PR DESCRIPTION
The `[Unreleased]` block named **one of the nine merges** since 8.11.1. Three of the missing ones are user-visible and would have shipped unannounced on 09-11:

| PR | Section | What a user notices |
|---|---|---|
| #200 | Added | `operational_coverage` produces fixes — the heaviest agents.md dimension (0.4) had no fix path |
| #204 | Fixed | fix deltas on an AGENTS.md no longer understate themselves by ~2.7x |
| #207 | Fixed | `/schliff:auto` and the dashboard stop advising an AGENTS.md as if it were a SKILL.md |

Deliberately left out: #197 and #209 (experiment operations, no user-facing surface) and #210 (tests).

## Numbers were re-measured at HEAD, not copied

Two figures from the commit messages had expired:

- #207's *"27.0 where `build_scores` gives 39.0"* gives **23.0 vs 35.0** on the same fixture today. It was correct when written — **#208 landed afterwards** and moved `efficiency`, which feeds both sides. `test_incomplete_score_dict_would_understate_the_composite` asserts `partial < full`, not the values, so it stayed green while the number went stale.
- That figure also described the *intermediate* state of #207's own work (format passed, dimensions still hand-listed). The user-facing before/after for the dashboard is **17.4 → 35.0**, because before #207 the whole SKILL profile applied.

## Reproduce

```bash
# #204 — rescaled delta on agents.md
printf '# Proj\n\nA tool.\n\n## Overview\n\nIt reads.\n\nTODO: fix this later\n' > /tmp/AGENTS.md
python3 skills/schliff/scripts/text_gradient.py /tmp/AGENTS.md --format agents.md   # delta +4.0, priority 1.6

# #200 — six operational_coverage fixes, confidence medium, effort moderate
python3 skills/schliff/scripts/text_gradient.py /tmp/AGENTS.md

# #207 — the dashboard path, before vs after
python3 - <<'PY'
import sys; sys.path.insert(0, 'skills/schliff/scripts')
import score_skill as sc
from shared import build_scores
p = '/tmp/AGENTS.md'
old = {'structure': sc.score_structure(p), 'triggers': sc.score_triggers(p, None),
       'quality': sc.score_quality(p, None), 'edges': sc.score_edges(p, None),
       'efficiency': sc.score_efficiency(p), 'composability': sc.score_composability(p),
       'clarity': sc.score_clarity(p)}   # include_clarity defaults to True in both versions
print('before:', sc.compute_composite(old)['score'])                                  # 17.4
new = build_scores(p, None, include_runtime=False, fmt='agents.md')
print('after :', sc.compute_composite(new, fmt='agents.md')['score'])                 # 35.0
PY
```

Also measured: a small CLAUDE.md moves 25.3 → 30.0 (different mechanism — the dimension set was already right there, but the format now reaches the scorers and the weight table). `skills/schliff/SKILL.md` gives 38.3 either way, unchanged.

## Scope of the behaviour note

The Notes section states which readings stop being comparable. `score`, `verify` and the Action already passed the format (`cli.py`, `verify.py`), so a CI gate on `verify --min-score` is untouched.

## Not verified

The 30-file field evidence quoted from #200 (median `operational_coverage` 35/100) is not reproducible from the repo; it is cited as that commit's measurement.

Docs only — no test asserts CHANGELOG content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y25UrwWic2BVESrLsbgTr4


---

### Review-Korrektur (2026-08-21)

Der Review von #211 hat zwei eigene Zahlen widerlegt, beide gefixt in `fdb9809`:

- **12.1 → 17.4.** Das Repro-Dict oben ließ `clarity` weg. `generate_dashboard` hat `include_clarity: bool = True` in **beiden** Versionen, also hat kein Default-Pfad je 17.4 unterschritten — 12.1 ist der `--no-clarity`-Wert. Gegengeprüft gegen die echte Vor-Fix-`dashboard.py` (`git show 2ea1731^`). Die CLAUDE.md-Zahl im selben Absatz (25.3 → 30.0) war **mit** clarity gemessen, die beiden Zahlen also unterschiedlich — genau der Fehler, den ein gemischtes Paar erzeugt.
- **+2 → +1.5** für `no_real_examples`. Aus #200s Commit-Message kopiert, die sich selbst widerspricht (39.0 + 2 = 40.5 geht nur mit 1.5 auf). Das Literal steht in `text_gradient.py:84`.

Der Lauf des Vor-#204-Moduls hat nebenbei „the only advice offered“ widerlegt: es kamen **acht** Gradienten, sieben davon SKILL-only. `no_real_examples` war der einzige **anwendbare** — so steht es jetzt da.
