### PR TITLE
chore(deps): hold anthropic below 1.0 until the judge is CI-covered

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # No CI job installs the `[judge]` extra and the only judge test runs with
+    # mock=True, so a green check on an anthropic major bump proves nothing about
+    # the judge. Widening that range is a decision to make by hand, after the
+    # extra is actually exercised in CI — not a PR to merge on a green tick.
+    ignore:
+      - dependency-name: "anthropic"
+        update-types: ["version-update:semver-major"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ known-first-party = ["scoring", "shared", "nlp"]
 evolve = ["litellm>=1.40.0,<2.0.0"]
 # Phase-1 LLM-judge smoke-test only (skills/schliff/scripts/judge/judge_v0.py).
 # Core schliff stays zero-dependency; install with `uv pip install -e ".[judge]"`.
+# The <1.0 cap is deliberate and Dependabot is told not to raise it (see the
+# `ignore` entry in .github/dependabot.yml): no CI job installs this extra, and
+# the only judge test runs with mock=True, so CI cannot observe a break here.
+# Lift the cap by hand, together with a job that actually installs and runs it.
 judge = ["anthropic>=0.104,<1.0", "pydantic>=2.13,<3.0"]
 # Phase 3b: mcp = ["mcp>=1.0.0,<2.0.0"]
 


### PR DESCRIPTION
Closes #213.

#213 proposed widening `anthropic` from `<1.0` to `<2.0` and was **green on all ten checks**.
That green proves nothing about the change:

- `test.yml` installs `ruff` and `pytest` only — **no job installs the `[judge]` extra**, so
  `anthropic` is never imported in CI at any version.
- The only judge test, `test_judge_v0.py::test_run_mock_smoke`, runs with `mock=True`.

So the code a major bump would break never loads during the run. Merging on the tick would be
merging on a check that structurally cannot fail.

This pins the cap and tells Dependabot to stop reproposing the major, which otherwise returns
every Monday. The reasoning is written at both sites — the `ignore` entry in `dependabot.yml` and
the `judge` extra in `pyproject.toml` — so whoever next reads either one sees why the cap is
there and what would have to happen first to lift it: a job that actually installs and exercises
the extra.

Minor-and-patch bumps for `anthropic` are unaffected.

## Verification

```
$ grep -rn "pip install" .github/workflows/test.yml
40:        run: pip install "ruff==0.15.8"
116:        run: pip install "pytest>=8,<9"
146:        run: pip install "pytest>=8,<9"      # no `.[judge]` anywhere

$ python3 -c "import yaml;d=yaml.safe_load(open('.github/dependabot.yml'));\
print([u for u in d['updates'] if u['package-ecosystem']=='pip'][0]['ignore'])"
[{'dependency-name': 'anthropic', 'update-types': ['version-update:semver-major']}]

$ ruff check skills/schliff/scripts/     # CI's path
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcYykJP28nNEShL1QPwa1k