### PR TITLE
fix(patterns): stop crediting the bare phrase "pin the version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
   in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and
-  both resolve to real hosts, so
+  both resolve to real hosts, and an octet rule also drops genuine four-part versions whose
+  parts all fall in 0–255, such as `v8@10.2.154.26` — so
   any octet rule is complete only until the next form) or by looking for a deploy command on
   the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while
   stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.``). Both
@@ -111,7 +112,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   recorded from an earlier version are not comparable for the non-SKILL formats.
 
 - Scores for files that document their commands or state an error contract go **up**; no
-  file's score goes down. If you gate CI with `verify --min-score`, nothing you pass today
+  file's score goes down **relative to 8.11.1**, the released version. (Within this
+  unreleased block one change withdraws credit: dropping the bare `pin the version`
+  phrase. Measured over 2304 local `.md`, 3 files lose 10 composability points against
+  the unreleased `main`; 0 of 159 installed skills, and 0 against 8.11.1, which never
+  credited the phrase.) If you gate CI with `verify --min-score`, nothing you pass today
   starts failing.
 - A denominator cap that would have stopped `efficiency` from penalising long files was
   implemented and reverted before release: it decoupled the score from length, which let

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,9 +81,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
   in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and
-  both resolve to real hosts, and an octet rule also drops genuine four-part versions whose
-  parts all fall in 0–255, such as `v8@10.2.154.26` — so
-  any octet rule is complete only until the next form) or by looking for a deploy command on
+  both resolve to real hosts, so any octet rule is complete only until the next form is
+  written — and it also drops genuine four-part versions whose parts all fall in 0–255, such
+  as `v8@10.2.154.26`) or by looking for a deploy command on
   the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while
   stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.``). Both
   error directions cost more than the limit, so it is documented rather than papered over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   prose "Pin the version to 1.2.3" matches nothing, here or in any earlier release.
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
-  in either direction: by number shape (`127.1` and `0x7f.1` both resolve to real hosts, so
+  in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and
+  both resolve to real hosts, so
   any octet rule is complete only until the next form) or by looking for a deploy command on
   the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while
   stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.``). Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,19 +72,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   facts, not as phrasings.** "Errors go to stderr with a non-zero exit" now counts as a
   declared error contract, `uv` counts as a declared prerequisite (the tool wordlist could
   never be completed), and `tool@1.2.3` counts as a compatibility statement. A version pin
-  is a stated compatibility *fact*, so two things that merely look like one are excluded:
-  an SSH target (`ssh root@100.127.18.39` — an address, not a version) and the bare
-  instruction "pin the version" *when it names no version*. "Pin the version to 8.8.2" still
-  counts, because it states one. The address test is a real
-  IPv4 check rather than "four dot-separated parts", because four-part versions exist —
-  `v8@6.7.288.46` keeps its credit, since `288` is not a valid octet. **The limit, stated
-  plainly:** a four-part pin whose parts are *all* 0–255 is indistinguishable from an
-  address by shape alone and loses the credit — `pkg@1.0.0.0` (the .NET assembly form) and
-  `protobuf@4.25.3.1` are affected. Five-part pins are unaffected (`pkg@1.2.3.4.5` is not
-  an address). If this costs you points, state the compatibility in prose as well —
-  "Compatible with protobuf 4.25.3.1" and "Requires protobuf >= 4.25.3.1" are both credited
-  by different, unchanged patterns. (Note the operator: a bare "requires protobuf 4.25.3.1"
-  is *not* credited, and never was.)
+  is a stated compatibility *fact*, so two things that merely look like one are excluded.
+  **An SSH target is not a version:** `ssh root@100.127.18.39` used to earn the credit. The
+  test is whether a deploy command (`ssh`, `scp`, `rsync`, `sftp`, `mosh`) shares the line —
+  not what the number looks like, because address forms are open-ended (`127.1`,
+  `0100.1.2.3` and `0x7f.1` all resolve to real hosts). Keying on the command means your
+  version keeps its credit whatever its shape: `v8@6.7.288.46` and `pkg@1.2.3.4.5` count,
+  and so does `v8@10.2.154.26` even though it would pass for an address. The exclusion is
+  **per line** — a file that documents a deploy command and states a version elsewhere keeps
+  the credit. **And "pin the version" on its own no longer counts:** it is an instruction,
+  naming no version. Write the version — `Pin the version in CI: \`tool@1.2.3\`` is credited,
+  as are "Compatible with protobuf 4.25.3.1" and "Requires protobuf >= 4.25.3.1". (Note the
+  operator: a bare "requires protobuf 4.25.3.1" is *not* credited, and never was.)
 - **`doctor` no longer counts vendored copies as installed skills.** A repo with one skill
   reported six — three of them the same file inside virtualenvs and a uv cache archive —
   inflating the skill count, the grade distribution and the headline "Total context cost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   an SSH target (`ssh root@100.127.18.39` — an address, not a version) and the bare
   instruction "pin the version", which names no version at all. The address test is a real
   IPv4 check rather than "four dot-separated parts", because four-part versions exist —
-  `v8@6.7.288.46` keeps its credit, since `288` is not a valid octet.
+  `v8@6.7.288.46` keeps its credit, since `288` is not a valid octet. **The limit, stated
+  plainly:** a four-part pin whose parts are *all* 0–255 is indistinguishable from an
+  address by shape alone and loses the credit — `pkg@1.0.0.0` (the .NET assembly form) and
+  `protobuf@4.25.3.1` are affected. Five-part pins are unaffected (`pkg@1.2.3.4.5` is not
+  an address). If this costs you points, state the compatibility in prose as well —
+  "Compatible with protobuf 4.25.3.1" and "Requires protobuf >= 4.25.3.1" are both credited
+  by different, unchanged patterns. (Note the operator: a bare "requires protobuf 4.25.3.1"
+  is *not* credited, and never was.)
 - **`doctor` no longer counts vendored copies as installed skills.** A repo with one skill
   reported six — three of them the same file inside virtualenvs and a uv cache archive —
   inflating the skill count, the grade distribution and the headline "Total context cost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,13 +80,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   patterns — "Minimum version 3.9." and "Compatible with Python 3.12" both count.)
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
-  in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and
-  both resolve through `socket.inet_aton`, so any octet rule is complete only until the next form is
-  written — and it also drops genuine four-part versions whose parts all fall in 0–255, such
-  as `v8@10.2.154.26`) or by looking for a deploy command on
-  the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while
-  stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.``). Both
-  error directions cost more than the limit, so it is documented rather than papered over.
+  without taking the credit from honest files, so it is documented rather than papered over.
+  The two attempted discriminators, why each failed and what was measured are recorded in
+  `docs/specs/2026-08-13-structural-signal-detection.md` under "Amendment 2026-08-25".
 - **`doctor` no longer counts vendored copies as installed skills.** A repo with one skill
   reported six — three of them the same file inside virtualenvs and a uv cache archive —
   inflating the skill count, the grade distribution and the headline "Total context cost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,8 +111,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Scores for files that document their commands or state an error contract go **up**; no
   file's score goes down **relative to 8.11.1**, the released version. (Within this
   unreleased block one change withdraws credit: dropping the bare `pin the version`
-  phrase. Measured over 2304 local `.md`, 3 files lose 10 composability points against
-  the unreleased `main`; 0 of 159 installed skills, and 0 against 8.11.1, which never
+  phrase. Measured against the unreleased `main`, 3 local files lose 10 composability
+  points; 0 of 159 installed skills, and 0 against 8.11.1, which never
   credited the phrase.) If you gate CI with `verify --min-score`, nothing you pass today
   starts failing.
 - A denominator cap that would have stopped `efficiency` from penalising long files was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   never be completed), and `tool@1.2.3` counts as a compatibility statement. The bare
   instruction "pin the version" does **not** count — it is an instruction, naming no
   version. Write the pin itself and it counts:
-  ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule. Be aware
-  that it is the `tool@version` syntax that carries it, not the presence of a number — a
-  prose "Pin the version to 1.2.3" matches nothing, here or in any earlier release.
+  ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule. Note which part
+  carries it: the pin, not the phrase. A prose "Pin the version to 1.2.3" matches nothing,
+  here or in any earlier release. (Other prose forms are credited by their own unchanged
+  patterns — "Minimum version 3.9." and "Compatible with Python 3.12" both count.)
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
   in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **`composability` recognises an error contract, a prerequisite and a version pin as
   facts, not as phrasings.** "Errors go to stderr with a non-zero exit" now counts as a
   declared error contract, `uv` counts as a declared prerequisite (the tool wordlist could
-  never be completed), and `tool@1.2.3` counts as a compatibility statement.
+  never be completed), and `tool@1.2.3` counts as a compatibility statement. A version pin
+  is a stated compatibility *fact*, so two things that merely look like one are excluded:
+  an SSH target (`ssh root@100.127.18.39` — an address, not a version) and the bare
+  instruction "pin the version", which names no version at all. The address test is a real
+  IPv4 check rather than "four dot-separated parts", because four-part versions exist —
+  `v8@6.7.288.46` keeps its credit, since `288` is not a valid octet.
 - **`doctor` no longer counts vendored copies as installed skills.** A repo with one skill
   reported six — three of them the same file inside virtualenvs and a uv cache archive —
   inflating the skill count, the grade distribution and the headline "Total context cost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   declared error contract, `uv` counts as a declared prerequisite (the tool wordlist could
   never be completed), and `tool@1.2.3` counts as a compatibility statement. The bare
   instruction "pin the version" does **not** count — it is an instruction, naming no
-  version. Write the pin itself and it counts, in that same sentence:
+  version. Write the pin itself and it counts:
   ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule. Be aware
   that it is the `tool@version` syntax that carries it, not the presence of a number — a
   prose "Pin the version to 1.2.3" matches nothing, here or in any earlier release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   declared error contract, `uv` counts as a declared prerequisite (the tool wordlist could
   never be completed), and `tool@1.2.3` counts as a compatibility statement. The bare
   instruction "pin the version" does **not** count — it is an instruction, naming no
-  version. Name one and it counts, including in that same sentence:
-  ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule.
+  version. Write the pin itself and it counts, in that same sentence:
+  ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule. Be aware
+  that it is the `tool@version` syntax that carries it, not the presence of a number — a
+  prose "Pin the version to 1.2.3" matches nothing, here or in any earlier release.
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
   in either direction: by number shape (`127.1` and `0x7f.1` both resolve to real hosts, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
   10 points. Separating an address from a version by pattern turned out not to be decidable
   in either direction: by number shape (`root@127.1` and `root@0000100.1.2.3` are credited and
-  both resolve to real hosts, so any octet rule is complete only until the next form is
+  both resolve through `socket.inet_aton`, so any octet rule is complete only until the next form is
   written — and it also drops genuine four-part versions whose parts all fall in 0–255, such
   as `v8@10.2.154.26`) or by looking for a deploy command on
   the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,19 +71,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **`composability` recognises an error contract, a prerequisite and a version pin as
   facts, not as phrasings.** "Errors go to stderr with a non-zero exit" now counts as a
   declared error contract, `uv` counts as a declared prerequisite (the tool wordlist could
-  never be completed), and `tool@1.2.3` counts as a compatibility statement. A version pin
-  is a stated compatibility *fact*, so two things that merely look like one are excluded.
-  **An SSH target is not a version:** `ssh root@100.127.18.39` used to earn the credit. The
-  test is whether a deploy command (`ssh`, `scp`, `rsync`, `sftp`, `mosh`) shares the line —
-  not what the number looks like, because address forms are open-ended (`127.1`,
-  `0100.1.2.3` and `0x7f.1` all resolve to real hosts). Keying on the command means your
-  version keeps its credit whatever its shape: `v8@6.7.288.46` and `pkg@1.2.3.4.5` count,
-  and so does `v8@10.2.154.26` even though it would pass for an address. The exclusion is
-  **per line** — a file that documents a deploy command and states a version elsewhere keeps
-  the credit. **And "pin the version" on its own no longer counts:** it is an instruction,
-  naming no version. Write the version — `Pin the version in CI: \`tool@1.2.3\`` is credited,
-  as are "Compatible with protobuf 4.25.3.1" and "Requires protobuf >= 4.25.3.1". (Note the
-  operator: a bare "requires protobuf 4.25.3.1" is *not* credited, and never was.)
+  never be completed), and `tool@1.2.3` counts as a compatibility statement. The bare
+  instruction "pin the version" does **not** count — it is an instruction, naming no
+  version. Name one and it counts, including in that same sentence:
+  ``Pin the version in CI: `tool@1.2.3`.`` is credited by the `tool@version` rule.
+  **Known limit:** an SSH target is credited as a pin — `ssh root@100.127.18.39` earns the
+  10 points. Separating an address from a version by pattern turned out not to be decidable
+  in either direction: by number shape (`127.1` and `0x7f.1` both resolve to real hosts, so
+  any octet rule is complete only until the next form) or by looking for a deploy command on
+  the line (which misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1`, while
+  stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.``). Both
+  error directions cost more than the limit, so it is documented rather than papered over.
 - **`doctor` no longer counts vendored copies as installed skills.** A repo with one skill
   reported six — three of them the same file inside virtualenvs and a uv cache archive —
   inflating the skill count, the grade distribution and the headline "Total context cost"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   never be completed), and `tool@1.2.3` counts as a compatibility statement. A version pin
   is a stated compatibility *fact*, so two things that merely look like one are excluded:
   an SSH target (`ssh root@100.127.18.39` — an address, not a version) and the bare
-  instruction "pin the version", which names no version at all. The address test is a real
+  instruction "pin the version" *when it names no version*. "Pin the version to 8.8.2" still
+  counts, because it states one. The address test is a real
   IPv4 check rather than "four dot-separated parts", because four-part versions exist —
   `v8@6.7.288.46` keeps its credit, since `288` is not a valid octet. **The limit, stated
   plainly:** a four-part pin whose parts are *all* 0–255 is indistinguishable from an

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -444,10 +444,13 @@ error directions at once:
   always inside backticks;
 - it **credited** "Pin the version in step 2.1." — a step number is not a version.
 
-The field settles it: all 10 occurrences of the phrase across 2304 local `.md` files write it as
-``Pin the version in CI: `tool@version` ``, which the `@` alternative already credits. So the
-alternative is not needed at all, and a re-added one must require a version token rather than the
-phrase.
+The field settles it, and the numbers agree with the loss count above: the phrase occurs **20
+times across 9 files** in that corpus. Six of those files also carry a `tool@version` pin, which
+the `@` alternative credits on its own — so removing the phrase costs them nothing. The remaining
+**3 are the files listed above as losing the credit**, and none of them names a version anywhere:
+they are instructions (`Pin the version pair precisely`) and notes about this defect. There is no
+file in the corpus that states a version through this phrase and through nothing else, which is
+the case a phrase alternative would have to exist for.
 
 *What is deliberately NOT fixed — an SSH target is still credited as a pin.*
 `ssh root@100.127.18.39` has digits after the `@` and earns the 10 points. Four review rounds

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -433,6 +433,22 @@ both arriving in the unreleased work above, so no published score moves. Against
 one instruction (`Pin the version pair precisely`) and two notes written *about* this defect. Of
 159 installed `SKILL.md`, **0** are affected.
 
+*A narrowed phrase alternative was tried and reverted, and the reason belongs here* — the
+test docstring sends the next implementer to this section before rebuilding it. The narrowed
+form was `pin\s+the\s+version\s+(?:\w+\s+){0,4}?(?:to\s+)?v?\d+\.\d`, an attempt to keep
+crediting "Pin the version to 8.8.2" while dropping the bare phrase. Measured, it opened both
+error directions at once:
+
+- it **missed** ``Pin the version to `8.8.2`.`` — the bounded word run is `\w`-tokens separated
+  by whitespace, so any punctuation ends it, and in Markdown the version literal is almost
+  always inside backticks;
+- it **credited** "Pin the version in step 2.1." — a step number is not a version.
+
+The field settles it: all 10 occurrences of the phrase across 2304 local `.md` files write it as
+``Pin the version in CI: `tool@version` ``, which the `@` alternative already credits. So the
+alternative is not needed at all, and a re-added one must require a version token rather than the
+phrase.
+
 *What is deliberately NOT fixed — an SSH target is still credited as a pin.*
 `ssh root@100.127.18.39` has digits after the `@` and earns the 10 points. Four review rounds
 established that separating an address from a version by pattern is not decidable, and that each

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -415,7 +415,7 @@ Precision on the new shapes is 53/55. The two misses are accepted rather than fi
 obvious discriminator would be the `...`, and `go test ./...` is a real command.
 
 **Score effect:** no file's score falls. Only credit is added, never withdrawn — the same
-monotonicity property this spec's §4 relies on.
+monotonicity property this spec's Requirement 5 relies on.
 
 ## Amendment 2026-08-25 — `VERSION_COMPAT` credits the pin, not the phrase
 

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -369,8 +369,9 @@ skill, because `tests/fixtures/self-skill-baseline/SKILL.md` is scanned. A SKILL
 under `playground/.venv/lib/python3.12/site-packages/`; in a user's repo that would be
 `node_modules` and `.venv`. Next after this.
 
-`benchmarks/anti-gaming/` runs in no CI job — `grep -rn 'anti-gaming\|benchmarks' .github/ Makefile`
-returns nothing — and its own `test_benchmark.py` is red: two assertions expect 6 benchmarks where
+`benchmarks/anti-gaming/` runs in no CI job — `grep -rn 'anti-gaming\|benchmarks' .github/workflows/
+Makefile` returns nothing (the wider `.github/` does hit one line, an option label in
+`ISSUE_TEMPLATE/feature_request.yml`, which runs nothing) — and its own `test_benchmark.py` is red: two assertions expect 6 benchmarks where
 `BENCHMARKS` holds 7, and `pyproject.toml`'s `testpaths` excludes the directory, so no default run
 collects it. Until both are fixed, adding a gaming vector there buys a line nobody runs. The vector
 for the SSH-address limit (Amendment 2026-08-25) is blocked on exactly this.

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -415,7 +415,7 @@ Precision on the new shapes is 53/55. The two misses are accepted rather than fi
 obvious discriminator would be the `...`, and `go test ./...` is a real command.
 
 **Score effect:** no file's score falls. Only credit is added, never withdrawn — the same
-monotonicity property this spec's Requirement 5 relies on.
+monotonicity property Requirement 5 states.
 
 ## Amendment 2026-08-25 — `VERSION_COMPAT` credits the pin, not the phrase
 
@@ -425,13 +425,18 @@ credited the *instruction to pin*, which names no version and is therefore not t
 fact the signal is defined on. `Pin the version.` earned the full 10 points on an otherwise empty
 file.
 
-*Score effect, and why it amends Requirement 5 (monotonicity):* credit is withdrawn here, which the
-original spec's "only credit is added, never withdrawn" did not anticipate. The rule it amends is Requirement 5 ("No file's score may fall"), not Requirement 4. It holds against the
-**released** version regardless: `v8.11.1` carries neither this phrase nor the `@` alternative,
-both arriving in the unreleased work above, so no published score moves. Against the unreleased
-`main`, measured over `~/schliff` + `~/.claude`, `*.md`, 2304 files: **3 files lose the credit** —
-one instruction (`Pin the version pair precisely`) and two notes written *about* this defect. Of
-159 installed `SKILL.md`, **0** are affected.
+*Score effect, and why it amends Requirement 5 (monotonicity):* credit is withdrawn here, which
+Requirement 5 ("No file's score may fall") forbids as written, and which the 2026-08-21
+amendment's restatement — "only credit is added, never withdrawn" — did not anticipate either.
+This amends Requirement 5; it does not touch Requirement 4.
+
+It holds against the **released** version regardless: `v8.11.1` carries neither this phrase nor
+the `@` alternative, both arriving in the unreleased work above, so no published score moves.
+Against the unreleased `main`, measured over `~/schliff` + `~/.claude`, `*.md`: **3 files lose the
+credit** — one instruction (`Pin the version pair precisely`) and two notes written *about* this
+defect. Of 159 installed `SKILL.md`, **0** are affected. (That corpus is a working directory, not
+a fixture, so its file count drifts between runs — around 2300 at the time of writing. The counts
+that carry the argument are the 3 and the 0, which are enumerated above rather than sampled.)
 
 *A narrowed phrase alternative was tried and reverted, and the reason belongs here* — the
 test docstring sends the next implementer to this section before rebuilding it. The narrowed

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -369,6 +369,12 @@ skill, because `tests/fixtures/self-skill-baseline/SKILL.md` is scanned. A SKILL
 under `playground/.venv/lib/python3.12/site-packages/`; in a user's repo that would be
 `node_modules` and `.venv`. Next after this.
 
+`benchmarks/anti-gaming/` runs in no CI job — `grep -rn 'anti-gaming\|benchmarks' .github/ Makefile`
+returns nothing — and its own `test_benchmark.py` is red: two assertions expect 6 benchmarks where
+`BENCHMARKS` holds 7, and `pyproject.toml`'s `testpaths` excludes the directory, so no default run
+collects it. Until both are fixed, adding a gaming vector there buys a line nobody runs. The vector
+for the SSH-address limit (Amendment 2026-08-25) is blocked on exactly this.
+
 Two smaller items, unowned: `commands/schliff/analyze.md` step 7 documents
 `run-eval.sh <skill> --eval-suite <suite>`, which exits `Error: unknown option --eval-suite` — the
 real signature is positional. And `doctor`'s "Total context cost" sums SKILL.md plus
@@ -434,7 +440,9 @@ It holds against the **released** version regardless: `v8.11.1` carries neither 
 the `@` alternative, both arriving in the unreleased work above, so no published score moves.
 Against the unreleased `main`, measured over `~/schliff` + `~/.claude`, `*.md`: **3 files lose the
 credit** — one instruction (`Pin the version pair precisely`) and two notes written *about* this
-defect. Of 159 installed `SKILL.md`, **0** are affected. (That corpus is a working directory, not
+defect. Of the installed skills under `~/.claude` — **159** `SKILL.md` at this HEAD, against the 299
+the Result section above records, because the vendored-copy filter in this same unreleased block
+stopped counting cache and virtualenv duplicates — **0** are affected. (That corpus is a working directory, not
 a fixture, so its file count drifts between runs — around 2300 at the time of writing. The counts
 that carry the argument are the 3 and the 0, which are enumerated above rather than sampled.)
 
@@ -474,5 +482,5 @@ the limit is documented at the pattern and in the CHANGELOG, and pinned by a tes
 current behaviour. The honest-pin counter-example is asserted in the *positive* set, so it
 survives the deletion of that limit test if an exclusion is ever made to work.
 
-The gaming vector belongs in `benchmarks/anti-gaming/` and is not added yet: that harness runs in
-no CI job, and `test_benchmark.py` is red (two assertions expect 6 benchmarks where 7 exist).
+The gaming vector for this limit is listed under
+[Follow-up](#follow-up-agreed-but-not-in-this-branch), with the reason it is not added yet.

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -425,8 +425,8 @@ credited the *instruction to pin*, which names no version and is therefore not t
 fact the signal is defined on. `Pin the version.` earned the full 10 points on an otherwise empty
 file.
 
-*Score effect, and why it does not break §4's monotonicity:* credit is withdrawn here, which the
-original spec's "only credit is added, never withdrawn" did not anticipate. It holds against the
+*Score effect, and why it amends Requirement 5 (monotonicity):* credit is withdrawn here, which the
+original spec's "only credit is added, never withdrawn" did not anticipate. The rule it amends is Requirement 5 ("No file's score may fall"), not Requirement 4. It holds against the
 **released** version regardless: `v8.11.1` carries neither this phrase nor the `@` alternative,
 both arriving in the unreleased work above, so no published score moves. Against the unreleased
 `main`, measured over `~/schliff` + `~/.claude`, `*.md`, 2304 files: **3 files lose the credit** —
@@ -440,7 +440,7 @@ candidate discriminator fails where the other does not:
 
 | discriminator | fails on |
 | --- | --- |
-| IPv4 shape (octet ranges, bounded padding) | `socket.inet_aton` resolves `127.1`, `0x7f.1` and `0000100.1.2.3` to real hosts, so any shape rule is complete only until the next form is written |
+| IPv4 shape (octet ranges, bounded padding) | `root@127.1` and `root@0000100.1.2.3` are credited today and both resolve through `socket.inet_aton`, so any shape rule is complete only until the next form is written — and it drops genuine four-part versions whose parts all fall in 0-255 (`v8@10.2.154.26`) |
 | a deploy command on the same line | misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1` — both caught by the shape rule — while stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.`` |
 
 Two successive shape attempts closed zero-padding at three and then six characters; seven was

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -416,3 +416,39 @@ obvious discriminator would be the `...`, and `go test ./...` is a real command.
 
 **Score effect:** no file's score falls. Only credit is added, never withdrawn — the same
 monotonicity property this spec's §4 relies on.
+
+## Amendment 2026-08-25 — `VERSION_COMPAT` credits the pin, not the phrase
+
+*What changed:* the `pin\s+the\s+version` alternative is removed. Requirement 4 above says the
+detector "recognises a version pin (`tool@1.2.3`)"; the phrase alternative went further and
+credited the *instruction to pin*, which names no version and is therefore not the compatibility
+fact the signal is defined on. `Pin the version.` earned the full 10 points on an otherwise empty
+file.
+
+*Score effect, and why it does not break §4's monotonicity:* credit is withdrawn here, which the
+original spec's "only credit is added, never withdrawn" did not anticipate. It holds against the
+**released** version regardless: `v8.11.1` carries neither this phrase nor the `@` alternative,
+both arriving in the unreleased work above, so no published score moves. Against the unreleased
+`main`, measured over `~/schliff` + `~/.claude`, `*.md`, 2304 files: **3 files lose the credit** —
+one instruction (`Pin the version pair precisely`) and two notes written *about* this defect. Of
+159 installed `SKILL.md`, **0** are affected.
+
+*What is deliberately NOT fixed — an SSH target is still credited as a pin.*
+`ssh root@100.127.18.39` has digits after the `@` and earns the 10 points. Four review rounds
+established that separating an address from a version by pattern is not decidable, and that each
+candidate discriminator fails where the other does not:
+
+| discriminator | fails on |
+| --- | --- |
+| IPv4 shape (octet ranges, bounded padding) | `socket.inet_aton` resolves `127.1`, `0x7f.1` and `0000100.1.2.3` to real hosts, so any shape rule is complete only until the next form is written |
+| a deploy command on the same line | misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1` — both caught by the shape rule — while stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.`` |
+
+Two successive shape attempts closed zero-padding at three and then six characters; seven was
+never reached. The command-wordlist attempt was worse than the shape rule in **both** directions
+and was reverted. Withholding the point from an honest file costs more than the limit does, so
+the limit is documented at the pattern and in the CHANGELOG, and pinned by a test that asserts
+current behaviour. The honest-pin counter-example is asserted in the *positive* set, so it
+survives the deletion of that limit test if an exclusion is ever made to work.
+
+The gaming vector belongs in `benchmarks/anti-gaming/` and is not added yet: that harness runs in
+no CI job, and `test_benchmark.py` is red (two assertions expect 6 benchmarks where 7 exist).

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -149,8 +149,9 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # points this signal is worth. Deliberate, not an oversight. The bare phrase
 # `pin the version` was removed for naming no version at all.
 #
-# WHY, both attempted fixes and every measurement: docs/specs/2026-08-13-structural-signal-
-# detection.md, "Amendment 2026-08-25". That is the single home, enforced by
+# WHY, both attempted fixes and every measurement live in one place:
+# `docs/specs/2026-08-13-structural-signal-detection.md`, "Amendment 2026-08-25".
+# That single home is enforced by
 # test_version_pin_limit_stated_once.py — this reasoning had four homes and four review
 # rounds each found one out of step, the failure #209 fixed for the cadence rule.
 _RE_VERSION_COMPAT = re.compile(

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -156,7 +156,16 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # shape alone and loses the credit. That is the conservative direction for a scorer —
 # withholding credit costs an author points, granting it wrongly is free score for anyone
 # who writes a deploy command.
-_IPV4_OCTET = r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
+# Leading zeros are ACCEPTED on purpose. `ssh root@010.1.2.3` connects, so it is a real
+# deploy command — a strict-form octet class (`[1-9]?\d`) would reject `010` and hand that
+# line the free +10 this exclusion exists to withdraw. The job here is recognising a deploy
+# target, not validating a canonical address, so the class is permissive on shape and strict
+# on the 255 ceiling, which is what keeps `288` a version.
+_IPV4_OCTET = r"(?:25[0-5]|2[0-4]\d|[01]?\d?\d)"
+# The trailing guard is load-bearing: without it the lookahead matches the first four parts
+# of a LONGER dotted version, so `pkg@1.2.3.4.5` would lose its credit to an address test.
+# Five parts is not an address. Covered by a positive fixture, since deleting this guard
+# otherwise leaves the suite fully green.
 _IPV4 = rf"{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}(?!\.?\d)"
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -159,8 +159,9 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 #     the credit from an honest "Deploy over ssh; pin `ruff@0.4.2` in CI."
 #
 # Withholding the point from an honest file costs more than the limit does, and no
-# attempted rule avoided that cost. Same treatment as the bare-`stderr` limit above
-# (:87) and the option-shape limit in `base.py`: documented, not papered over.
+# attempted rule avoided that cost. Same treatment as the KNOWN LIMIT on
+# `_RE_ERROR_BEHAVIOR` above and the option-shape limit in `base.py`: documented,
+# not papered over.
 #
 # REVISIT IF: the scorer gains fenced-block language, which would separate a shell block
 # from prose without enumerating number forms or command names. The gaming vector belongs

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -146,23 +146,14 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # and keeps the pattern linear.
 #
 # KNOWN LIMIT — an SSH target is credited as a pin: `ssh root@100.127.18.39` earns the 10
-# points this signal is worth. Not fixed: two discriminators were tried, and each cost an
-# honest file its point, which is worse than the limit itself.
+# points this signal is worth. Two discriminators were tried and both cost an honest file its
+# point, which is worse than the limit itself; the bare phrase `pin the version` was removed
+# for naming no version at all.
 #
-#   - By NUMBER SHAPE: the octet rule cannot be completed — `root@127.1` and
-#     `root@0000100.1.2.3` are credited today and both resolve through `inet_aton`. It
-#     also drops genuine four-part versions whose parts all fall in 0-255
-#     (`v8@10.2.154.26`, `zlib@1.2.13.1`), which are indistinguishable by shape.
-#   - By DEPLOY COMMAND on the line: a wordlist misses `git clone git@10.0.0.5` and
-#     `curl http://admin@192.168.1.1`, and strips the credit from an honest
-#     "Deploy over ssh; pin `ruff@0.4.2` in CI." — asserted in the POSITIVE set of
-#     test_composability_structural_signals.py, so it outlives that file's limit test,
-#     which carries an instruction to delete it once an exclusion works.
-#
-# Same treatment as the KNOWN LIMIT on `_RE_ERROR_BEHAVIOR` above. Full history, including
-# the two abandoned attempts, in docs/specs/2026-08-13-structural-signal-detection.md. The
-# gaming vector waits on `benchmarks/anti-gaming/`, which runs in no CI job and whose own
-# test is red (two assertions expect 6 benchmarks where 7 exist).
+# ONE HOME for the reasoning, both failed attempts and the field measurements:
+# docs/specs/2026-08-13-structural-signal-detection.md, "Amendment 2026-08-25". Do not
+# restate it here — this comment had four homes and every review round found one of them
+# out of step with the others, the same failure #209 fixed for the cadence rule.
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -146,14 +146,13 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # and keeps the pattern linear.
 #
 # KNOWN LIMIT — an SSH target is credited as a pin: `ssh root@100.127.18.39` earns the 10
-# points this signal is worth. Two discriminators were tried and both cost an honest file its
-# point, which is worse than the limit itself; the bare phrase `pin the version` was removed
-# for naming no version at all.
+# points this signal is worth. Deliberate, not an oversight. The bare phrase
+# `pin the version` was removed for naming no version at all.
 #
-# ONE HOME for the reasoning, both failed attempts and the field measurements:
-# docs/specs/2026-08-13-structural-signal-detection.md, "Amendment 2026-08-25". Do not
-# restate it here — this comment had four homes and every review round found one of them
-# out of step with the others, the same failure #209 fixed for the cadence rule.
+# WHY, both attempted fixes and every measurement: docs/specs/2026-08-13-structural-signal-
+# detection.md, "Amendment 2026-08-25". That is the single home, enforced by
+# test_version_pin_limit_stated_once.py — this reasoning had four homes and four review
+# rounds each found one out of step, the failure #209 fixed for the cadence rule.
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -146,27 +146,22 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # and keeps the pattern linear.
 #
 # KNOWN LIMIT — an SSH target is credited as a pin: `ssh root@100.127.18.39` earns the 10
-# points this signal is worth. It is recorded rather than fixed, because neither available
-# discriminator is decidable, and each fails where the other does not. Counter-examples,
-# not statistics, because these reproduce anywhere:
+# points this signal is worth. Not fixed: two discriminators were tried, and each cost an
+# honest file its point, which is worse than the limit itself.
 #
-#   - By NUMBER SHAPE: `socket.inet_aton` resolves `127.1`, `0x7f.1` and `0000100.1.2.3`
-#     to real hosts, so an octet rule is complete only until the next form is written.
-#     Two attempts on this pattern closed zero-padding at three and then six characters;
-#     seven was never reached.
+#   - By NUMBER SHAPE: the octet rule cannot be completed — `root@127.1` and
+#     `root@0000100.1.2.3` are credited today and both resolve through `inet_aton`. It
+#     also drops genuine four-part versions whose parts all fall in 0-255
+#     (`v8@10.2.154.26`, `zlib@1.2.13.1`), which are indistinguishable by shape.
 #   - By DEPLOY COMMAND on the line: a wordlist misses `git clone git@10.0.0.5` and
-#     `curl http://admin@192.168.1.1` — both caught by the shape rule — while stripping
-#     the credit from an honest "Deploy over ssh; pin `ruff@0.4.2` in CI."
+#     `curl http://admin@192.168.1.1`, and strips the credit from an honest
+#     "Deploy over ssh; pin `ruff@0.4.2` in CI." — asserted in the positive set of
+#     test_composability_structural_signals.py so it outlives the limit test below.
 #
-# Withholding the point from an honest file costs more than the limit does, and no
-# attempted rule avoided that cost. Same treatment as the KNOWN LIMIT on
-# `_RE_ERROR_BEHAVIOR` above and the option-shape limit in `base.py`: documented,
-# not papered over.
-#
-# REVISIT IF: the scorer gains fenced-block language, which would separate a shell block
-# from prose without enumerating number forms or command names. The gaming vector belongs
-# in `benchmarks/anti-gaming/` and is not added yet — that harness runs in no CI job and
-# `test_benchmark.py` is red today (two assertions expect 6 benchmarks where 7 exist).
+# Same treatment as the KNOWN LIMIT on `_RE_ERROR_BEHAVIOR` above. Full history, including
+# the two abandoned attempts, in docs/specs/2026-08-13-structural-signal-detection.md. The
+# gaming vector waits on `benchmarks/anti-gaming/`, which runs in no CI job and whose own
+# test is red (two assertions expect 6 benchmarks where 7 exist).
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -155,8 +155,9 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 #     (`v8@10.2.154.26`, `zlib@1.2.13.1`), which are indistinguishable by shape.
 #   - By DEPLOY COMMAND on the line: a wordlist misses `git clone git@10.0.0.5` and
 #     `curl http://admin@192.168.1.1`, and strips the credit from an honest
-#     "Deploy over ssh; pin `ruff@0.4.2` in CI." — asserted in the positive set of
-#     test_composability_structural_signals.py so it outlives the limit test below.
+#     "Deploy over ssh; pin `ruff@0.4.2` in CI." — asserted in the POSITIVE set of
+#     test_composability_structural_signals.py, so it outlives that file's limit test,
+#     which carries an instruction to delete it once an exclusion works.
 #
 # Same treatment as the KNOWN LIMIT on `_RE_ERROR_BEHAVIOR` above. Full history, including
 # the two abandoned attempts, in docs/specs/2026-08-13-structural-signal-detection.md. The

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -161,16 +161,29 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # line the free +10 this exclusion exists to withdraw. The job here is recognising a deploy
 # target, not validating a canonical address, so the class is permissive on shape and strict
 # on the 255 ceiling, which is what keeps `288` a version.
-_IPV4_OCTET = r"(?:25[0-5]|2[0-4]\d|[01]?\d?\d)"
+#
+# The zero run is a BOUNDED prefix rather than part of the digit class, because padding is
+# not limited to three characters: `inet_aton` resolves `0100.1.2.3` to 64.1.2.3 and
+# `00010.1.2.3` to 8.1.2.3, so both connect and both must be excluded. `0{0,3}` covers the
+# padding widths that occur while staying linear — an unbounded `0*` would put a second
+# quantifier in front of an already-quantified class and give the linearity gate a reason
+# to complain. No real version has a four-digit zero-padded part.
+_IPV4_OCTET = r"(?:0{0,3})(?:25[0-5]|2[0-4]\d|[01]?\d?\d)"
 # The trailing guard is load-bearing: without it the lookahead matches the first four parts
 # of a LONGER dotted version, so `pkg@1.2.3.4.5` would lose its credit to an address test.
 # Five parts is not an address. Covered by a positive fixture, since deleting this guard
 # otherwise leaves the suite fully green.
 _IPV4 = rf"{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}(?!\.?\d)"
+# "Pin the version" is NARROWED, not deleted. The defect was that the bare imperative — an
+# instruction naming no version — counted as a stated compatibility fact. "Pin the version
+# to 8.8.2" does name one, and no other alternative picks it up (`version\s*[><=!]` needs an
+# operator), so deleting the alternative outright would drop a real fact. The intervening
+# word run is bounded, which keeps it linear.
+_PIN_TO_VERSION = r"pin\s+the\s+version\s+(?:\w+\s+){0,4}?(?:to\s+)?v?\d+\.\d"
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"
-    r"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|"
+    rf"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|{_PIN_TO_VERSION}|"
     rf"[\w.-]{{1,64}}@(?!{_IPV4})\d+\.\d+)"
 )
 

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -156,35 +156,36 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # shape alone and loses the credit. That is the conservative direction for a scorer —
 # withholding credit costs an author points, granting it wrongly is free score for anyone
 # who writes a deploy command.
-# Leading zeros are ACCEPTED on purpose. `ssh root@010.1.2.3` connects, so it is a real
-# deploy command — a strict-form octet class (`[1-9]?\d`) would reject `010` and hand that
-# line the free +10 this exclusion exists to withdraw. The job here is recognising a deploy
-# target, not validating a canonical address, so the class is permissive on shape and strict
-# on the 255 ceiling, which is what keeps `288` a version.
+# What the `@` shape does NOT keep out is an SSH target: `ssh root@100.127.18.39` has digits
+# after the `@` and was credited as a pin (measured: composability 20 -> 30 for free).
 #
-# The zero run is a BOUNDED prefix rather than part of the digit class, because padding is
-# not limited to three characters: `inet_aton` resolves `0100.1.2.3` to 64.1.2.3 and
-# `00010.1.2.3` to 8.1.2.3, so both connect and both must be excluded. `0{0,3}` covers the
-# padding widths that occur while staying linear — an unbounded `0*` would put a second
-# quantifier in front of an already-quantified class and give the linearity gate a reason
-# to complain. No real version has a four-digit zero-padded part.
-_IPV4_OCTET = r"(?:0{0,3})(?:25[0-5]|2[0-4]\d|[01]?\d?\d)"
-# The trailing guard is load-bearing: without it the lookahead matches the first four parts
-# of a LONGER dotted version, so `pkg@1.2.3.4.5` would lose its credit to an address test.
-# Five parts is not an address. Covered by a positive fixture, since deleting this guard
-# otherwise leaves the suite fully green.
-_IPV4 = rf"{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}(?!\.?\d)"
-# "Pin the version" is NARROWED, not deleted. The defect was that the bare imperative — an
-# instruction naming no version — counted as a stated compatibility fact. "Pin the version
-# to 8.8.2" does name one, and no other alternative picks it up (`version\s*[><=!]` needs an
-# operator), so deleting the alternative outright would drop a real fact. The intervening
-# word run is bounded, which keeps it linear.
-_PIN_TO_VERSION = r"pin\s+the\s+version\s+(?:\w+\s+){0,4}?(?:to\s+)?v?\d+\.\d"
+# The discriminator is the COMMAND, not the shape of the number. Three rounds of review
+# established that "does this look like an address" is not decidable by pattern: `inet_aton`
+# resolves `127.1` to 127.0.0.1, `0000100.1.2.3` to 64.1.2.3, and `0x7f.1` to 127.0.0.1, so
+# every shape rule — four parts, octet ranges, bounded zero padding — is complete only until
+# someone writes the next form. Each round closed one width and left the next one open.
+#
+# A deploy command on the same line is decidable, and it is what actually separates the two
+# in the field: measured over 2304 local `.md` files, all 28 `user@number` occurrences on a
+# line carrying ssh/scp/rsync are addresses, and all 40 without one are versions
+# (`iconv@2.1.4`, `acorn@5.2`, `v8@6.7.288.46`). No shape arithmetic is needed, and the
+# number is never inspected — which is why `127.1` and `0x7f.1` need no special case.
+#
+# The tempered run is bounded to one line by `[^\n]` and measured linear (~2.0x per
+# doubling), so the ReDoS gate is satisfied without an octet class.
+_DEPLOY_CMD = r"(?:ssh|scp|rsync|sftp|ssh-copy-id|mosh)"
+_AT_PIN = rf"^(?:(?!\b{_DEPLOY_CMD}\b)[^\n])*?[\w.-]{{1,64}}@\d+\.\d+"
+# `pin the version` is GONE as an alternative rather than narrowed. It was added for
+# schliff's own line, and narrowing it opened both error directions at once: it missed
+# `Pin the version to `8.8.2`.` (punctuation ends the word run) while crediting
+# `Pin the version in step 2.1.` (a step number is not a version). The field says it is not
+# needed — all 10 occurrences of the phrase across 2304 local `.md` files write it as
+# `Pin the version in CI: `tool@version``, which the `@` alternative already credits.
 _RE_VERSION_COMPAT = re.compile(
-    r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
+    r"(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"
-    rf"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|{_PIN_TO_VERSION}|"
-    rf"[\w.-]{{1,64}}@(?!{_IPV4})\d+\.\d+)"
+    rf"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|{_AT_PIN})",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 # --- Trigger patterns (SKILL.md-specific) ---

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -144,11 +144,25 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # exists). 64 covers the longest real package name by a wide margin
 # (`@vercel/microfrontends` is 22); a bounded run costs O(bound) per start position
 # and keeps the pattern linear.
+#
+# What the `@` shape does NOT keep out is an SSH target: `ssh root@100.127.18.39` has
+# digits after the `@` and was credited as a pin (measured: composability 20 -> 30 for
+# free). The discriminator is a real IPv4 test — four 0-255 octets — not "four dot-parts",
+# because four-part VERSIONS are real: V8 numbers itself `6.7.288.46`, and `288` is not a
+# valid octet, so the octet test keeps that pin while dropping the address.
+#
+# Known limit, stated rather than hidden: a four-part version whose every part happens to
+# be 0-255 (`v8@10.2.154.26`, `zlib@1.2.13.1`) is indistinguishable from an address by
+# shape alone and loses the credit. That is the conservative direction for a scorer —
+# withholding credit costs an author points, granting it wrongly is free score for anyone
+# who writes a deploy command.
+_IPV4_OCTET = r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
+_IPV4 = rf"{_IPV4_OCTET}(?:\.{_IPV4_OCTET}){{3}}(?!\.?\d)"
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"
     r"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|"
-    r"[\w.-]{1,64}@\d+\.\d+|pin\s+the\s+version)"
+    rf"[\w.-]{{1,64}}@(?!{_IPV4})\d+\.\d+)"
 )
 
 # --- Trigger patterns (SKILL.md-specific) ---

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -146,14 +146,20 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # and keeps the pattern linear.
 #
 # KNOWN LIMIT — an SSH target is credited as a pin. `ssh root@100.127.18.39` has digits
-# after the `@` and earns the 10 points this signal is worth. It is recorded here rather
-# than fixed, because four rounds of review established that separating the two by pattern
-# is not decidable, in either direction:
+# after the `@` and earns the 10 points this signal is worth.
+#
+# How often it fires: measured over 2304 local `.md` files, 28 lines carry a
+# `user@<number>` next to a deploy command (ssh/scp/rsync) — every one of them an address.
+# The other 40 `user@<number>` lines carry no deploy command and are all genuine versions
+# (`iconv@2.1.4`, `acorn@5.2`, `v8@6.7.288.46`). So the limit is live, not theoretical.
+#
+# It is recorded rather than fixed because separating the two by pattern is not decidable,
+# in either direction — established by review, with counter-examples, not by argument:
 #
 #   - By NUMBER SHAPE: `inet_aton` resolves `127.1` to 127.0.0.1, `0000100.1.2.3` to
 #     64.1.2.3 and `0x7f.1` to 127.0.0.1, so an octet rule is complete only until someone
-#     writes the next form. Three successive attempts each closed one width — 3-digit
-#     padding, then 6, then 7 — and left the next open.
+#     writes the next form. Two attempts closed padding at three and then six characters;
+#     seven was never reached, which is why `0000100.1.2.3` above still defeats the rule.
 #   - By COMMAND on the line: the wordlist has the identical property. `ssh|scp|rsync`
 #     misses `git clone git@10.0.0.5`, `psql postgres://admin@10.0.0.5` and
 #     `curl http://admin@192.168.1.1`, all of which the shape rule caught — while
@@ -162,10 +168,18 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 #
 # Both directions of error are worse than the limit itself: withholding credit from an
 # honest file is a real cost, and no attempted discriminator avoided it. This follows the
-# treatment already given to the assertion-credit limit — documented, with a benchmark
-# vector, rather than fixed by a rule that cannot be made correct. Add the gaming vector
-# to `benchmarks/anti-gaming/` once that harness actually runs and its `caught` predicate
-# is bound to the detection field.
+# treatment already given to the assertion-credit limit — documented rather than fixed by
+# a rule that cannot be made correct.
+#
+# REVISIT IF: a discriminator appears that needs neither a number-shape rule nor a command
+# wordlist — for example a scorer that sees the fenced-block language, which would separate
+# a shell block from prose without enumerating anything.
+#
+# The gaming vector belongs in `benchmarks/anti-gaming/`, and is NOT added yet because that
+# harness cannot currently report it: it runs in no CI job (`.github/workflows/test.yml`
+# collects `tests/unit/` only), and `pytest benchmarks/anti-gaming/test_benchmark.py` is red
+# today — `test_six_benchmarks_defined` and `test_returns_list` both assert 6 where 7 exist.
+# Adding a vector before that is fixed buys a line nobody runs.
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -145,41 +145,27 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # (`@vercel/microfrontends` is 22); a bounded run costs O(bound) per start position
 # and keeps the pattern linear.
 #
-# KNOWN LIMIT — an SSH target is credited as a pin. `ssh root@100.127.18.39` has digits
-# after the `@` and earns the 10 points this signal is worth.
+# KNOWN LIMIT — an SSH target is credited as a pin: `ssh root@100.127.18.39` earns the 10
+# points this signal is worth. It is recorded rather than fixed, because neither available
+# discriminator is decidable, and each fails where the other does not. Counter-examples,
+# not statistics, because these reproduce anywhere:
 #
-# How often it fires: measured over 2304 local `.md` files, 28 lines carry a
-# `user@<number>` next to a deploy command (ssh/scp/rsync) — every one of them an address.
-# The other 40 `user@<number>` lines carry no deploy command and are all genuine versions
-# (`iconv@2.1.4`, `acorn@5.2`, `v8@6.7.288.46`). So the limit is live, not theoretical.
+#   - By NUMBER SHAPE: `socket.inet_aton` resolves `127.1`, `0x7f.1` and `0000100.1.2.3`
+#     to real hosts, so an octet rule is complete only until the next form is written.
+#     Two attempts on this pattern closed zero-padding at three and then six characters;
+#     seven was never reached.
+#   - By DEPLOY COMMAND on the line: a wordlist misses `git clone git@10.0.0.5` and
+#     `curl http://admin@192.168.1.1` — both caught by the shape rule — while stripping
+#     the credit from an honest "Deploy over ssh; pin `ruff@0.4.2` in CI."
 #
-# It is recorded rather than fixed because separating the two by pattern is not decidable,
-# in either direction — established by review, with counter-examples, not by argument:
+# Withholding the point from an honest file costs more than the limit does, and no
+# attempted rule avoided that cost. Same treatment as the bare-`stderr` limit above
+# (:87) and the option-shape limit in `base.py`: documented, not papered over.
 #
-#   - By NUMBER SHAPE: `inet_aton` resolves `127.1` to 127.0.0.1, `0000100.1.2.3` to
-#     64.1.2.3 and `0x7f.1` to 127.0.0.1, so an octet rule is complete only until someone
-#     writes the next form. Two attempts closed padding at three and then six characters;
-#     seven was never reached, which is why `0000100.1.2.3` above still defeats the rule.
-#   - By COMMAND on the line: the wordlist has the identical property. `ssh|scp|rsync`
-#     misses `git clone git@10.0.0.5`, `psql postgres://admin@10.0.0.5` and
-#     `curl http://admin@192.168.1.1`, all of which the shape rule caught — while
-#     simultaneously destroying honest pins, since "Deploy over ssh; pin `ruff@0.4.2`"
-#     loses its credit to the word `ssh` sitting earlier in the sentence.
-#
-# Both directions of error are worse than the limit itself: withholding credit from an
-# honest file is a real cost, and no attempted discriminator avoided it. This follows the
-# treatment already given to the assertion-credit limit — documented rather than fixed by
-# a rule that cannot be made correct.
-#
-# REVISIT IF: a discriminator appears that needs neither a number-shape rule nor a command
-# wordlist — for example a scorer that sees the fenced-block language, which would separate
-# a shell block from prose without enumerating anything.
-#
-# The gaming vector belongs in `benchmarks/anti-gaming/`, and is NOT added yet because that
-# harness cannot currently report it: it runs in no CI job (`.github/workflows/test.yml`
-# collects `tests/unit/` only), and `pytest benchmarks/anti-gaming/test_benchmark.py` is red
-# today — `test_six_benchmarks_defined` and `test_returns_list` both assert 6 where 7 exist.
-# Adding a vector before that is fixed buys a line nobody runs.
+# REVISIT IF: the scorer gains fenced-block language, which would separate a shell block
+# from prose without enumerating number forms or command names. The gaming vector belongs
+# in `benchmarks/anti-gaming/` and is not added yet — that harness runs in no CI job and
+# `test_benchmark.py` is red today (two assertions expect 6 benchmarks where 7 exist).
 _RE_VERSION_COMPAT = re.compile(
     r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"

--- a/skills/schliff/scripts/scoring/patterns/skill_md.py
+++ b/skills/schliff/scripts/scoring/patterns/skill_md.py
@@ -145,47 +145,32 @@ _RE_NAMESPACE_ISOLATION = re.compile(
 # (`@vercel/microfrontends` is 22); a bounded run costs O(bound) per start position
 # and keeps the pattern linear.
 #
-# What the `@` shape does NOT keep out is an SSH target: `ssh root@100.127.18.39` has
-# digits after the `@` and was credited as a pin (measured: composability 20 -> 30 for
-# free). The discriminator is a real IPv4 test — four 0-255 octets — not "four dot-parts",
-# because four-part VERSIONS are real: V8 numbers itself `6.7.288.46`, and `288` is not a
-# valid octet, so the octet test keeps that pin while dropping the address.
+# KNOWN LIMIT — an SSH target is credited as a pin. `ssh root@100.127.18.39` has digits
+# after the `@` and earns the 10 points this signal is worth. It is recorded here rather
+# than fixed, because four rounds of review established that separating the two by pattern
+# is not decidable, in either direction:
 #
-# Known limit, stated rather than hidden: a four-part version whose every part happens to
-# be 0-255 (`v8@10.2.154.26`, `zlib@1.2.13.1`) is indistinguishable from an address by
-# shape alone and loses the credit. That is the conservative direction for a scorer —
-# withholding credit costs an author points, granting it wrongly is free score for anyone
-# who writes a deploy command.
-# What the `@` shape does NOT keep out is an SSH target: `ssh root@100.127.18.39` has digits
-# after the `@` and was credited as a pin (measured: composability 20 -> 30 for free).
+#   - By NUMBER SHAPE: `inet_aton` resolves `127.1` to 127.0.0.1, `0000100.1.2.3` to
+#     64.1.2.3 and `0x7f.1` to 127.0.0.1, so an octet rule is complete only until someone
+#     writes the next form. Three successive attempts each closed one width — 3-digit
+#     padding, then 6, then 7 — and left the next open.
+#   - By COMMAND on the line: the wordlist has the identical property. `ssh|scp|rsync`
+#     misses `git clone git@10.0.0.5`, `psql postgres://admin@10.0.0.5` and
+#     `curl http://admin@192.168.1.1`, all of which the shape rule caught — while
+#     simultaneously destroying honest pins, since "Deploy over ssh; pin `ruff@0.4.2`"
+#     loses its credit to the word `ssh` sitting earlier in the sentence.
 #
-# The discriminator is the COMMAND, not the shape of the number. Three rounds of review
-# established that "does this look like an address" is not decidable by pattern: `inet_aton`
-# resolves `127.1` to 127.0.0.1, `0000100.1.2.3` to 64.1.2.3, and `0x7f.1` to 127.0.0.1, so
-# every shape rule — four parts, octet ranges, bounded zero padding — is complete only until
-# someone writes the next form. Each round closed one width and left the next one open.
-#
-# A deploy command on the same line is decidable, and it is what actually separates the two
-# in the field: measured over 2304 local `.md` files, all 28 `user@number` occurrences on a
-# line carrying ssh/scp/rsync are addresses, and all 40 without one are versions
-# (`iconv@2.1.4`, `acorn@5.2`, `v8@6.7.288.46`). No shape arithmetic is needed, and the
-# number is never inspected — which is why `127.1` and `0x7f.1` need no special case.
-#
-# The tempered run is bounded to one line by `[^\n]` and measured linear (~2.0x per
-# doubling), so the ReDoS gate is satisfied without an octet class.
-_DEPLOY_CMD = r"(?:ssh|scp|rsync|sftp|ssh-copy-id|mosh)"
-_AT_PIN = rf"^(?:(?!\b{_DEPLOY_CMD}\b)[^\n])*?[\w.-]{{1,64}}@\d+\.\d+"
-# `pin the version` is GONE as an alternative rather than narrowed. It was added for
-# schliff's own line, and narrowing it opened both error directions at once: it missed
-# `Pin the version to `8.8.2`.` (punctuation ends the word run) while crediting
-# `Pin the version in step 2.1.` (a step number is not a version). The field says it is not
-# needed — all 10 occurrences of the phrase across 2304 local `.md` files write it as
-# `Pin the version in CI: `tool@version``, which the `@` alternative already credits.
+# Both directions of error are worse than the limit itself: withholding credit from an
+# honest file is a real cost, and no attempted discriminator avoided it. This follows the
+# treatment already given to the assertion-credit limit — documented, with a benchmark
+# vector, rather than fixed by a rule that cannot be made correct. Add the gaming vector
+# to `benchmarks/anti-gaming/` once that harness actually runs and its `caught` predicate
+# is bound to the detection field.
 _RE_VERSION_COMPAT = re.compile(
-    r"(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
+    r"(?i)(version\s*[><=!]+\s*[\d.]+|compatible\s+with\s+\w+\s+v?\d|"
     r"requires?\s+\w+\s*[><=]+\s*[\d.]+|minimum\s+version|"
-    rf"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|{_AT_PIN})",
-    re.IGNORECASE | re.MULTILINE,
+    r"supported\s+versions?|works\s+with\s+\w+\s+v?\d+\.\d+|"
+    r"[\w.-]{1,64}@\d+\.\d+)"
 )
 
 # --- Trigger patterns (SKILL.md-specific) ---

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -142,13 +142,30 @@ class TestVersionCompatibility:
         "Pin the version.",
         "Pin the version before release.",
         "Pin the version in step 2.1.",
-        # CHANGELOG states this matches nothing. Without the case, a re-added
-        # phrase alternative would leave the suite green and the CHANGELOG
-        # documenting behaviour the code no longer has.
-        "Pin the version to 1.2.3.",
     ])
     def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
+
+    def test_the_phrase_with_a_version_is_currently_not_credited(self):
+        """CURRENT BEHAVIOUR, not a required property. Change it if you must.
+
+        Nothing credits "Pin the version to 1.2.3" today, and CHANGELOG says so,
+        which is why this is pinned: a re-added phrase alternative would
+        otherwise leave the suite green while the CHANGELOG described behaviour
+        the code no longer had.
+
+        But do not read it as a rule that the form MUST stay uncredited. The
+        spec records the reverted narrowed alternative's failure to credit
+        ``Pin the version to `8.8.2`.`` as one of its two error directions — so
+        a genuinely correct prose alternative, crediting the backticked and the
+        plain form alike, would be an improvement and would land here as a red
+        test. Update this test and the CHANGELOG line together in that case.
+
+        The form does not occur in the field: measured over the local corpus,
+        every "pin the version … <version>" line without a `tool@version` beside
+        it was documentation about this very defect.
+        """
+        assert not _RE_VERSION_COMPAT.search("Pin the version to 1.2.3.")
 
     def test_an_ssh_target_is_still_credited_known_limit(self):
         """Documents behaviour this pattern deliberately does NOT fix.

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -103,14 +103,18 @@ class TestVersionCompatibility:
         "Requires node >= 18.0",
         "Minimum version 3.9.",
         "Compatible with Python 3.12",
-        # An honest pin on a line that also mentions a deploy command. This is
-        # the counter-example the SSH limit below rests on: a command-wordlist
-        # exclusion would strip this file's credit. It lives HERE, in the
-        # positive set, on purpose — the limit test below carries an
-        # instruction to delete it once an exclusion works, and after that
-        # deletion this assertion is the only thing left that notices if the
-        # new exclusion takes honest pins with it.
+        # The two honest pins each attempted exclusion would have destroyed.
+        # They live HERE, in the positive set, on purpose: the limit test below
+        # carries an instruction to delete it once an exclusion works, and after
+        # that deletion these are the only assertions left that notice a new
+        # exclusion taking real pins with it. One per error direction, because
+        # covering only the wordlist would leave the shape rule unguarded.
+        #
+        # a wordlist keyed on `ssh` would strip this:
         "Deploy over ssh; pin `ruff@0.4.2` in CI.",
+        # an IPv4-shape rule would strip this — every part falls in 0-255, so it
+        # is indistinguishable from an address by shape alone:
+        "Bundled runtime is v8@10.2.154.26.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -85,17 +85,14 @@ class TestDependencyDeclaration:
 class TestVersionCompatibility:
     """A version pin is a compatibility FACT: a stated version, in some syntax.
 
-    `tool@1.2.3` and the prose forms below qualify. The bare instruction
-    `pin the version` does not — it names no version — and that alternative was
-    removed.
+    `tool@1.2.3` and the prose forms below qualify; the bare instruction
+    `pin the version` does not, and that alternative was removed.
 
-    If you are re-adding a phrase alternative: do not copy a regex from this
-    docstring. An earlier version of it prescribed one that matched
-    "Pin the version to 1.2.3.", which the negative cases below forbid, and that
-    still missed the backticked form. The negative cases ARE the specification —
-    run any candidate against them, and against the reverted narrowed form
-    recorded in docs/specs/2026-08-13-structural-signal-detection.md, before
-    believing it works.
+    Re-adding a phrase alternative: the negative cases below are the
+    specification — run any candidate against them. Do not copy a regex out of a
+    docstring; an earlier one prescribed here was wrong in both directions. The
+    reasoning and both reverted attempts live in
+    docs/specs/2026-08-13-structural-signal-detection.md, "Amendment 2026-08-25".
     """
     @pytest.mark.parametrize("text", [
         # schliff's own line — a pin, in the syntax people actually use.
@@ -168,20 +165,12 @@ class TestVersionCompatibility:
         assert not _RE_VERSION_COMPAT.search("Pin the version to 1.2.3.")
 
     def test_an_ssh_target_is_still_credited_known_limit(self):
-        """Documents behaviour this pattern deliberately does NOT fix.
+        """Asserts behaviour this pattern deliberately does NOT fix.
 
-        `ssh root@<ipv4>` is credited as a version pin. Two discriminators were
-        tried, and each cost an honest file its point:
-
-        - number shape: `root@127.1` and `root@0000100.1.2.3` are credited and
-          both resolve, so an octet rule cannot be completed — and it drops
-          genuine four-part versions whose parts all fall in 0-255, such as
-          `v8@10.2.154.26`;
-        - command wordlist: misses `git@`/`psql`/`curl` targets, and strips the
-          credit from `Deploy over ssh; pin `ruff@0.4.2` in CI.`, which is
-          asserted in the positive set above precisely so it outlives this test.
-
-        This test asserts the CURRENT behaviour. If a future change makes the
-        exclusion work, delete it — do not weaken it.
+        Reasoning and the two reverted discriminators: see the spec amendment
+        named in this class's docstring. If a future change makes an exclusion
+        work, DELETE this test — do not weaken it. The honest-pin case that a
+        wordlist exclusion would break is asserted in the positive set above, so
+        it survives that deletion.
         """
         assert _RE_VERSION_COMPAT.search("Deploy with `ssh root@100.127.18.39`.")

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -103,10 +103,11 @@ class TestVersionCompatibility:
         # `1.2.3.4` here and drops a legal pin. Without this case the whole
         # suite stays green through that mutation.
         "Requires pkg@1.2.3.4.5.",
-        # "Pin the version" is narrowed, not deleted: naming a version makes it
-        # a stated fact, and no other alternative picks these up.
-        "Pin the version to 8.8.2.",
-        "Pin the version at release time to 3.11.",
+        # The discriminator is the command, not the number: with no deploy
+        # command on the line, a version keeps its credit whatever it looks
+        # like — including shapes that are valid addresses.
+        "Pin the version in CI: `uvx schliff@8.8.2`.",
+        "Bundled runtime is v8@10.2.154.26.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -118,28 +119,46 @@ class TestVersionCompatibility:
         # 8.12.0 scorer: these lifted composability 20 -> 30 for free.
         "Deploy with `ssh root@100.127.18.39` once the build is green.",
         "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
-        # Leading zeros still address a host — `ssh root@010.1.2.3` connects.
-        # A strict-form octet class would let these through the exclusion.
+        # Every one of these resolves and connects, and no shape rule catches
+        # them all — which is the point of keying on the command instead.
+        # inet_aton: 010.1.2.3 -> 8.1.2.3, 0100.1.2.3 -> 64.1.2.3,
+        # 00010.1.2.3 -> 8.1.2.3, 127.1 -> 127.0.0.1, 0x7f.1 -> 127.0.0.1.
         "Deploy with `ssh root@010.1.2.3`.",
         "Run `ssh root@01.02.03.04` on the jump host.",
-        "Try `ssh root@10.00.0.1` first.",
-        # Padding is not capped at three characters. inet_aton resolves
-        # `0100.1.2.3` to 64.1.2.3 and `00010.1.2.3` to 8.1.2.3, so these
-        # connect by the same mechanism and must be excluded too.
         "Deploy with `ssh root@0100.1.2.3`.",
         "Deploy with `ssh root@00010.1.2.3`.",
-        "Reach it at `ssh root@0000.0.0.1`.",
+        "Reach it at `ssh root@0000100.1.2.3`.",
+        # Two- and three-part forms resolve too, and an octet rule that only
+        # knows the four-part shape never sees them.
+        "Reach it at `ssh root@127.1`.",
+        "Reach it at `ssh root@10.0.1`.",
+        # Other transports carry the same target.
+        "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
+        "Sync with `rsync deploy@10.0.0.5:/srv/ .`",
     ])
     def test_addresses_are_not_version_pins(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
 
     @pytest.mark.parametrize("text", [
-        # An instruction to pin is not a pin. The credited thing is a stated
-        # compatibility FACT; this sentence names no version at all. Kept
-        # apart from the address cases because the two exclusions are
-        # independent — one is a lookahead, this one is a removed alternative.
+        # An instruction to pin is not a pin — it names no version at all.
+        # The alternative that used to credit this phrase is gone entirely:
+        # narrowing it missed quoted versions and credited step numbers.
         "Pin the version.",
         "Pin the version before release.",
+        "Pin the version in step 2.1.",
     ])
     def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
+
+    def test_a_version_on_a_deploy_line_still_counts_elsewhere(self):
+        """The exclusion is per line, not per document.
+
+        A SKILL.md that documents a deploy command AND states a version must
+        keep its credit — otherwise the fix would punish honest files that
+        happen to mention `ssh`.
+        """
+        body = (
+            "Deploy with `ssh root@10.0.0.5`.\n"
+            "Requires node >= 18.0.\n"
+        )
+        assert _RE_VERSION_COMPAT.search(body)

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -83,15 +83,15 @@ class TestDependencyDeclaration:
 
 
 class TestVersionCompatibility:
-    """A version pin is a compatibility FACT — and it is the `tool@1.2.3` syntax
-    that carries it, not the presence of a number.
+    """A version pin is a compatibility FACT: a stated version, in some syntax.
 
-    The phrase `pin the version` was credited as a pin until this was removed; an
-    instruction naming no version is not a fact. Do not add a phrasing alternative
-    back without a field measurement showing the phrasing occurs without a pin
-    beside it — it did not, in 2304 local `.md` files.
+    `tool@1.2.3` and the prose forms below both qualify. What does NOT is the bare
+    instruction `pin the version`, which names no version — that alternative was
+    removed. Before adding a phrasing alternative back, measure that the phrasing
+    occurs NAMING A VERSION with no `tool@version` pin beside it; over 2304 local
+    `.md` files it did not. (Files do carry the bare phrase — three lose the credit
+    by this change — but none of them names a version, which is the whole point.)
     """
-
     @pytest.mark.parametrize("text", [
         # schliff's own line — a pin, in the syntax people actually use.
         "Pin the version in CI: `uvx schliff@8.8.2 verify <file> --min-score 75`.",
@@ -137,7 +137,7 @@ class TestVersionCompatibility:
 
         `ssh root@<ipv4>` is credited as a version pin. Four review rounds
         established that no pattern separates an address from a version in
-        either direction — by number shape (`127.1`, `0x7f.1` both resolve)
+        either direction — by number shape (`127.1` and `0000100.1.2.3` are credited and resolve)
         or by command wordlist (which misses `git@`/`psql`/`curl` while
         destroying honest pins that merely mention ssh in prose). The limit
         is recorded, with the cost named, rather than papered over.

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -138,6 +138,10 @@ class TestVersionCompatibility:
         "Pin the version.",
         "Pin the version before release.",
         "Pin the version in step 2.1.",
+        # CHANGELOG states this matches nothing. Without the case, a re-added
+        # phrase alternative would leave the suite green and the CHANGELOG
+        # documenting behaviour the code no longer has.
+        "Pin the version to 1.2.3.",
     ])
     def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -102,7 +102,7 @@ class TestVersionCompatibility:
         "Email the maintainer at user@example.com for access.",
         "The versioning policy is documented separately.",
     ])
-    def test_addresses_are_not_version_pins(self, text):
+    def test_an_email_address_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
 
     @pytest.mark.parametrize("text", [
@@ -127,7 +127,7 @@ class TestVersionCompatibility:
             "Pin the version in CI: `uvx schliff@8.8.2`."
         )
 
-    def test_an_ssh_target_is_a_known_limit_not_a_pin(self):
+    def test_an_ssh_target_is_still_credited_known_limit(self):
         """Documents behaviour this pattern deliberately does NOT fix.
 
         `ssh root@<ipv4>` is credited as a version pin. Four review rounds

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -83,15 +83,19 @@ class TestDependencyDeclaration:
 
 
 class TestVersionCompatibility:
-    r"""A version pin is a compatibility FACT: a stated version, in some syntax.
+    """A version pin is a compatibility FACT: a stated version, in some syntax.
 
     `tool@1.2.3` and the prose forms below qualify. The bare instruction
     `pin the version` does not — it names no version — and that alternative was
-    removed. If it is ever re-added, the ALTERNATIVE ITSELF must require a version
-    token (`pin\s+the\s+version\s+(?:to|at)\s+[\d.]+`), never the bare phrase:
-    an alternative matching the phrase alone hands `Pin the version.` 10 points
-    again, which is the whole defect. A narrowed form was tried and reverted for
-    separate reasons — see the spec — so check that history before rebuilding it.
+    removed.
+
+    If you are re-adding a phrase alternative: do not copy a regex from this
+    docstring. An earlier version of it prescribed one that matched
+    "Pin the version to 1.2.3.", which the negative cases below forbid, and that
+    still missed the backticked form. The negative cases ARE the specification —
+    run any candidate against them, and against the reverted narrowed form
+    recorded in docs/specs/2026-08-13-structural-signal-detection.md, before
+    believing it works.
     """
     @pytest.mark.parametrize("text", [
         # schliff's own line — a pin, in the syntax people actually use.

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -103,6 +103,10 @@ class TestVersionCompatibility:
         # `1.2.3.4` here and drops a legal pin. Without this case the whole
         # suite stays green through that mutation.
         "Requires pkg@1.2.3.4.5.",
+        # "Pin the version" is narrowed, not deleted: naming a version makes it
+        # a stated fact, and no other alternative picks these up.
+        "Pin the version to 8.8.2.",
+        "Pin the version at release time to 3.11.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -119,6 +123,12 @@ class TestVersionCompatibility:
         "Deploy with `ssh root@010.1.2.3`.",
         "Run `ssh root@01.02.03.04` on the jump host.",
         "Try `ssh root@10.00.0.1` first.",
+        # Padding is not capped at three characters. inet_aton resolves
+        # `0100.1.2.3` to 64.1.2.3 and `00010.1.2.3` to 8.1.2.3, so these
+        # connect by the same mechanism and must be excluded too.
+        "Deploy with `ssh root@0100.1.2.3`.",
+        "Deploy with `ssh root@00010.1.2.3`.",
+        "Reach it at `ssh root@0000.0.0.1`.",
     ])
     def test_addresses_are_not_version_pins(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -98,6 +98,11 @@ class TestVersionCompatibility:
         # discriminator below must not swallow them. `288` is not a valid
         # octet, so this cannot be an address.
         "Built against v8@6.7.288.46.",
+        # Five parts is not an address either. This one guards the trailing
+        # `(?!\\.?\\d)` in _IPV4: delete that guard and the lookahead matches
+        # `1.2.3.4` here and drops a legal pin. Without this case the whole
+        # suite stays green through that mutation.
+        "Requires pkg@1.2.3.4.5.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -109,9 +114,22 @@ class TestVersionCompatibility:
         # 8.12.0 scorer: these lifted composability 20 -> 30 for free.
         "Deploy with `ssh root@100.127.18.39` once the build is green.",
         "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
-        # An instruction to pin is not a pin. The credited thing is a stated
-        # compatibility FACT; this sentence names no version at all.
-        "Pin the version.",
+        # Leading zeros still address a host — `ssh root@010.1.2.3` connects.
+        # A strict-form octet class would let these through the exclusion.
+        "Deploy with `ssh root@010.1.2.3`.",
+        "Run `ssh root@01.02.03.04` on the jump host.",
+        "Try `ssh root@10.00.0.1` first.",
     ])
     def test_addresses_are_not_version_pins(self, text):
+        assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        # An instruction to pin is not a pin. The credited thing is a stated
+        # compatibility FACT; this sentence names no version at all. Kept
+        # apart from the address cases because the two exclusions are
+        # independent — one is a lookahead, this one is a removed alternative.
+        "Pin the version.",
+        "Pin the version before release.",
+    ])
+    def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -83,7 +83,14 @@ class TestDependencyDeclaration:
 
 
 class TestVersionCompatibility:
-    """A version pin is a compatibility statement, whatever syntax expresses it."""
+    """A version pin is a compatibility FACT — and it is the `tool@1.2.3` syntax
+    that carries it, not the presence of a number.
+
+    The phrase `pin the version` was credited as a pin until this was removed; an
+    instruction naming no version is not a fact. Do not add a phrasing alternative
+    back without a field measurement showing the phrasing occurs without a pin
+    beside it — it did not, in 2304 local `.md` files.
+    """
 
     @pytest.mark.parametrize("text", [
         # schliff's own line — a pin, in the syntax people actually use.
@@ -94,6 +101,14 @@ class TestVersionCompatibility:
         "Requires node >= 18.0",
         "Minimum version 3.9.",
         "Compatible with Python 3.12",
+        # An honest pin on a line that also mentions a deploy command. This is
+        # the counter-example the SSH limit below rests on: a command-wordlist
+        # exclusion would strip this file's credit. It lives HERE, in the
+        # positive set, on purpose — the limit test below carries an
+        # instruction to delete it once an exclusion works, and after that
+        # deletion this assertion is the only thing left that notices if the
+        # new exclusion takes honest pins with it.
+        "Deploy over ssh; pin `ruff@0.4.2` in CI.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -108,7 +123,8 @@ class TestVersionCompatibility:
     @pytest.mark.parametrize("text", [
         # An instruction to pin is not a pin: the credited thing is a stated
         # compatibility FACT, and these name no version at all. Measured on the
-        # 8.12.0 scorer, the bare phrase lifted composability by 10 for free.
+        # unreleased scorer this branch forked from (`main` at 922fd92), the bare
+        # phrase lifted composability by 10 on an otherwise empty file.
         "Pin the version.",
         "Pin the version before release.",
         "Pin the version in step 2.1.",

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -94,20 +94,6 @@ class TestVersionCompatibility:
         "Requires node >= 18.0",
         "Minimum version 3.9.",
         "Compatible with Python 3.12",
-        # Four-part pins are real — V8 numbers them this way — and the SSH
-        # discriminator below must not swallow them. `288` is not a valid
-        # octet, so this cannot be an address.
-        "Built against v8@6.7.288.46.",
-        # Five parts is not an address either. This one guards the trailing
-        # `(?!\\.?\\d)` in _IPV4: delete that guard and the lookahead matches
-        # `1.2.3.4` here and drops a legal pin. Without this case the whole
-        # suite stays green through that mutation.
-        "Requires pkg@1.2.3.4.5.",
-        # The discriminator is the command, not the number: with no deploy
-        # command on the line, a version keeps its credit whatever it looks
-        # like — including shapes that are valid addresses.
-        "Pin the version in CI: `uvx schliff@8.8.2`.",
-        "Bundled runtime is v8@10.2.154.26.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -115,34 +101,14 @@ class TestVersionCompatibility:
     @pytest.mark.parametrize("text", [
         "Email the maintainer at user@example.com for access.",
         "The versioning policy is documented separately.",
-        # An SSH target is a host, not a compatibility fact. Measured on the
-        # 8.12.0 scorer: these lifted composability 20 -> 30 for free.
-        "Deploy with `ssh root@100.127.18.39` once the build is green.",
-        "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
-        # Every one of these resolves and connects, and no shape rule catches
-        # them all — which is the point of keying on the command instead.
-        # inet_aton: 010.1.2.3 -> 8.1.2.3, 0100.1.2.3 -> 64.1.2.3,
-        # 00010.1.2.3 -> 8.1.2.3, 127.1 -> 127.0.0.1, 0x7f.1 -> 127.0.0.1.
-        "Deploy with `ssh root@010.1.2.3`.",
-        "Run `ssh root@01.02.03.04` on the jump host.",
-        "Deploy with `ssh root@0100.1.2.3`.",
-        "Deploy with `ssh root@00010.1.2.3`.",
-        "Reach it at `ssh root@0000100.1.2.3`.",
-        # Two- and three-part forms resolve too, and an octet rule that only
-        # knows the four-part shape never sees them.
-        "Reach it at `ssh root@127.1`.",
-        "Reach it at `ssh root@10.0.1`.",
-        # Other transports carry the same target.
-        "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
-        "Sync with `rsync deploy@10.0.0.5:/srv/ .`",
     ])
     def test_addresses_are_not_version_pins(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
 
     @pytest.mark.parametrize("text", [
-        # An instruction to pin is not a pin — it names no version at all.
-        # The alternative that used to credit this phrase is gone entirely:
-        # narrowing it missed quoted versions and credited step numbers.
+        # An instruction to pin is not a pin: the credited thing is a stated
+        # compatibility FACT, and these name no version at all. Measured on the
+        # 8.12.0 scorer, the bare phrase lifted composability by 10 for free.
         "Pin the version.",
         "Pin the version before release.",
         "Pin the version in step 2.1.",
@@ -150,15 +116,28 @@ class TestVersionCompatibility:
     def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
 
-    def test_a_version_on_a_deploy_line_still_counts_elsewhere(self):
-        """The exclusion is per line, not per document.
+    def test_naming_the_version_still_counts(self):
+        """Removing the phrase must not cost a file that actually names one.
 
-        A SKILL.md that documents a deploy command AND states a version must
-        keep its credit — otherwise the fix would punish honest files that
-        happen to mention `ssh`.
+        schliff's own SKILL.md line is the case that matters: it opens with
+        the phrase and then gives the pin, which the `tool@version`
+        alternative credits on its own.
         """
-        body = (
-            "Deploy with `ssh root@10.0.0.5`.\n"
-            "Requires node >= 18.0.\n"
+        assert _RE_VERSION_COMPAT.search(
+            "Pin the version in CI: `uvx schliff@8.8.2`."
         )
-        assert _RE_VERSION_COMPAT.search(body)
+
+    def test_an_ssh_target_is_a_known_limit_not_a_pin(self):
+        """Documents behaviour this pattern deliberately does NOT fix.
+
+        `ssh root@<ipv4>` is credited as a version pin. Four review rounds
+        established that no pattern separates an address from a version in
+        either direction — by number shape (`127.1`, `0x7f.1` both resolve)
+        or by command wordlist (which misses `git@`/`psql`/`curl` while
+        destroying honest pins that merely mention ssh in prose). The limit
+        is recorded, with the cost named, rather than papered over.
+
+        This test asserts the CURRENT behaviour. If a future change makes the
+        exclusion work, delete it — do not weaken it.
+        """
+        assert _RE_VERSION_COMPAT.search("Deploy with `ssh root@100.127.18.39`.")

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -102,7 +102,7 @@ class TestVersionCompatibility:
         "Email the maintainer at user@example.com for access.",
         "The versioning policy is documented separately.",
     ])
-    def test_an_email_address_is_not_a_version_pin(self, text):
+    def test_prose_without_a_pin_is_not_credited(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
 
     @pytest.mark.parametrize("text", [
@@ -115,17 +115,6 @@ class TestVersionCompatibility:
     ])
     def test_bare_imperative_is_not_a_version_pin(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
-
-    def test_naming_the_version_still_counts(self):
-        """Removing the phrase must not cost a file that actually names one.
-
-        schliff's own SKILL.md line is the case that matters: it opens with
-        the phrase and then gives the pin, which the `tool@version`
-        alternative credits on its own.
-        """
-        assert _RE_VERSION_COMPAT.search(
-            "Pin the version in CI: `uvx schliff@8.8.2`."
-        )
 
     def test_an_ssh_target_is_still_credited_known_limit(self):
         """Documents behaviour this pattern deliberately does NOT fix.

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -83,14 +83,15 @@ class TestDependencyDeclaration:
 
 
 class TestVersionCompatibility:
-    """A version pin is a compatibility FACT: a stated version, in some syntax.
+    r"""A version pin is a compatibility FACT: a stated version, in some syntax.
 
-    `tool@1.2.3` and the prose forms below both qualify. What does NOT is the bare
-    instruction `pin the version`, which names no version — that alternative was
-    removed. Before adding a phrasing alternative back, measure that the phrasing
-    occurs NAMING A VERSION with no `tool@version` pin beside it; over 2304 local
-    `.md` files it did not. (Files do carry the bare phrase — three lose the credit
-    by this change — but none of them names a version, which is the whole point.)
+    `tool@1.2.3` and the prose forms below qualify. The bare instruction
+    `pin the version` does not — it names no version — and that alternative was
+    removed. If it is ever re-added, the ALTERNATIVE ITSELF must require a version
+    token (`pin\s+the\s+version\s+(?:to|at)\s+[\d.]+`), never the bare phrase:
+    an alternative matching the phrase alone hands `Pin the version.` 10 points
+    again, which is the whole defect. A narrowed form was tried and reverted for
+    separate reasons — see the spec — so check that history before rebuilding it.
     """
     @pytest.mark.parametrize("text", [
         # schliff's own line — a pin, in the syntax people actually use.
@@ -113,12 +114,21 @@ class TestVersionCompatibility:
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
 
-    @pytest.mark.parametrize("text", [
-        "Email the maintainer at user@example.com for access.",
-        "The versioning policy is documented separately.",
-    ])
-    def test_prose_without_a_pin_is_not_credited(self, text):
-        assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"
+    def test_an_email_address_is_not_a_version_pin(self):
+        r"""Pins the `@\d+\.\d+` digit requirement.
+
+        The module comment on `_RE_VERSION_COMPAT` relies on exactly this: the
+        digit after the `@` is what keeps an address out. Widening the alternative
+        to `@[\w.]+` must break here.
+        """
+        assert not _RE_VERSION_COMPAT.search(
+            "Email the maintainer at user@example.com for access."
+        )
+
+    def test_prose_about_versioning_is_not_a_pin(self):
+        assert not _RE_VERSION_COMPAT.search(
+            "The versioning policy is documented separately."
+        )
 
     @pytest.mark.parametrize("text", [
         # An instruction to pin is not a pin: the credited thing is a stated
@@ -135,12 +145,16 @@ class TestVersionCompatibility:
     def test_an_ssh_target_is_still_credited_known_limit(self):
         """Documents behaviour this pattern deliberately does NOT fix.
 
-        `ssh root@<ipv4>` is credited as a version pin. Four review rounds
-        established that no pattern separates an address from a version in
-        either direction — by number shape (`127.1` and `0000100.1.2.3` are credited and resolve)
-        or by command wordlist (which misses `git@`/`psql`/`curl` while
-        destroying honest pins that merely mention ssh in prose). The limit
-        is recorded, with the cost named, rather than papered over.
+        `ssh root@<ipv4>` is credited as a version pin. Two discriminators were
+        tried, and each cost an honest file its point:
+
+        - number shape: `root@127.1` and `root@0000100.1.2.3` are credited and
+          both resolve, so an octet rule cannot be completed — and it drops
+          genuine four-part versions whose parts all fall in 0-255, such as
+          `v8@10.2.154.26`;
+        - command wordlist: misses `git@`/`psql`/`curl` targets, and strips the
+          credit from `Deploy over ssh; pin `ruff@0.4.2` in CI.`, which is
+          asserted in the positive set above precisely so it outlives this test.
 
         This test asserts the CURRENT behaviour. If a future change makes the
         exclusion work, delete it — do not weaken it.

--- a/skills/schliff/tests/unit/test_composability_structural_signals.py
+++ b/skills/schliff/tests/unit/test_composability_structural_signals.py
@@ -94,6 +94,10 @@ class TestVersionCompatibility:
         "Requires node >= 18.0",
         "Minimum version 3.9.",
         "Compatible with Python 3.12",
+        # Four-part pins are real — V8 numbers them this way — and the SSH
+        # discriminator below must not swallow them. `288` is not a valid
+        # octet, so this cannot be an address.
+        "Built against v8@6.7.288.46.",
     ])
     def test_states_compatibility(self, text):
         assert _RE_VERSION_COMPAT.search(text), f"not recognised: {text!r}"
@@ -101,6 +105,13 @@ class TestVersionCompatibility:
     @pytest.mark.parametrize("text", [
         "Email the maintainer at user@example.com for access.",
         "The versioning policy is documented separately.",
+        # An SSH target is a host, not a compatibility fact. Measured on the
+        # 8.12.0 scorer: these lifted composability 20 -> 30 for free.
+        "Deploy with `ssh root@100.127.18.39` once the build is green.",
+        "Copy it over: `scp deploy@10.0.0.5:/srv/app .`",
+        # An instruction to pin is not a pin. The credited thing is a stated
+        # compatibility FACT; this sentence names no version at all.
+        "Pin the version.",
     ])
     def test_addresses_are_not_version_pins(self, text):
         assert not _RE_VERSION_COMPAT.search(text), f"false positive: {text!r}"

--- a/skills/schliff/tests/unit/test_patterns.py
+++ b/skills/schliff/tests/unit/test_patterns.py
@@ -1,4 +1,7 @@
-"""Tests for recently modified regex patterns in scoring/patterns.py.
+"""Tests for regex patterns in the `scoring/patterns` package.
+
+Patterns live in `scoring/patterns/skill_md.py` (and `base.py` for
+`_RE_ACTIONABLE_LINES`); there is no `scoring/patterns.py`.
 
 Covers:
 - Five new composability patterns (v6.0.1)

--- a/skills/schliff/tests/unit/test_patterns.py
+++ b/skills/schliff/tests/unit/test_patterns.py
@@ -5,9 +5,11 @@ Covers:
 - False positive guards for common skill prose
 - Efficiency deduplication logic
 
-Three pattern bugs are documented inline. Tests are written against
-actual current behavior; known bugs are marked with BUG comments so
-they fail visibly when the bug is fixed and need to be updated.
+Tests are written against actual current behaviour. The three "known bugs" this
+file once documented have all been fixed since; the sections below now assert the
+fixed behaviour, and the names say so. Patterns are NOT transcribed into
+docstrings here — every previous copy drifted from the definition in
+`scoring/patterns/skill_md.py` without a single test failing.
 """
 import sys
 from pathlib import Path
@@ -45,19 +47,12 @@ def matches(pattern, text: str) -> bool:
 class TestErrorBehavior:
     """Tests for _RE_ERROR_BEHAVIOR.
 
-    Pattern (line 78-81 of patterns.py):
-        (?i)(on\\s+error|error\\s+handling|if\\s+\\w+\\s+fails?|when\\s+\\w+\\s+fails?|
-             graceful(?:ly)?\\s+(?:handle|degrade|fail)|recover(?:y|s)?\\s+(?:from|when))
-
-    KNOWN BUG #1: 'if the command fails' does NOT match.
-        Cause: if\\s+\\w+\\s+fails? allows only ONE \\w+ token between 'if' and 'fails'.
-        'the command' is two words. Only 'if <single_word> fails' matches.
-        Example that does work: 'if it fails', 'if script fails'.
-
-    KNOWN BUG #2: 'graceful degradation' does NOT match.
-        Cause: pattern is graceful(?:ly)?\\s+(?:handle|degrade|fail).
-        'degradation' is not in the alternation. Only the verb forms match.
-        Example that does work: 'gracefully degrade', 'graceful failure'.
+    Defined in `scoring/patterns/skill_md.py`. No transcription here on purpose:
+    the copy that used to sit in this docstring went stale and ended up asserting
+    two KNOWN BUGs that had been fixed — `if the command fails` and
+    `graceful degradation` both match today, as the tests below assert. It also
+    predated the 2026-08-13 additions (`stderr`, non-zero exit, exit status), so
+    it implied a stated error contract earns nothing.
     """
 
     # --- Should match ---
@@ -105,7 +100,7 @@ class TestErrorBehavior:
         # 'if something is missing from the description' — no 'fails'
         assert not matches(_RE_ERROR_BEHAVIOR, "if something is missing from the description")
 
-    # --- KNOWN BUGS (document current behavior; update tests when fixed) ---
+    # --- Formerly documented as bugs; fixed, and asserted fixed here ---
 
     def test_if_multi_word_fails_matched(self):
         """'if the command fails' matches with multi-word subjects."""
@@ -125,9 +120,8 @@ class TestErrorBehavior:
 class TestIdempotency:
     """Tests for _RE_IDEMPOTENCY.
 
-    Pattern (line 82-85):
-        (?i)(idempotent|safe to (?:re-?run|run (?:again|twice|multiple))|
-             running (?:again|twice)|no side.?effects?|re-?entrant)
+    Defined in `scoring/patterns/skill_md.py`. Read it there — a copy here drifts
+    from the definition without anything failing.
     """
 
     # --- Should match ---
@@ -183,16 +177,12 @@ class TestIdempotency:
 class TestDependencyDecl:
     """Tests for _RE_DEPENDENCY_DECL.
 
-    Pattern (line 86-90):
-        (?i)(requires?:\\s*\\w|depends? on|prerequisite|
-             needs?\\s+(?:python|node|npm|pip|git|jq|bash|ruby|go)\\b|
-             install\\s+\\w+\\s+first)
-
-    KNOWN BUG #3: 'requires python 3.9' does NOT match.
-        Cause: The 'requires?' branch needs a colon (requires?:\\s*\\w).
-        The bare 'requires python' without colon is not covered.
-        The 'needs?' branch covers 'needs python' but not 'requires python'.
-        Fix: add a branch like requires?\\s+(?:python|node|npm|pip|git|...)\\b
+    Defined in `scoring/patterns/skill_md.py`. No transcription here on purpose:
+    the previous copy asserted a KNOWN BUG that `requires python 3.9` needs a
+    colon to match. It does not — `test_requires_python_without_colon_matched`
+    below asserts the opposite. The copy also predated the 2026-08-13 additions
+    (`anywhere X is available`, `requires X to be installed`, `needs X on the
+    PATH`).
     """
 
     # --- Should match ---
@@ -236,7 +226,7 @@ class TestDependencyDecl:
         # 'needs' but not followed by a known tool name
         assert not matches(_RE_DEPENDENCY_DECL, "this needs improvement")
 
-    # --- KNOWN BUG ---
+    # --- Formerly documented as a bug; fixed, and asserted fixed here ---
 
     def test_requires_python_without_colon_matched(self):
         """'requires python 3.9' matches with space separator."""
@@ -252,9 +242,8 @@ class TestDependencyDecl:
 class TestNamespaceIsolation:
     """Tests for _RE_NAMESPACE_ISOLATION.
 
-    Pattern (line 91-94):
-        (?i)(namespace\\s+\\w+|namespaced?\\b|__\\w+__|
-             @[\\w-]+/[\\w-]+|plugin[_-]\\w+|scoped\\s+to\\b)
+    Defined in `scoring/patterns/skill_md.py`. Read it there — a copy here drifts
+    from the definition without anything failing.
     """
 
     # --- Should match ---

--- a/skills/schliff/tests/unit/test_patterns.py
+++ b/skills/schliff/tests/unit/test_patterns.py
@@ -307,12 +307,16 @@ class TestNamespaceIsolation:
 # ---------------------------------------------------------------------------
 
 class TestVersionCompat:
-    """Tests for _RE_VERSION_COMPAT.
+    r"""Tests for _RE_VERSION_COMPAT.
 
-    Pattern (line 95-99):
-        (?i)(version\\s*[><=!]+\\s*[\\d.]+|compatible\\s+with\\s+\\w+\\s+v?\\d|
-             requires?\\s+\\w+\\s*[><=]+\\s*[\\d.]+|minimum\\s+version|
-             supported\\s+versions?|works\\s+with\\s+\\w+\\s+v?\\d+\\.\\d+)
+    Defined in `scoring/patterns/skill_md.py`. The transcription that used to sit
+    here went stale — it predated the `tool@1.2.3` alternative and so implied that
+    a pin is not credited, the opposite of the truth. Read the pattern at its
+    definition; the KNOWN LIMIT comment beside it explains why an SSH target is
+    credited too.
+
+    Prose forms covered below; `tool@1.2.3` and the bare-phrase exclusion are
+    covered in test_composability_structural_signals.py.
     """
 
     # --- Should match ---

--- a/skills/schliff/tests/unit/test_patterns.py
+++ b/skills/schliff/tests/unit/test_patterns.py
@@ -304,8 +304,8 @@ class TestVersionCompat:
     Defined in `scoring/patterns/skill_md.py`. The transcription that used to sit
     here went stale — it predated the `tool@1.2.3` alternative and so implied that
     a pin is not credited, the opposite of the truth. Read the pattern at its
-    definition; the KNOWN LIMIT comment beside it explains why an SSH target is
-    credited too.
+    definition; the KNOWN LIMIT comment beside it names the SSH-address limit and
+    points at the spec amendment that argues it.
 
     Prose forms covered below; `tool@1.2.3` and the bare-phrase exclusion are
     covered in test_composability_structural_signals.py.

--- a/skills/schliff/tests/unit/test_version_pin_limit_stated_once.py
+++ b/skills/schliff/tests/unit/test_version_pin_limit_stated_once.py
@@ -1,0 +1,105 @@
+"""The SSH-address limit on `_RE_VERSION_COMPAT` must be argued in one place.
+
+The reasoning had four homes — the pattern comment, the CHANGELOG, and two test
+docstrings. Every correction then had to land in all four, and four review rounds
+in a row found one out of step: `0x7f.1` was removed from four sites and left in
+a fifth; "not the presence of a number" was fixed in a docstring and left in the
+CHANGELOG; a stale pattern transcription was replaced in one class of four; a
+clause order was corrected in the spec and re-scrambled in the CHANGELOG.
+
+That is the failure #209 fixed for the collector's cadence rule, and this guard
+is the same shape: the argument lives in the spec amendment, every other site
+names the limit and links to it.
+
+WHAT THIS GUARD CANNOT DO, stated because a guard giving false assurance is
+worse than none (the lesson `test_cadence_rule_stated_once.py` records about its
+own first version): it keys on the concrete EVIDENCE — an address form, a
+command, a version literal — not on the shape of the argument. Someone who
+restates the reasoning with fresh examples defeats it. It catches the copy-paste
+case, which is the one that actually happened four times.
+"""
+import os
+
+import pytest
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+
+# Prose sites that describe the limit. Test files are deliberately absent: an
+# assertion naming `v8@10.2.154.26` is a check, not a restatement of the
+# argument, and the positive set has to name it for the guard on the shape rule's
+# error direction to exist at all.
+_SITES = [
+    "CHANGELOG.md",
+    "README.md",
+    "skills/schliff/scripts/scoring/patterns/skill_md.py",
+    "skills/schliff/scripts/scoring/composability.py",
+    "docs/specs/2026-08-13-structural-signal-detection.md",
+    "docs/SCORING.md",
+]
+
+# The evidence the argument is built from. Each is a literal a copy-paste would
+# carry along; none is a phrasing that can be reworded while keeping the point.
+_EVIDENCE = [
+    "inet_aton",            # the shape rule cannot be completed
+    "0000100.1.2.3",        # ...demonstrated by this address
+    "git clone git@",       # the wordlist misses this
+    "admin@192.168.1.1",    # ...and this
+    "v8@10.2.154.26",       # the shape rule drops this honest pin
+    "ruff@0.4.2",           # the wordlist drops this honest pin
+]
+
+_HOME = "docs/specs/2026-08-13-structural-signal-detection.md"
+
+
+def _sites_containing(needle: str):
+    found = []
+    for rel in _SITES:
+        path = os.path.join(_REPO, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding="utf-8") as fh:
+            if needle in fh.read():
+                found.append(rel)
+    return found
+
+
+@pytest.mark.parametrize("needle", _EVIDENCE)
+def test_evidence_appears_in_exactly_one_prose_site(needle):
+    sites = _sites_containing(needle)
+    assert len(sites) <= 1, (
+        f"{needle!r} is stated in {len(sites)} places: {sites}.\n"
+        f"The argument has one home ({_HOME}); other sites name the limit and "
+        f"link to it. Restating the evidence is how it drifted four times."
+    )
+
+
+def test_the_home_actually_carries_the_argument():
+    """A pointer to a document without the finding is worse than no pointer.
+
+    Round 10 found exactly that: the test docstring sent the reader to the spec
+    for history the spec did not have.
+    """
+    with open(os.path.join(_REPO, _HOME), encoding="utf-8") as fh:
+        home = fh.read()
+    missing = [n for n in _EVIDENCE if n not in home]
+    assert not missing, (
+        f"the spec amendment is the stated home of this argument but does not "
+        f"contain: {missing}"
+    )
+
+
+def test_every_pointer_names_a_section_that_exists():
+    """The three linking sites name an anchor. It has to be there."""
+    anchor = "Amendment 2026-08-25"
+    with open(os.path.join(_REPO, _HOME), encoding="utf-8") as fh:
+        assert f"## {anchor}" in fh.read(), f"{_HOME} has no '## {anchor}' heading"
+
+    pointers = [
+        "skills/schliff/scripts/scoring/patterns/skill_md.py",
+        "CHANGELOG.md",
+        "skills/schliff/tests/unit/test_composability_structural_signals.py",
+    ]
+    for rel in pointers:
+        with open(os.path.join(_REPO, rel), encoding="utf-8") as fh:
+            text = fh.read()
+        assert anchor in text, f"{rel} no longer points at the argument's home"

--- a/skills/schliff/tests/unit/test_version_pin_limit_stated_once.py
+++ b/skills/schliff/tests/unit/test_version_pin_limit_stated_once.py
@@ -11,65 +11,110 @@ That is the failure #209 fixed for the collector's cadence rule, and this guard
 is the same shape: the argument lives in the spec amendment, every other site
 names the limit and links to it.
 
-WHAT THIS GUARD CANNOT DO, stated because a guard giving false assurance is
-worse than none (the lesson `test_cadence_rule_stated_once.py` records about its
-own first version): it keys on the concrete EVIDENCE — an address form, a
-command, a version literal — not on the shape of the argument. Someone who
-restates the reasoning with fresh examples defeats it. It catches the copy-paste
-case, which is the one that actually happened four times.
+The FIRST version of this guard listed six file paths and skipped missing ones.
+It was defeated three ways, each demonstrated: pasting the whole argument into a
+file not on the list, renaming a listed file, and writing it into a test
+docstring — the very place two of the four original homes sat. A guard that
+gives false assurance is worse than none, because the spec then tells future
+editors it will catch them. It now enumerates from `git ls-files`, so a new file
+is covered the moment it is tracked, and it reads the test file's docstrings.
+
+WHAT IT STILL CANNOT DO: it keys on the concrete EVIDENCE — an address form, a
+function name, a version literal — not on the shape of the argument. Someone who
+restates the reasoning with fresh examples defeats it. It catches copy-paste,
+which is the case that actually happened four times.
 """
+import ast
 import os
+import subprocess
 
 import pytest
 
 _REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 
-# Prose sites that describe the limit. Test files are deliberately absent: an
-# assertion naming `v8@10.2.154.26` is a check, not a restatement of the
-# argument, and the positive set has to name it for the guard on the shape rule's
-# error direction to exist at all.
-_SITES = [
-    "CHANGELOG.md",
-    "README.md",
-    "skills/schliff/scripts/scoring/patterns/skill_md.py",
-    "skills/schliff/scripts/scoring/composability.py",
-    "docs/specs/2026-08-13-structural-signal-detection.md",
-    "docs/SCORING.md",
-]
-
-# The evidence the argument is built from. Each is a literal a copy-paste would
-# carry along; none is a phrasing that can be reworded while keeping the point.
-_EVIDENCE = [
-    "inet_aton",            # the shape rule cannot be completed
-    "0000100.1.2.3",        # ...demonstrated by this address
-    "git clone git@",       # the wordlist misses this
-    "admin@192.168.1.1",    # ...and this
-    "v8@10.2.154.26",       # the shape rule drops this honest pin
-    "ruff@0.4.2",           # the wordlist drops this honest pin
-]
-
 _HOME = "docs/specs/2026-08-13-structural-signal-detection.md"
+_GUARD = "skills/schliff/tests/unit/test_version_pin_limit_stated_once.py"
+
+# The file whose ASSERTIONS legitimately name two of these literals: they are
+# test data for the honest-pin guards, one per error direction, not a
+# restatement of the argument. Its docstrings are still checked — that is where
+# two of the four original homes were.
+_ASSERTS = "skills/schliff/tests/unit/test_composability_structural_signals.py"
+
+# Evidence carried by copy-paste. Split by whether it may also appear as test
+# data, so the first group can be required to sit in exactly one place.
+_PROSE_ONLY = [
+    "inet_aton",              # the shape rule cannot be completed
+    "0000100.1.2.3",          # ...demonstrated by this address
+    "git clone git@10.0.0.5",  # the wordlist misses this (the example, not a real clone line)
+    "admin@192.168.1.1",      # ...and this
+]
+_ALSO_TEST_DATA = [
+    "v8@10.2.154.26",  # the honest pin the shape rule drops
+    "ruff@0.4.2",      # the honest pin the wordlist drops
+]
 
 
-def _sites_containing(needle: str):
-    found = []
-    for rel in _SITES:
-        path = os.path.join(_REPO, rel)
-        if not os.path.exists(path):
+def _tracked(*globs):
+    out = subprocess.run(
+        ["git", "ls-files", *globs],
+        cwd=_REPO, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    return [p for p in out if p not in (_GUARD,)]
+
+
+def _read(rel):
+    with open(os.path.join(_REPO, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _sites_containing(needle, allow=()):
+    hits = []
+    for rel in _tracked("*.md", "*.py"):
+        if rel in allow:
             continue
-        with open(path, encoding="utf-8") as fh:
-            if needle in fh.read():
-                found.append(rel)
-    return found
+        if needle in _read(rel):
+            hits.append(rel)
+    return hits
 
 
-@pytest.mark.parametrize("needle", _EVIDENCE)
-def test_evidence_appears_in_exactly_one_prose_site(needle):
+@pytest.mark.parametrize("needle", _PROSE_ONLY)
+def test_prose_evidence_appears_in_exactly_one_file(needle):
     sites = _sites_containing(needle)
-    assert len(sites) <= 1, (
-        f"{needle!r} is stated in {len(sites)} places: {sites}.\n"
-        f"The argument has one home ({_HOME}); other sites name the limit and "
-        f"link to it. Restating the evidence is how it drifted four times."
+    assert sites == [_HOME], (
+        f"{needle!r} is in {sites}, expected only {_HOME!r}.\n"
+        f"The argument has one home; other sites name the limit and link to it. "
+        f"Restating the evidence is how it drifted four times."
+    )
+
+
+@pytest.mark.parametrize("needle", _ALSO_TEST_DATA)
+def test_test_data_evidence_is_in_the_home_and_at_most_the_assertions(needle):
+    sites = _sites_containing(needle, allow=(_ASSERTS,))
+    assert sites == [_HOME], (
+        f"{needle!r} is in {sites}, expected only {_HOME!r} (plus assertions in "
+        f"{_ASSERTS}). It is evidence for the argument, not a phrase to repeat."
+    )
+
+
+@pytest.mark.parametrize("needle", _PROSE_ONLY + _ALSO_TEST_DATA)
+def test_the_assertions_file_does_not_restate_the_argument_in_prose(needle):
+    """Two of the four original homes were docstrings in this very file.
+
+    Excluding it wholesale would leave the place the drift actually sat
+    unguarded, so only its executable lines get the exemption.
+    """
+    tree = ast.parse(_read(_ASSERTS))
+    prose = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef)):
+            doc = ast.get_docstring(node)
+            if doc:
+                prose.append(doc)
+    offenders = [d.splitlines()[0][:60] for d in prose if needle in d]
+    assert not offenders, (
+        f"{needle!r} appears in a docstring of {_ASSERTS}: {offenders}.\n"
+        f"Assertions may name it; prose may not — restate nothing, link instead."
     )
 
 
@@ -79,27 +124,27 @@ def test_the_home_actually_carries_the_argument():
     Round 10 found exactly that: the test docstring sent the reader to the spec
     for history the spec did not have.
     """
-    with open(os.path.join(_REPO, _HOME), encoding="utf-8") as fh:
-        home = fh.read()
-    missing = [n for n in _EVIDENCE if n not in home]
+    home = _read(_HOME)
+    missing = [n for n in _PROSE_ONLY + _ALSO_TEST_DATA if n not in home]
     assert not missing, (
         f"the spec amendment is the stated home of this argument but does not "
         f"contain: {missing}"
     )
 
 
-def test_every_pointer_names_a_section_that_exists():
-    """The three linking sites name an anchor. It has to be there."""
+def test_every_pointer_names_a_target_that_exists():
+    """The linking sites name a file and a heading. Both have to be there."""
     anchor = "Amendment 2026-08-25"
-    with open(os.path.join(_REPO, _HOME), encoding="utf-8") as fh:
-        assert f"## {anchor}" in fh.read(), f"{_HOME} has no '## {anchor}' heading"
+    assert f"## {anchor}" in _read(_HOME), f"{_HOME} has no '## {anchor}' heading"
 
-    pointers = [
-        "skills/schliff/scripts/scoring/patterns/skill_md.py",
-        "CHANGELOG.md",
-        "skills/schliff/tests/unit/test_composability_structural_signals.py",
-    ]
-    for rel in pointers:
-        with open(os.path.join(_REPO, rel), encoding="utf-8") as fh:
-            text = fh.read()
+    for rel in ("skills/schliff/scripts/scoring/patterns/skill_md.py",
+                "CHANGELOG.md", _ASSERTS):
+        text = _read(rel)
         assert anchor in text, f"{rel} no longer points at the argument's home"
+        # The path must survive a plain grep. An earlier version of the pattern
+        # comment wrapped it across a line break, so `grep <filename>` found
+        # nothing at the one site whose only job is to point at the home.
+        assert os.path.basename(_HOME) in text, (
+            f"{rel} names the anchor but no greppable path to {_HOME} — check "
+            f"whether a line break splits the filename"
+        )


### PR DESCRIPTION
Removes one alternative from `_RE_VERSION_COMPAT`: the bare phrase `pin the version`.

**The defect.** The unreleased work on `main` taught `composability` to read a version pin as a
*fact* rather than a phrasing. It credited the phrase itself, so an instruction naming no version
earned the full 10 points — `Pin the version.` lifted composability by 10 on an otherwise empty
file.

**What still counts.** The pin itself: ``Pin the version in CI: `tool@1.2.3`.`` is credited by the
`tool@version` alternative, which is how schliff's own `SKILL.md:37` writes it.

## The SSH-address defect is deliberately NOT fixed here

`ssh root@100.127.18.39` is still credited as a version pin. Four review rounds established that
separating an address from a version by pattern is not decidable, and each candidate failed where
the other did not:

| discriminator | fails on |
| --- | --- |
| IPv4 shape (octet ranges, bounded padding) | `root@127.1` and `root@0000100.1.2.3` are credited today and both resolve through `socket.inet_aton`, so no octet rule can be completed — and it drops genuine four-part versions whose parts all fall in 0-255, such as `v8@10.2.154.26` |
| deploy command on the line | misses `git clone git@10.0.0.5` and `curl http://admin@192.168.1.1` (both caught by the shape rule), while stripping the credit from an honest ``Deploy over ssh; pin `ruff@0.4.2` in CI.`` |

Two shape attempts closed zero-padding at three and then six characters; seven was never reached.
The wordlist attempt was worse than the shape rule in **both** directions and was reverted.
Withholding the point from an honest file costs more than the limit does, so the limit is
documented — at the pattern, in `CHANGELOG.md`, in the spec the test module cites as its source,
and pinned by a test.

That test carries an instruction to **delete rather than weaken** it if an exclusion is ever made
to work. So the honest-pin counter-example is asserted in the *positive* set, where it survives
that deletion — verified by reintroducing a wordlist exclusion and deleting the limit test: the
positive assertion still fails on its own.

The gaming vector belongs in `benchmarks/anti-gaming/` and is not added yet, because that harness
runs in no CI job and `test_benchmark.py` is red today (two assertions expect 6 benchmarks where 7
exist). Adding a vector before that is fixed buys a line nobody runs.

## Verification

```
pytest skills/schliff/tests -q         ->  2236 passed
ruff / markdownlint                    ->  clean
cli.py score AGENTS.md                 ->  95.6  unchanged
cli.py score skills/schliff/SKILL.md   ->  93.0  unchanged (composability 76)
```

Field measurement, corpus named — `~/schliff` + `~/.claude`, `*.md`, node_modules included,
measured 2026-08-25 at this HEAD:

```
2304 files scanned          ->  3 lose the credit, 0 gain
                                one instruction ("Pin the version pair precisely"),
                                two notes written about this defect
159 installed SKILL.md      ->  0 lose, 0 gain
```

`v8.11.1` carries neither this phrase nor the `@` alternative — both arrived in the unreleased
work — so **no published score moves**, and the CHANGELOG's "no file's score goes down" holds
against the released version by construction.

Mutation: restoring the alternative turns 4 tests red; reintroducing a wordlist exclusion turns 2
red. The removal is guarded, not merely commented.

## Review history

Eleven rounds: 4 → 2 → 5 → 10 → 6 → 8 → 6 → 6 → 6 → 4 → 6 findings. The count not falling was the useful signal.
Rounds 1–4 were spent trying to make the address exclusion work, and each fix opened the next gap;
the scope was cut to the decidable half on the owner's decision. The abandoned attempts are
recorded at the pattern and in the spec, so the next person does not re-derive them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcYykJP28nNEShL1QPwa1k