### PR TITLE
fix(doctor): count one install per payload, and name the copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply
   enough to exhaust the parser's recursion (the last only below Python 3.14, so CI's newest leg
   stayed green while the oldest failed). Every failure now degrades to "no suite" with a warning
-  on stderr. `doctor` distinguishes it from an absent suite: `--json` gains `eval_suite_error`
-  per row and `broken_eval_suite` in the summary, and such a skill is kept out of the
+  on stderr. `doctor` distinguishes it from an absent suite: The loader also checks `stat().st_size` before reading, so an oversized suite is
+  never pulled into memory. `--json` gains `eval_suite_error` per row plus
+  `broken_eval_suite`, `grouped_duplicates` and `skills_discovered` in the summary, and such a skill is kept out of the
   `/schliff:init` recommendation — that command would write over the file that failed to load.
 
 - **`doctor` counts one install per skill, not one per copy on disk.** A plugin present in both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **A broken `eval-suite.json` no longer ends the run.** `schliff score`, `bench`, `eval`, `auto`
+  and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply
+  enough to exhaust the parser's recursion (the last only below Python 3.14, so CI's newest leg
+  stayed green while the oldest failed). Every failure now degrades to "no suite" with a warning
+  on stderr. `doctor` distinguishes it from an absent suite: `--json` gains `eval_suite_error`
+  per row and `broken_eval_suite` in the summary, and such a skill is kept out of the
+  `/schliff:init` recommendation — that command would write over the file that failed to load.
+
 - **`doctor` counts one install per skill, not one per copy on disk.** A plugin present in both
   `plugins/cache/` and `plugins/marketplaces/` was scored and billed twice, inflating the skill
   count, the grade distribution and the headline "Total context cost". Copies are now collapsed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,15 +45,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `plugins/cache/` and `plugins/marketplaces/` was scored and billed twice, inflating the skill
   count, the grade distribution and the headline "Total context cost". Copies are now collapsed
   by a digest over SKILL.md, `references/*.md` and `eval-suite.json` — the files a row is
-  actually derived from — and every path in a group is printed so you can delete one. Nothing is
-  removed for you. `--json` gains `duplicate_copies` and `skills_discovered` (the physical file
+  actually derived from — and every path in a group is printed. Nothing is removed for you, and
+  the report states only that comparison: the directories are not compared, so members of a group
+  may be different versions of the same plugin and may both be live installs. `--json` gains `duplicate_copies` and `skills_discovered` (the physical file
   count, next to the deduplicated `skills_found`). Path-based exclusion was measured and
   rejected; see `docs/specs/2026-08-13-doctor-counts-vendored-skills.md`, "Amendment 2026-08-26".
-  The report no longer claims the counted copy is "usually the plugin cache": that holds when
-  the scan is pointed at `~/.claude`, but under the default directories `.claude/skills` sorts
-  ahead of the home path, so the counted copy is your own project one — and the advice to act
-  on "the copy you control" pointed at exactly the wrong file. The counted path is now
-  described as what it is, an artifact of sort order. A duplicated skill also no longer draws
+  The report describes the counted path as what it is, whichever member sorted first, and draws no
+  conclusion from that: it had advised acting on "the copy you control", which under the default
+  directories is the reader's own project copy. A duplicated skill also no longer draws
   skill-specific advice telling you to edit it, which contradicted its own row.
 
 - **An oversized `eval-suite.json` says so.** It reported `unreadable`, the same word as a
@@ -69,7 +68,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   reason string. A duplicated skill whose suite is also broken now keeps the "do NOT run
   `/schliff:init` on these" warning, which fell through the counters that gate it. The bounded
   reader no longer references `os.O_NONBLOCK` directly, a Unix-only constant whose absence on
-  Windows raised an `AttributeError` past every guard on every scan path.
+  Windows raised an `AttributeError` past every guard on every scan path. The size guard is now
+  asserted through behaviour rather than by spying on `pathlib.Path.read_text`, which stopped
+  observing anything when the reader moved to `os.open` — deleting the guard had left its own test
+  green. And a run whose duplicate detection failed reports `digest_degraded`, so an uncollapsed
+  count can no longer be mistaken for a scan that found no duplicates.
 
 - **Documented commands in tables and indented bullets now count.** `efficiency`
   credited a documented command only as a top-level bullet, so an indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   once per run instead of twice — the duplicate read also printed every warning twice. And a
   suite that parses but will not serialise no longer hashes as a fixed marker: two skills with
   different unserialisable suites shared one identity, so the second was reported as a copy of
-  the first.
+  the first — and the same held for two suites broken in different ways, which shared the coarse
+  reason string. A duplicated skill whose suite is also broken now keeps the "do NOT run
+  `/schliff:init` on these" warning, which fell through the counters that gate it. The bounded
+  reader no longer references `os.O_NONBLOCK` directly, a Unix-only constant whose absence on
+  Windows raised an `AttributeError` past every guard on every scan path.
 
 - **Documented commands in tables and indented bullets now count.** `efficiency`
   credited a documented command only as a top-level bullet, so an indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   the column was two characters narrower than the string it was widened to keep whole; the
   width is now derived from the reasons the loader can actually produce and asserted by a test,
   so a new reason cannot silently re-open it. And each `eval-suite.json` is read and parsed
-  once per run instead of twice — the duplicate read also printed every warning twice.
+  once per run instead of twice — the duplicate read also printed every warning twice. And a
+  suite that parses but will not serialise no longer hashes as a fixed marker: two skills with
+  different unserialisable suites shared one identity, so the second was reported as a copy of
+  the first.
 
 - **Documented commands in tables and indented bullets now count.** `efficiency`
   credited a documented command only as a top-level bullet, so an indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **`doctor` counts one install per skill, not one per copy on disk.** A plugin present in both
+  `plugins/cache/` and `plugins/marketplaces/` was scored and billed twice, inflating the skill
+  count, the grade distribution and the headline "Total context cost". Copies are now collapsed
+  by a digest over SKILL.md, `references/*.md` and `eval-suite.json` — the files a row is
+  actually derived from — and every path in a group is printed so you can delete one. Nothing is
+  removed for you. `--json` gains `duplicate_copies` and `skills_discovered` (the physical file
+  count, next to the deduplicated `skills_found`). Path-based exclusion was measured and
+  rejected; see `docs/specs/2026-08-13-doctor-counts-vendored-skills.md`, "Amendment 2026-08-26".
+
 - **Documented commands in tables and indented bullets now count.** `efficiency`
   credited a documented command only as a top-level bullet, so an indented
   sub-bullet or a markdown command table scored nothing. Measured over 1732

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   enough to exhaust the parser's recursion (the last only below Python 3.14, so CI's newest leg
   stayed green while the oldest failed). Every failure now degrades to "no suite" with a warning
   on stderr. `doctor` distinguishes it from an absent suite via `eval_suite_error` and a per-row
-  action that says to repair rather than overwrite. Every file this module opens is now checked
-  for being a regular file and for its size *before* it is read, so a FIFO cannot hang the scan
-  and an oversized file cannot exhaust memory. `--json` gains `eval_suite_error` per row plus
+  action that says to repair rather than overwrite. Every file read on the discovery and scoring path — SKILL.md,
+  `references/*.md` and `eval-suite.json` — is now checked for being a regular file and for its
+  size *before* it is read, so a FIFO cannot hang the scan and an oversized file cannot exhaust
+  memory. (`read_skill_safe` still reads before checking size, deliberately: it resolves the
+  TOCTOU race the other way and its callers sit inside a handler.) `--json` gains `eval_suite_error` per row plus
   `broken_eval_suite`, `grouped_duplicates` and `skills_discovered` in the summary, and such a skill is kept out of the
   `/schliff:init` recommendation — that command would write over the file that failed to load.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   action that says to repair rather than overwrite. Every file read on the discovery and scoring path — SKILL.md,
   `references/*.md` and `eval-suite.json` — is now checked for being a regular file and for its
   size *before* it is read, so a FIFO cannot hang the scan and an oversized file cannot exhaust
-  memory. (`read_skill_safe` still reads before checking size, deliberately: it resolves the
+  memory. Those two checks run on the descriptor the read is about to use (`O_NONBLOCK` open,
+  then `fstat`), not on the path: checking the path first leaves a window in which it can be
+  swapped for a FIFO afterwards, and anyone able to plant the FIFO can also win that race.
+  (`read_skill_safe` still reads before checking size, deliberately: it resolves the
   TOCTOU race the other way and its callers sit inside a handler.) `--json` gains `eval_suite_error` per row plus
   `broken_eval_suite`, `grouped_duplicates` and `skills_discovered` in the summary, and such a skill is kept out of the
   `/schliff:init` recommendation — that command would write over the file that failed to load.
@@ -46,6 +49,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   removed for you. `--json` gains `duplicate_copies` and `skills_discovered` (the physical file
   count, next to the deduplicated `skills_found`). Path-based exclusion was measured and
   rejected; see `docs/specs/2026-08-13-doctor-counts-vendored-skills.md`, "Amendment 2026-08-26".
+  The report no longer claims the counted copy is "usually the plugin cache": that holds when
+  the scan is pointed at `~/.claude`, but under the default directories `.claude/skills` sorts
+  ahead of the home path, so the counted copy is your own project one — and the advice to act
+  on "the copy you control" pointed at exactly the wrong file. The counted path is now
+  described as what it is, an artifact of sort order. A duplicated skill also no longer draws
+  skill-specific advice telling you to edit it, which contradicted its own row.
+
+- **An oversized `eval-suite.json` says so.** It reported `unreadable`, the same word as a
+  permission error, so the fix suggested was to repair a file whose only problem was its size.
+  A grouped-and-broken row also truncated its own reason mid-word (`not a JSON objec`), because
+  the column was two characters narrower than the string it was widened to keep whole; the
+  width is now derived from the reasons the loader can actually produce and asserted by a test,
+  so a new reason cannot silently re-open it. And each `eval-suite.json` is read and parsed
+  once per run instead of twice — the duplicate read also printed every warning twice.
 
 - **Documented commands in tables and indented bullets now count.** `efficiency`
   credited a documented command only as a top-level bullet, so an indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply
   enough to exhaust the parser's recursion (the last only below Python 3.14, so CI's newest leg
   stayed green while the oldest failed). Every failure now degrades to "no suite" with a warning
-  on stderr. `doctor` distinguishes it from an absent suite: The loader also checks `stat().st_size` before reading, so an oversized suite is
-  never pulled into memory. `--json` gains `eval_suite_error` per row plus
+  on stderr. `doctor` distinguishes it from an absent suite via `eval_suite_error` and a per-row
+  action that says to repair rather than overwrite. Every file this module opens is now checked
+  for being a regular file and for its size *before* it is read, so a FIFO cannot hang the scan
+  and an oversized file cannot exhaust memory. `--json` gains `eval_suite_error` per row plus
   `broken_eval_suite`, `grouped_duplicates` and `skills_discovered` in the summary, and such a skill is kept out of the
   `/schliff:init` recommendation — that command would write over the file that failed to load.
 

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -34,11 +34,22 @@ Run a comprehensive health check on all installed skills.
    Summary: X skills scanned, Y healthy, Z need attention
    ```
 
-3. For skills with grade D or F, suggest specific next steps:
+3. If `duplicate_copies` is non-empty, report it under the table. The same skill
+   installed twice (typically a plugin present in both `plugins/cache/` and
+   `plugins/marketplaces/`) is counted once, so `skills_found` is lower than
+   `skills_discovered` — say so, or the drop looks like skills went missing:
+
+   ```
+   N skills are installed more than once (M extra copies, counted once).
+   Which copy is counted is arbitrary — name every path in the group and let
+   the reader pick the one they control before acting on it.
+   ```
+
+4. For skills with grade D or F, suggest specific next steps:
    - "Run `/schliff:init <path>` to set up improvement tracking"
    - "Run `/schliff:analyze <path>` for detailed gap analysis"
 
-4. If `--verbose` flag is provided, show per-dimension breakdowns for each skill.
+5. If `--verbose` flag is provided, show per-dimension breakdowns for each skill.
 
 ## Flags
 

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -36,15 +36,15 @@ Run a comprehensive health check on all installed skills.
 
 3. If `duplicate_copies` is non-empty, report it **above** the table — the CLI
    renderer prints it there, and the two surfaces should not disagree on shape.
-   The same skill installed twice is counted once. That pairing is usually
-   `plugins/cache/` and `plugins/marketplaces/` when the scan is pointed at
-   `~/.claude`; a default run never scans `~/.claude/plugins` at all, so there it
-   is a home copy and a project-local one:
+   A skill whose scored payload (SKILL.md, `references/*.md`, `eval-suite.json`)
+   is identical at several paths is counted once. Report the comparison, never a
+   conclusion about the filesystem: the directories are not compared, so members
+   may be different versions of the same plugin, and both may be live installs.
 
    ```
-   N skills are installed more than once (M extra copies, counted once).
-   The counted path is whichever sorted first — an artifact of sort order, not
-   a recommendation. Name every path in the group so the reader can check them.
+   N skills have an identical scored payload at M paths — each counted once (K paths collapsed).
+   The counted path is whichever sorted first, an artifact of sort order rather
+   than a recommendation. Name every path so the reader can check them.
    ```
 
    Do not explain the whole `skills_discovered` − `skills_found` gap as

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -41,8 +41,8 @@ Run a comprehensive health check on all installed skills.
 
    ```
    N skills are installed more than once (M extra copies, counted once).
-   Which copy is counted is arbitrary — name every path in the group and let
-   the reader pick the one they control before acting on it.
+   The counted path is whichever sorted first, usually the plugin cache — name
+   every path in the group so the reader can act on the copy they control.
    ```
 
    Do not explain the whole `skills_discovered` − `skills_found` gap as
@@ -51,11 +51,16 @@ Run a comprehensive health check on all installed skills.
    Result rows carry an `also_installed_at` too, but only on rows that scored —
    summing those undercounts whenever a duplicated skill failed.
 
-4. For skills with grade D or F, suggest specific next steps:
+4. A row with `eval_suite_error` has a suite that is present but unreadable —
+   report the reason and do not suggest `/schliff:init`, which would write over
+   that file. A row with `also_installed_at` names one arbitrary member of a
+   group; use its `action` verbatim rather than composing a command from `path`.
+
+5. For skills with grade D or F, suggest specific next steps:
    - "Run `/schliff:init <path>` to set up improvement tracking"
    - "Run `/schliff:analyze <path>` for detailed gap analysis"
 
-5. If `--verbose` flag is provided, show per-dimension breakdowns for each skill.
+6. If `--verbose` flag is provided, show per-dimension breakdowns for each skill.
 
 ## Flags
 

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -36,8 +36,10 @@ Run a comprehensive health check on all installed skills.
 
 3. If `duplicate_copies` is non-empty, report it **above** the table — the CLI
    renderer prints it there, and the two surfaces should not disagree on shape.
-   The same skill installed twice (typically a plugin present in both
-   `plugins/cache/` and `plugins/marketplaces/`) is counted once:
+   The same skill installed twice is counted once. That pairing is usually
+   `plugins/cache/` and `plugins/marketplaces/` when the scan is pointed at
+   `~/.claude`; a default run never scans `~/.claude/plugins` at all, so there it
+   is a home copy and a project-local one:
 
    ```
    N skills are installed more than once (M extra copies, counted once).

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -41,8 +41,8 @@ Run a comprehensive health check on all installed skills.
 
    ```
    N skills are installed more than once (M extra copies, counted once).
-   The counted path is whichever sorted first, usually the plugin cache — name
-   every path in the group so the reader can act on the copy they control.
+   The counted path is whichever sorted first — an artifact of sort order, not
+   a recommendation. Name every path in the group so the reader can check them.
    ```
 
    Do not explain the whole `skills_discovered` − `skills_found` gap as
@@ -54,8 +54,8 @@ Run a comprehensive health check on all installed skills.
 4. A row with `eval_suite_error` has a suite that is present but unreadable —
    report the reason and do not suggest `/schliff:init`, which would write over
    that file. A row with `also_installed_at` names whichever member sorted
-   first — usually the plugin cache; use its `action` verbatim rather than
-   composing a command from `path`.
+   first, which is picked by sort order and not by merit; use its `action`
+   verbatim rather than composing a command from `path`.
 
 5. For skills with grade D or F, suggest specific next steps — **except** on rows
    carrying `eval_suite_error` or `also_installed_at`, whose own `action` already

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -47,7 +47,9 @@ Run a comprehensive health check on all installed skills.
 
    Do not explain the whole `skills_discovered` − `skills_found` gap as
    duplicates: a skill that fails to score widens it too. The duplicate share is
-   the sum of `also_installed_at` lengths; the rest is `failed`.
+   the sum over `duplicate_copies[].also_installed_at`; the rest is `failed`.
+   Result rows carry an `also_installed_at` too, but only on rows that scored —
+   summing those undercounts whenever a duplicated skill failed.
 
 4. For skills with grade D or F, suggest specific next steps:
    - "Run `/schliff:init <path>` to set up improvement tracking"

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -53,8 +53,9 @@ Run a comprehensive health check on all installed skills.
 
 4. A row with `eval_suite_error` has a suite that is present but unreadable —
    report the reason and do not suggest `/schliff:init`, which would write over
-   that file. A row with `also_installed_at` names one arbitrary member of a
-   group; use its `action` verbatim rather than composing a command from `path`.
+   that file. A row with `also_installed_at` names whichever member sorted
+   first — usually the plugin cache; use its `action` verbatim rather than
+   composing a command from `path`.
 
 5. For skills with grade D or F, suggest specific next steps:
    - "Run `/schliff:init <path>` to set up improvement tracking"

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -34,16 +34,20 @@ Run a comprehensive health check on all installed skills.
    Summary: X skills scanned, Y healthy, Z need attention
    ```
 
-3. If `duplicate_copies` is non-empty, report it under the table. The same skill
-   installed twice (typically a plugin present in both `plugins/cache/` and
-   `plugins/marketplaces/`) is counted once, so `skills_found` is lower than
-   `skills_discovered` — say so, or the drop looks like skills went missing:
+3. If `duplicate_copies` is non-empty, report it **above** the table — the CLI
+   renderer prints it there, and the two surfaces should not disagree on shape.
+   The same skill installed twice (typically a plugin present in both
+   `plugins/cache/` and `plugins/marketplaces/`) is counted once:
 
    ```
    N skills are installed more than once (M extra copies, counted once).
    Which copy is counted is arbitrary — name every path in the group and let
    the reader pick the one they control before acting on it.
    ```
+
+   Do not explain the whole `skills_discovered` − `skills_found` gap as
+   duplicates: a skill that fails to score widens it too. The duplicate share is
+   the sum of `also_installed_at` lengths; the rest is `failed`.
 
 4. For skills with grade D or F, suggest specific next steps:
    - "Run `/schliff:init <path>` to set up improvement tracking"

--- a/commands/schliff/doctor.md
+++ b/commands/schliff/doctor.md
@@ -57,7 +57,11 @@ Run a comprehensive health check on all installed skills.
    first — usually the plugin cache; use its `action` verbatim rather than
    composing a command from `path`.
 
-5. For skills with grade D or F, suggest specific next steps:
+5. For skills with grade D or F, suggest specific next steps — **except** on rows
+   carrying `eval_suite_error` or `also_installed_at`, whose own `action` already
+   says what to do and must be used verbatim. A broken suite often scores F, so
+   the blanket recommendation would otherwise hand out the command that
+   overwrites it.
    - "Run `/schliff:init <path>` to set up improvement tracking"
    - "Run `/schliff:analyze <path>` for detailed gap analysis"
 

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -134,8 +134,24 @@ times — each time by re-deriving a domain instead of asking the code that owns
   two copies collapsed again. The digest now calls `load_eval_suite` instead of re-deriving
   where the file is, which makes the domains identical by construction rather than by review.
 
-All three are pinned by mutation-verified tests in
+* *The loader's error contract.* Calling `load_eval_suite` fixed the discovery mismatch and
+  created a new one: it caught only `JSONDecodeError`, so a suite that is a directory,
+  unreadable, or not UTF-8 raised. That was survivable while its only caller sat inside
+  `_score_single_skill`'s `except Exception` — one row went to `failed` — and stopped being
+  survivable the moment the digest called it before the scoring loop. One malformed
+  `eval-suite.json` anywhere under `~/.claude` turned `doctor` into a traceback. Fixed at the
+  loader: every failure degrades to `None`, so digest and score see the same value by
+  construction rather than one crashing where the other degraded.
+
+All four are pinned by mutation-verified tests in
 `skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py`.
+
+**The shape behind all four.** Each was a domain re-derived instead of asked for. The
+`references/*.md` enumeration is now `shared._payload_files`, called by both
+`estimate_token_cost` and `skill_payload_digest`, so the cost domain and the identity domain
+cannot drift apart. The drift was already primed: `estimate_token_cost`'s docstring says "all
+files in references/" while its code globbed `*.md`; making the code match would have widened
+the cost and not the digest.
 
 **Known limit, deliberately not closed.** The `Issues` column can still differ between two
 copies with the same digest: `structure`'s dangling-reference lint resolves declared paths such

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -286,6 +286,33 @@ extracting into references/" beside a row whose own action says to resolve the d
 against a path picked by sort order. Carved out the same way the `/schliff:init` and
 `/schliff:auto` tallies already carve it out.
 
+## Amendment 2026-08-28 (2) — round 11
+
+**A constant is not an identity.** When a suite parsed but `json.dumps` raised, the digest absorbed
+the literal `"<unserialisable>"`. Two skills sharing a SKILL.md but holding *different*
+unserialisable suites therefore got one digest, and the second vanished from the report as a copy
+of the first — the failure the `else` branch three lines below it names in the same function. The
+marker now comes from `shared.eval_suite_content_id`, a sha256 the loader records over the bytes it
+read; the digest reads it rather than re-opening the path, which is the re-derivation this module
+has already paid for five times.
+
+The test forces `json.dumps` to raise instead of building a deeply nested fixture: below Python
+3.14 `json.loads` recurses first, so the branch is unreachable on the interpreter this suite
+usually runs on and a nesting fixture would prove nothing there.
+
+**Two findings from round 11 were deliberately NOT fixed here**, both because they are design
+choices rather than mechanical corrections, and neither has a site in the field:
+
+- *`MAX_SKILL_SIZE` is bytes in `_read_bounded` and characters in `read_skill_safe`.* A file
+  between the two thresholds is dropped from `doctor` and `mesh` with empty stderr while
+  `schliff score` still reads it. Measured over the real 159: largest SKILL.md is 80,431 B /
+  80,328 c, a factor of 12 below the limit, 0 files above 200 KB, byte-to-char ratio 1.0013. Real,
+  latent, and it moves a DoS boundary — which does not belong in a green PR inside a freeze window.
+- *`_payload_files` checks `is_symlink()` on the path, `_read_bounded` then opens that path.* Not a
+  regression: `main` had `is_symlink()` followed by `read_text()`, the same check-then-open shape.
+  Closing it means `O_NOFOLLOW`, which would also take the symlink-following that `load_eval_suite`
+  deliberately has for stow/chezmoi layouts — so it needs a per-caller flag and a decision.
+
 **Not fixed, awaiting a decision:** a grouped row lands in no quality tally — `grouped_duplicates`
 counts it, but `healthy`/`needs_work` do not, so on the real install 19 of 138 skills are absent
 from the counts the summary line reports. The suppression is right for the command

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -86,3 +86,55 @@ vendored path segment; the count of files excluded *without* one is 0.
 
 Full suite: **2121 passed**. `EXCLUDED_DIRS` is shared, so the three added entries also
 apply to `sync.py` and the AGENTS.md walk — same semantics, no test moved.
+
+## Amendment 2026-08-26 — path exclusion does not reach the duplicate-install case
+
+The section above solved *vendored copies* — a skill sitting inside `site-packages` or a uv
+cache archive — by extending `EXCLUDED_DIRS`. That fix stands. It does not reach the case
+below, and extending the set further would break the measurement rather than repair it.
+
+**The case.** A Claude Code plugin is installed under `~/.claude/plugins/cache/…` and also
+appears under `~/.claude/plugins/marketplaces/…`. Both copies are real, both are the same
+bytes, and both were counted.
+
+**Measured on a real `~/.claude` at `c651d13`** — this is the single home for these numbers;
+the code comments point here rather than restating them:
+
+| | before | after |
+| --- | --- | --- |
+| skills counted | 159 | 138 |
+| headline context cost | 495,928 tokens | 438,597 tokens |
+| duplicate groups reported | — | 20 (21 extra copies) |
+
+**Why not `EXCLUDED_DIRS`.** Adding `cache` takes the count from **159 to 50**: the cache *is*
+where plugins install, so the exclusion would delete the majority of real skills instead of the
+duplicates. The set has already needed three extensions (`site-packages`, `.cache`, `.vercel`);
+a path wordlist is complete only until the next package manager. This is the enumeration trap
+recorded in the 2026-08-25 amendment to
+`docs/specs/2026-08-13-structural-signal-detection.md`, in a different file.
+
+**The rule instead.** `shared.skill_payload_digest` — sha256 over SKILL.md, `references/*.md`
+and `eval-suite.json`, length-prefixed. It carries no vendor names and does not grow.
+
+**The key covers exactly what a doctor row is derived from, and that was got wrong twice:**
+
+* *Cost.* Hashing SKILL.md alone collapses installs that cost different amounts — two
+  byte-identical SKILL.md with different `references/` came to 9,013 and 9,591 tokens. The
+  published total then depended on iteration order (keep-first 429,006, keep-last 429,584), and
+  keep-first kept a June **backup** while discarding the live
+  `~/.claude/skills/schliff/SKILL.md`: the cure deleting the subject of the measurement.
+* *Score.* `eval-suite.json` moves a row from 4-of-7 dimensions to 7-of-7. Two byte-identical
+  SKILL.md, one with the suite beside it, scored **38.3 [E]** and **93.0 [A]**. Ignoring it let
+  path sort order decide which the reader saw — a 55-point swing settled by a string comparison.
+
+Both are pinned by mutation-verified tests in
+`skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py`.
+
+**What is deliberately not decided.** Which copy of a genuine duplicate is *counted* is
+arbitrary: after the digest they are identical in everything measured. The path is not
+interchangeable to a reader — `/schliff:auto` writes `.schliff/` history beside the file, and a
+plugin cache directory is overwritten on the next update — so the report prints every path in a
+group and says the choice is arbitrary. Nothing is deleted (ADR 0019).
+
+**Still open, unchanged by this:** `doctor --json` reports `mesh_issue_count: 0` under
+`incremental=True` while a fresh analysis finds 49. Present on `main` before this change.

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -179,6 +179,20 @@ an OOM; `skill_mesh` confines resolved paths to the scan root for the same reaso
 real and the case was not. If a field case appears, the fix is confinement plus a
 `stat().st_size` check before the read, not a bare `resolve()`.
 
+**One reader for every file this module opens.** `shared._read_bounded` checks *regular file*,
+then *size*, then reads — and the ordering of those three is the whole point. `read_text` on a
+FIFO blocks forever (measured: still blocked after six seconds) and `st_size` is 0 for one, so a
+size gate alone lets it through; reading before the size check raises `MemoryError` on a
+multi-gigabyte target, which is neither `OSError` nor `ValueError`. Both were survivable while
+every caller sat inside `_score_single_skill`'s handler and stopped being survivable when the
+digest began reading before the scoring loop. The same two-line omission produced five defects
+here, which is why the check exists once rather than at each call site.
+
+**A suite that is not a JSON object is a broken suite.** `null` parses to `None`, which was
+indistinguishable from "no file" and routed the row to `/schliff:init` — the command that
+overwrites it. A list or string was accepted outright, while `cli._load_eval_suite_from_args`
+rejects the identical content; the auto-discovery half was the permissive one.
+
 **The loader checks size before reading.** `read_text` on a multi-gigabyte target raises
 `MemoryError`, which none of the handlers above catch, and the digest calls the loader before the
 scoring loop — so one such file ended the run rather than marking one row failed.

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -116,7 +116,8 @@ recorded in the 2026-08-25 amendment to
 **The rule instead.** `shared.skill_payload_digest` — sha256 over SKILL.md, `references/*.md`
 and `eval-suite.json`, length-prefixed. It carries no vendor names and does not grow.
 
-**The key covers exactly what a doctor row is derived from, and that was got wrong twice:**
+**The key covers what a row's SCORE and COST are derived from, and that was got wrong three
+times — each time by re-deriving a domain instead of asking the code that owns it:**
 
 * *Cost.* Hashing SKILL.md alone collapses installs that cost different amounts — two
   byte-identical SKILL.md with different `references/` came to 9,013 and 9,591 tokens. The
@@ -127,8 +128,21 @@ and `eval-suite.json`, length-prefixed. It carries no vendor names and does not 
   SKILL.md, one with the suite beside it, scored **38.3 [E]** and **93.0 [A]**. Ignoring it let
   path sort order decide which the reader saw — a 55-point swing settled by a string comparison.
 
-Both are pinned by mutation-verified tests in
+* *The loader's own discovery.* The first eval-suite branch copied
+  `estimate_token_cost`'s symlink skip. `load_eval_suite` has no such guard — it follows the
+  link — so a stow/chezmoi layout was scored 7-of-7 and hashed as if it had no suite, and the
+  two copies collapsed again. The digest now calls `load_eval_suite` instead of re-deriving
+  where the file is, which makes the domains identical by construction rather than by review.
+
+All three are pinned by mutation-verified tests in
 `skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py`.
+
+**Known limit, deliberately not closed.** The `Issues` column can still differ between two
+copies with the same digest: `structure`'s dangling-reference lint resolves declared paths such
+as `scripts/run.py` against the skill directory and its plugin/git ancestors, which lie outside
+the digest's domain. Measured over the 20 real groups: 0 divergences, and that lint does not
+score. Widening the digest to every path a skill might declare is the enumeration trap again;
+reporting the union of issues across a group is the fix if a field case ever appears.
 
 **What is deliberately not decided.** Which copy of a genuine duplicate is *counted* is
 arbitrary: after the digest they are identical in everything measured. The path is not

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -168,8 +168,9 @@ reporting the union of issues across a group is the fix if a field case ever app
 
 **Which copy is counted, and why the row carries no command.** Not arbitrary: `discover_skills`
 sorts by path and the first wins, so `plugins/cache/…` beats `plugins/marketplaces/…` and
-`~/.claude/skills/…` every time. That is a systematic bias toward the one copy a reader should
-*not* act on — `/schliff:auto` writes `.schliff/` history beside the file, and a plugin cache is
+`~/.claude/skills/…`. That holds for those three absolute paths, i.e. for a scan pointed at
+`~/.claude` — **it is not true of the default invocation**; see "Amendment 2026-08-28". Where it
+does hold it is a systematic bias toward the one copy a reader should *not* act on — `/schliff:auto` writes `.schliff/` history beside the file, and a plugin cache is
 overwritten on the next update. Preferring another member would require a path wordlist, the
 enumeration this key exists to avoid, so instead a grouped row states the duplicate rather than
 emitting a command against one member. Every path in the group is printed; nothing is deleted
@@ -227,3 +228,65 @@ to fix the file rather than `/schliff:init`, which would write over it.
 
 **Still open, unchanged by this:** `doctor --json` reports `mesh_issue_count: 0` under
 `incremental=True` while a fresh analysis finds 49. Present on `main` before this change.
+
+## Amendment 2026-08-28 — the reporting layer, from review round 10
+
+Nine rounds went to the collapse logic; the tenth found six defects, all of them in what the
+report *says* rather than in what it counts. Recorded because five of the six are the same shape:
+a sentence that was true of the measured case and stated unconditionally.
+
+**"Usually the plugin cache" is false under the default invocation.** `_default_skill_dirs()` is
+`[~/.claude/skills, .claude/skills]`; `~/.claude/plugins` is never scanned by a default run, so
+no plugin cache is in the comparison at all. And `.` (0x2E) sorts before `/` (0x2F), so the
+relative project path wins:
+
+```
+counted: .claude/skills/dup/SKILL.md
+also at: /…/home/.claude/skills/dup/SKILL.md
+```
+
+The banner then told the reader that this counted path is "usually the plugin cache — act on the
+copy you control", i.e. to treat their own working copy as the disposable one. The claim had
+**eight homes** (banner, four code comments, two lines of `commands/schliff/doctor.md`, one spec
+sentence above) — the #209 pattern again. All are now either qualified with the invocation they
+hold for, or state only what is invariant: the counted path is an artifact of sort order.
+
+**A repair reason was truncated by the column widened to keep it.** `"Resolve the duplicate
+install first; eval-suite.json: "` is 54 characters, so a 70-wide cap cut `not a JSON object` to
+`not a JSON objec`. The width is now `REPAIR_ACTION_WIDTH`, and
+`test_repair_action_fits_its_column` derives the longest composed action from the reasons
+`load_eval_suite` can actually produce — enumerated out of the module's AST, not hand-listed — so
+a new reason fails the test instead of silently truncating. A gate, not a convention.
+
+**"Unreadable" hid the one diagnosis the reader needed.** `_read_bounded` collapsed "not a regular
+file", "too large" and `OSError` into a single `None`, so a 2 MB suite was reported as unreadable
+and the advice was to repair a file whose only defect was its size. It now returns a short,
+path-free reason (path-free because the reason is folded into the identity — the defect recorded
+in "Amendment 2026-08-26").
+
+**The size check ran on the path, not on the descriptor.** `is_file()` → `stat()` → `read_text()`
+leaves a window in which the path is swapped for a FIFO after it has answered "regular file", and
+a party that can plant the FIFO can win that race — so under this function's own stated threat
+model the hang stayed reachable. Now `O_NONBLOCK` open, then `fstat` on that descriptor.
+
+A plain FIFO is the **wrong test** for this and was written first: `is_file()` already returns
+False for one, so a FIFO fixture stays green against the very mutation it quotes. The
+discriminating fixture answers the path-level questions the old shape asked while the object on
+disk is a FIFO; under the old shape it blocks, and the instrument is a clock, not an exception.
+Verified: the mutation hangs the thread and the test fails after 5.16 s.
+
+**Every `eval-suite.json` was read and parsed twice per run** — once by `skill_payload_digest`,
+once by `_score_single_skill` — and every warning printed twice. Cached following the shape
+`_file_cache` already uses in the module, with one addition: the key carries an
+`(st_mtime_ns, st_size)` stamp. A path-only key made a repaired suite stale and
+`test_a_repaired_suite_clears_its_recorded_failure` — an existing test — caught it.
+
+**Grouped rows still drew skill-specific advice.** A duplicated 408-line skill got "Consider
+extracting into references/" beside a row whose own action says to resolve the duplicate first,
+against a path picked by sort order. Carved out the same way the `/schliff:init` and
+`/schliff:auto` tallies already carve it out.
+
+**Not fixed, awaiting a decision:** a grouped row lands in no quality tally — `grouped_duplicates`
+counts it, but `healthy`/`needs_work` do not, so on the real install 19 of 138 skills are absent
+from the counts the summary line reports. The suppression is right for the command
+recommendations; whether it is right for the counts is a separate judgement.

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -160,11 +160,23 @@ the digest's domain. Measured over the 20 real groups: 0 divergences, and that l
 score. Widening the digest to every path a skill might declare is the enumeration trap again;
 reporting the union of issues across a group is the fix if a field case ever appears.
 
-**What is deliberately not decided.** Which copy of a genuine duplicate is *counted* is
-arbitrary: after the digest they are identical in everything measured. The path is not
-interchangeable to a reader — `/schliff:auto` writes `.schliff/` history beside the file, and a
-plugin cache directory is overwritten on the next update — so the report prints every path in a
-group and says the choice is arbitrary. Nothing is deleted (ADR 0019).
+**Which copy is counted, and why the row carries no command.** Not arbitrary: `discover_skills`
+sorts by path and the first wins, so `plugins/cache/…` beats `plugins/marketplaces/…` and
+`~/.claude/skills/…` every time. That is a systematic bias toward the one copy a reader should
+*not* act on — `/schliff:auto` writes `.schliff/` history beside the file, and a plugin cache is
+overwritten on the next update. Preferring another member would require a path wordlist, the
+enumeration this key exists to avoid, so instead a grouped row states the duplicate rather than
+emitting a command against one member. Every path in the group is printed; nothing is deleted
+(ADR 0019).
+
+**A broken eval suite is not an absent one.** `load_eval_suite` degrades every failure to `None`
+so one bad file cannot end a run — including `RecursionError`, which `json.loads` raises on deeply
+nested input below CPython 3.14 and which is neither `OSError` nor `ValueError`. That version
+dependence is the dangerous part: the newest CI leg stays green while the oldest tracebacks.
+Degrading is not enough on its own, though — "absent" and "present but broken" produce different
+rows, so the failure is recorded in `shared.eval_suite_error`, reported per row as
+`eval_suite_error`, folded into the digest so the two do not collapse, and the row's action says
+to fix the file rather than `/schliff:init`, which would write over it.
 
 **Still open, unchanged by this:** `doctor --json` reports `mesh_issue_count: 0` under
 `incremental=True` while a fresh analysis finds 49. Present on `main` before this change.

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -179,6 +179,17 @@ an OOM; `skill_mesh` confines resolved paths to the scan root for the same reaso
 real and the case was not. If a field case appears, the fix is confinement plus a
 `stat().st_size` check before the read, not a bare `resolve()`.
 
+**The loader checks size before reading.** `read_text` on a multi-gigabyte target raises
+`MemoryError`, which none of the handlers above catch, and the digest calls the loader before the
+scoring loop — so one such file ended the run rather than marking one row failed.
+`cli._load_eval_suite_from_args` had done `stat().st_size` first since the OOM-safe-loading fix;
+the shared loader never received it. It does now.
+
+**A grouped row is not "missing an eval suite".** Its own action says to resolve the duplicate,
+and its path is the plugin cache. Counting it as missing put all 20 real groups into "Run
+/schliff:init on N skills missing eval suites" — writing into a directory the next plugin update
+deletes, and contradicting the row itself. Counted separately as `grouped_duplicates`.
+
 **A broken eval suite is not an absent one.** `load_eval_suite` degrades every failure to `None`
 so one bad file cannot end a run — including `RecursionError`, which `json.loads` raises on deeply
 nested input below CPython 3.14 and which is neither `OSError` nor `ValueError`. That version

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -313,6 +313,41 @@ choices rather than mechanical corrections, and neither has a site in the field:
   Closing it means `O_NOFOLLOW`, which would also take the symlink-following that `load_eval_suite`
   deliberately has for stow/chezmoi layouts — so it needs a per-caller flag and a decision.
 
+## Amendment 2026-08-28 (3) — round 12, and the sweep that was not one
+
+Four findings, and the instructive part is that **two of them were introduced by the round-11
+fix itself**. The finding count stopped falling (7 → 3 → 4) not because the review was grinding
+but because new defects were being added at roughly the rate old ones were removed.
+
+**`os.O_NONBLOCK` is Unix-only.** The descriptor-based reader shipped in round 10 referenced it
+directly. On Windows the attribute lookup raises `AttributeError` — neither `OSError` nor
+`ValueError`, so the reader's own guard does not catch it — and the reader now sits on *every*
+scan path, so the first file of any run would traceback. `getattr(os, "O_NONBLOCK", 0)`. The
+project treats Windows as in scope elsewhere (`verify.py:155` has an explicit fallback with a
+comment saying so) and `pyproject.toml` declares no OS classifier.
+
+**The `<unserialisable>` fix was applied to one branch of two.** Three lines below it, the
+`else` branch absorbed only the coarse reason string, so two suites both `malformed` for
+different reasons shared a digest and were reported as copies of each other. `eval_suite_content_id`
+was already populated on those paths — it is recorded before `json.loads` runs — so the fix was
+available and simply not carried across. This is the defect class this document has now recorded
+three times: *fix every site of a class, not the one the finding named.*
+
+**The digest phase ran outside every handler.** `_collapse_duplicate_copies` is called before the
+scoring loop, and `skill_payload_digest` reaches `read_skill_safe`, which reads before it checks
+size and can raise `MemoryError`. `_payload_files` justifies leaving `read_skill_safe` outside the
+bounded reader on the grounds that "its callers sit inside a handler" — false for this caller,
+exactly where a failure ends the whole run. Wrapped; the fallback reports every copy, the
+over-count direction this module has repeatedly recorded as the survivable one.
+
+**A grouped-and-broken row fell through every bucket** and took the report's strongest line with
+it. `grouped` is tested before `eval_suite_error`, so such a row incremented neither counter, and
+the whole "Recommended next steps" block is gated on those counts — so `do NOT run /schliff:init
+on these, it writes over them` was absent from the rendered report. Tracked as
+`grouped_broken_eval_suite`, beside the disjoint buckets rather than inside them, so the partition
+still holds exactly. Note this is *not* the open question below: the safety warning is separable
+from the quality counts, and only the counts are still undecided.
+
 **Not fixed, awaiting a decision:** a grouped row lands in no quality tally — `grouped_duplicates`
 counts it, but `healthy`/`needs_work` do not, so on the real install 19 of 138 skills are absent
 from the counts the summary line reports. The suppression is right for the command

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -116,7 +116,7 @@ recorded in the 2026-08-25 amendment to
 **The rule instead.** `shared.skill_payload_digest` — sha256 over SKILL.md, `references/*.md`
 and `eval-suite.json`, length-prefixed. It carries no vendor names and does not grow.
 
-**The key covers what a row's SCORE and COST are derived from, and that was got wrong three
+**The key covers what a row's SCORE and COST are derived from, and that was got wrong four
 times — each time by re-deriving a domain instead of asking the code that owns it:**
 
 * *Cost.* Hashing SKILL.md alone collapses installs that cost different amounts — two
@@ -168,6 +168,16 @@ overwritten on the next update. Preferring another member would require a path w
 enumeration this key exists to avoid, so instead a grouped row states the duplicate rather than
 emitting a command against one member. Every path in the group is printed; nothing is deleted
 (ADR 0019).
+
+**Symlinked `references/` stay rejected.** `estimate_token_cost` has rejected them since a
+shipped security fix, and `_payload_files` inherits that. It was briefly reversed here so a stow
+layout would collapse with its plain twin — on the strength of a self-written fixture. Measured
+afterwards: **0 symlinks across the 41 skills in the real installation that have a `references/`
+directory**. doctor walks other people's directories, so following a link there turns a word
+count into a filesystem oracle and reading before the size check turns a link to a huge file into
+an OOM; `skill_mesh` confines resolved paths to the scan root for the same reason. The cost was
+real and the case was not. If a field case appears, the fix is confinement plus a
+`stat().st_size` check before the read, not a bare `resolve()`.
 
 **A broken eval suite is not an absent one.** `load_eval_suite` degrades every failure to `None`
 so one bad file cannot end a run — including `RecursionError`, which `json.loads` raises on deeply

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -106,6 +106,12 @@ the code comments point here rather than restating them:
 | headline context cost | 495,928 tokens | 438,597 tokens |
 | duplicate groups reported | — | 20 (21 extra copies) |
 
+Measured 2026-08-26 on that installation. **It drifts**: a re-run the next day found 157 files and
+19 groups, with `skills counted` and the token total unchanged, because the two files that had
+gone were both duplicate copies. Plugins get installed and removed; the numbers above are a dated
+observation, not a fixture. What does not drift is the shape — every removed copy takes a group
+member with it and leaves the counted total alone, which is the property being claimed.
+
 **Why not `EXCLUDED_DIRS`.** Adding `cache` takes the count from **159 to 50**: the cache *is*
 where plugins install, so the exclusion would delete the majority of real skills instead of the
 duplicates. The set has already needed three extensions (`site-packages`, `.cache`, `.vercel`);
@@ -179,7 +185,13 @@ an OOM; `skill_mesh` confines resolved paths to the scan root for the same reaso
 real and the case was not. If a field case appears, the fix is confinement plus a
 `stat().st_size` check before the read, not a bare `resolve()`.
 
-**One reader for every file this module opens.** `shared._read_bounded` checks *regular file*,
+**One reader for every file on the discovery and scoring path.** `discover_skills` reads
+SKILL.md and is therefore the *first* file doctor opens — the guard has to start there, not
+downstream of it. A FIFO named SKILL.md blocked discovery past eight seconds before the reader
+below was ever reached. `read_skill_safe` is deliberately excluded: it reads before checking size
+to close the TOCTOU race, and its callers sit inside a handler.
+
+**The reader itself.** `shared._read_bounded` checks *regular file*,
 then *size*, then reads — and the ordering of those three is the whole point. `read_text` on a
 FIFO blocks forever (measured: still blocked after six seconds) and `st_size` is 0 for one, so a
 size gate alone lets it through; reading before the size check raises `MemoryError` on a

--- a/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
+++ b/docs/specs/2026-08-13-doctor-counts-vendored-skills.md
@@ -246,13 +246,18 @@ also at: /…/home/.claude/skills/dup/SKILL.md
 ```
 
 The banner then told the reader that this counted path is "usually the plugin cache — act on the
-copy you control", i.e. to treat their own working copy as the disposable one. The claim had
-**eight homes** (banner, four code comments, two lines of `commands/schliff/doctor.md`, one spec
-sentence above) — the #209 pattern again. All are now either qualified with the invocation they
-hold for, or state only what is invariant: the counted path is an artifact of sort order.
+copy you control", i.e. to treat their own working copy as the disposable one.
 
-**A repair reason was truncated by the column widened to keep it.** `"Resolve the duplicate
-install first; eval-suite.json: "` is 54 characters, so a 70-wide cap cut `not a JSON object` to
+The invariant, and the only thing any surface may state: **the counted path is whichever member
+sorted first.** That is a property of `sorted()`. Which member sort order favours depends on the
+directories being scanned, so it carries no information about which copy to act on.
+
+No claim is made here about how many places said otherwise. Three such counts were written during
+this work and all three were wrong, which is what a census of prose is worth; `grep -rn "plugin
+cache"` answers the question in a second and does not go stale.
+
+**A repair reason was truncated by the column widened to keep it.** The composed grouped-and-broken
+prefix runs well past 35 characters before the reason starts, so a 70-wide cap cut `not a JSON object` to
 `not a JSON objec`. The width is now `REPAIR_ACTION_WIDTH`, and
 `test_repair_action_fits_its_column` derives the longest composed action from the reasons
 `load_eval_suite` can actually produce — enumerated out of the module's AST, not hand-listed — so
@@ -352,3 +357,62 @@ from the quality counts, and only the counts are still undecided.
 counts it, but `healthy`/`needs_work` do not, so on the real install 19 of 138 skills are absent
 from the counts the summary line reports. The suppression is right for the command
 recommendations; whether it is right for the counts is a separate judgement.
+
+## Amendment 2026-08-28 (4) — the council round, and four items that were NOT done
+
+A four-advisor review was run against the *fix plan*, not the code. Three advisors returned REJECT.
+Four of the five planned items were wrong, and the replacement is smaller than the plan was. What
+follows is the reasoning, because the rejected items are the ones likely to be proposed again.
+
+**The digest measures a payload; the row and the advice spoke about a directory.** That mismatch,
+not the plugin-version case, is the defect. Measured: two skill directories differing in
+`scripts/run.py` collapse into one row. On the real install one group is **two live plugin
+versions** — `supabase/0.1.13` and `supabase/0.1.15`, both present in
+`~/.claude/plugins/installed_plugins.json`, one project-scoped and one user-scoped — whose
+directories differ in `CHANGELOG.md`, and sort order names the older one as the survivor.
+
+The report now states the comparison and stops: *"N skills have an identical scored payload at M
+paths — each counted once"*, followed by what was compared and the fact that the directories were
+not. The action a grouped row carries changed from `Resolve the duplicate install first` to
+`Scored once; other paths are listed above`. Deleting one sentence would not have been enough —
+the imperative lived in the Action column, the banner headline, `commands/schliff/doctor.md` and
+the CHANGELOG.
+
+**NOT DONE — refusing to collapse when the suite could not be read.** This was planned and it is a
+regression, measured: `skills_found 1→2` and the token total doubles for the group, because copies
+are byte-identical *by construction*, so their read failures are correlated, while two genuinely
+different skills failing identically is a coincidence. It also breaks
+`test_two_copies_with_the_same_broken_suite_still_collapse`, which exists to protect this. And the
+premise was wrong: nothing a row reports derives from an unread suite's bytes, so two such rows are
+identical in every quantity — which is when the digest is supposed to collapse them. Only the
+comment claiming otherwise was false; it is now correct.
+
+**NOT DONE — a gate over the prose claim.** The existing AST gate is legitimate because it
+enumerates a *machine-consumed, language-closed* set: string literals assigned into a named dict
+and returned from one named function. Sentences have no such closure, and a gate over them must
+decide whether a sentence *is* a claim. The proposed key ("concrete evidence strings") is the
+wordlist this key exists to avoid, and `ast.get_docstring` could not have seen the `#` comment or
+the Markdown lines where the claim actually lived. `grep -rn "plugin cache"` answers it in a second.
+What failed was writing the census, not the absence of a tool.
+
+**NOT DONE — widening the narrow action column to 80.** That branch carries `/schliff:auto <abs
+path>`; 80 characters of a path is neither whole nor short. The real defect was the *gate's* domain:
+it derived one prefix, so the bare grouped action — 35 characters against a 35-wide cap — sat
+outside it. The width branch now keys on whether the row's action is path-free, and the gate
+enumerates all three composed shapes from the module's own constants.
+
+**Two instruments were dead, both disarmed by an earlier round's own fix.** `ed99c12` moved reads to
+`os.open`/`os.fdopen`, and both `read_text` spies stopped observing anything; deleting the size
+guard left the references-side test green, and the suite-side one was carried by an unrelated
+assertion. Both are replaced by behavioural assertions — the recorded reason, and cost/identity
+unchanged by an oversized reference — which no change of read mechanic can disarm.
+
+**The bucket-partition test could not detect a broken partition.** All three fixtures shared one
+body, so all three collapsed into a single grouped row and disjointness was asserted over n=1 in
+the one bucket that cannot collide; double-counting a non-grouped row left the file green. The
+population now spans a grouped pair, an ungrouped row and a broken-suite row.
+
+**A degraded digest phase now says so in the artifact.** The round-12 fallback reported every copy
+and warned on stderr only, so `--json` was byte-shape identical to a clean scan with no duplicates —
+a case study generated from it would have published the uncollapsed count unmarked.
+`digest_degraded` travels in the report.

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -22,7 +22,12 @@ import skill_mesh
 from terminal_art import grade_colored, score_to_grade
 
 from scoring.formats import detect_format
-from shared import EXCLUDED_DIRS, estimate_token_cost, skill_payload_digest
+from shared import (
+    EXCLUDED_DIRS,
+    estimate_token_cost,
+    eval_suite_error,
+    skill_payload_digest,
+)
 
 # Filenames to match (lowercase) for instruction file discovery
 _INSTRUCTION_FILENAMES = {"claude.md", ".cursorrules", "agents.md"}
@@ -107,7 +112,15 @@ def _score_single_skill(skill_path: str) -> dict:
     score = composite["score"]
     has_eval = eval_suite is not None
 
-    if not has_eval:
+    # A suite that is present but unreadable is not the same as no suite. It was
+    # degraded to None so one bad file cannot end the run, but telling the user
+    # to run /schliff:init here would write eval-suite.json over the very file
+    # that failed to load.
+    suite_error = eval_suite_error.get(str(Path(skill_path).parent / "eval-suite.json"))
+
+    if suite_error:
+        action = f"Fix eval-suite.json first ({suite_error})"
+    elif not has_eval:
         action = f"/schliff:init {skill_path}"
     elif score < 50:
         action = f"/schliff:auto {skill_path}"
@@ -130,6 +143,7 @@ def _score_single_skill(skill_path: str) -> dict:
         "issue_count": len(all_issues),
         "issues": all_issues,
         "action": action,
+        "eval_suite_error": suite_error,
         "tokens": tokens,
         "recommendations": recommendations,
         # Vendor + line only, never the value (ADR 0014).
@@ -149,9 +163,14 @@ def _collapse_duplicate_copies(skills: list[dict]) -> tuple[list[dict], list[dic
     "Amendment 2026-08-26".
 
     Nothing is deleted; every path in a group is reported and the caller decides
-    (ADR 0019). Which copy is counted is arbitrary — after the digest they are
-    identical in everything measured — so the report says so rather than implying
-    the surviving path is the canonical one.
+    (ADR 0019). The counted copy is the first in discovery order, which sorts by
+    path — so for the dominant real case ``plugins/cache/…`` wins over
+    ``plugins/marketplaces/…`` and over ``~/.claude/skills/…``. That is not
+    arbitrary, it is a systematic bias toward the one copy the reader should NOT
+    act on: a plugin cache is overwritten on the next update. The copies are
+    identical in everything measured, so preferring another member would need a
+    path wordlist — the enumeration this whole key exists to avoid. Instead the
+    row for a group carries no runnable ``action``.
 
     Skills whose digest could not be computed are all kept: an empty digest is
     not an identity, so they must not collapse together.
@@ -256,6 +275,11 @@ def run_doctor(
         # explicit that the path is not interchangeable to a reader.
         if path in copies_by_path:
             result["also_installed_at"] = copies_by_path[path]
+            # `path` is one member of a group, picked by sort order rather than
+            # by merit, and it is usually the plugin cache. Emitting
+            # `/schliff:auto <that path>` would write .schliff/ history into a
+            # directory the next plugin update deletes.
+            result["action"] = "Resolve the duplicate install first"
         results.append(result)
 
         if not score_result["has_eval_suite"]:
@@ -382,8 +406,8 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
             f"once ({extra} extra {'copy' if extra == 1 else 'copies'}, counted once):"
         )
         lines.append(
-            "    Which copy is counted is arbitrary — pick the one you control "
-            "before acting on its path."
+            "    The counted path is whichever sorted first, which is usually the "
+            "plugin cache — act on the copy you control."
         )
         for d in duplicate_copies[:10]:
             lines.append(f"    {d['name']}")

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -140,28 +140,21 @@ def _score_single_skill(skill_path: str) -> dict:
 def _collapse_duplicate_copies(skills: list[dict]) -> tuple[list[dict], list[dict]]:
     """Count one install per distinct payload, and report the copies.
 
-    A plugin that is both cached and vendored appears twice on disk. Measured on
-    a real ``~/.claude``: 159 SKILL.md files, 138 distinct payloads, inflating the
-    headline token cost by 57,331. Counting the same bytes twice is a defect in
-    the report, not a property of the installation.
+    A plugin that is both cached and vendored appears twice on disk, so the
+    count, the grades and the headline token cost were all inflated. Identity is
+    ``shared.skill_payload_digest``.
 
-    Identity is ``skill_payload_digest`` — SKILL.md plus ``references/*.md``,
-    exactly what the token estimate charges for. The reasoning for that key,
-    including the two ways a bare SKILL.md hash gets it wrong, is in that
-    function's docstring; it is not repeated here.
+    Why a digest and not another ``EXCLUDED_DIRS`` entry — the path exclusion
+    was measured and rejected — plus the before/after numbers: docs/specs/2026-08-13-doctor-counts-vendored-skills.md,
+    "Amendment 2026-08-26".
 
-    Path-based exclusion was measured and rejected: adding ``cache`` to
-    ``EXCLUDED_DIRS`` takes 159 to 50, because the cache IS where plugins install.
-    A digest carries no vendor names and does not grow with the next package
-    manager.
+    Nothing is deleted; every path in a group is reported and the caller decides
+    (ADR 0019). Which copy is counted is arbitrary — after the digest they are
+    identical in everything measured — so the report says so rather than implying
+    the surviving path is the canonical one.
 
-    Nothing is deleted. Every path in a group is reported, and the caller decides
-    — the same stance ADR 0019 takes for credential findings. The survivor is the
-    first in discovery order, which is stable because the digest makes every
-    member of a group identical in cost.
-
-    Skills whose digest could not be computed (unreadable, oversized) are all
-    kept: an empty digest is not an identity, so they must not collapse together.
+    Skills whose digest could not be computed are all kept: an empty digest is
+    not an identity, so they must not collapse together.
     """
     seen: dict[str, dict] = {}
     groups: dict[str, list[str]] = {}
@@ -215,6 +208,8 @@ def run_doctor(
             "needs_work": 0,
             "no_eval_suite": 0,
             "total_tokens": 0,
+            "skills_discovered": 0,
+            "duplicate_copies": [],
             "mesh_health": 100,
             "mesh_issue_count": 0,
             "results": [],
@@ -324,6 +319,10 @@ def run_doctor(
         "needs_work": needs_work,
         "no_eval_suite": no_eval,
         "total_tokens": total_tokens,
+        # Physical files on disk, before collapsing copies. `skills_found` is the
+        # deduplicated count; without this the difference is only recoverable by
+        # summing `also_installed_at`.
+        "skills_discovered": len(skills),
         "duplicate_copies": duplicate_copies,
         "mesh_health": mesh_health,
         "mesh_issue_count": len(mesh_issues),
@@ -370,6 +369,10 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         lines.append(
             f"  {len(duplicate_copies)} skills are installed more than once "
             f"({extra} extra copies, counted once):"
+        )
+        lines.append(
+            "    Which copy is counted is arbitrary — pick the one you control "
+            "before acting on its path."
         )
         for d in duplicate_copies[:10]:
             lines.append(f"    {d['name']}")

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -338,6 +338,10 @@ def run_doctor(
         summary_parts.append(f"{no_eval} missing eval suite")
     if broken_eval:
         summary_parts.append(f"{broken_eval} unreadable eval suite")
+    if grouped:
+        # Excluded from every other bucket on purpose, so without this line these
+        # rows appear in no tally at all — 20 of 138 on a real installation.
+        summary_parts.append(f"{grouped} duplicate install")
     if failed:
         summary_parts.append(f"{failed} failed to score")
     if mesh_issues:

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -219,6 +219,11 @@ def run_doctor(
         }
 
     unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
+    # path -> the other install locations, so a row carries its own signal. A
+    # --json consumer acting on `action` would otherwise have to join against
+    # duplicate_copies to learn that the path it was handed is one arbitrary
+    # choice among several.
+    copies_by_path = {d["counted"]: d["also_installed_at"] for d in duplicate_copies}
 
     results = []
     healthy = 0
@@ -246,6 +251,11 @@ def run_doctor(
             "path": path,
             **score_result,
         }
+        # Present only when this row stands for more than one install. `path` and
+        # therefore `action` name one arbitrary member of the group; the spec is
+        # explicit that the path is not interchangeable to a reader.
+        if path in copies_by_path:
+            result["also_installed_at"] = copies_by_path[path]
         results.append(result)
 
         if not score_result["has_eval_suite"]:
@@ -366,9 +376,10 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
     duplicate_copies = report.get("duplicate_copies", [])
     if duplicate_copies:
         extra = sum(len(d["also_installed_at"]) for d in duplicate_copies)
+        n = len(duplicate_copies)
         lines.append(
-            f"  {len(duplicate_copies)} skills are installed more than once "
-            f"({extra} extra copies, counted once):"
+            f"  {n} {'skill is' if n == 1 else 'skills are'} installed more than "
+            f"once ({extra} extra {'copy' if extra == 1 else 'copies'}, counted once):"
         )
         lines.append(
             "    Which copy is counted is arbitrary — pick the one you control "

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -280,7 +280,11 @@ def run_doctor(
             # by merit, and it is usually the plugin cache. Emitting
             # `/schliff:auto <that path>` would write .schliff/ history into a
             # directory the next plugin update deletes.
-            result["action"] = "Resolve the duplicate install first"
+            reason = result.get("eval_suite_error")
+            result["action"] = (
+                f"Resolve the duplicate install first; eval-suite.json is {reason}"
+                if reason else "Resolve the duplicate install first"
+            )
         results.append(result)
 
         if score_result.get("eval_suite_error"):
@@ -518,15 +522,19 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
 
     if no_eval > 0 or needs_work > 0 or broken_eval > 0:
         lines.append("  Recommended next steps:")
+        step = 0
         if no_eval > 0:
-            lines.append(f"    1. Run /schliff:init on {no_eval} skills missing eval suites")
+            step += 1
+            lines.append(f"    {step}. Run /schliff:init on {no_eval} skills missing eval suites")
         if broken_eval > 0:
+            step += 1
             lines.append(
-                f"    {'2' if no_eval else '1'}. Repair {broken_eval} unreadable "
-                f"eval-suite.json — do NOT run /schliff:init on these, it writes over them"
+                f"    {step}. Repair {broken_eval} unreadable eval-suite.json — "
+                f"do NOT run /schliff:init on these, it writes over them"
             )
         if needs_work > 0:
-            lines.append(f"    {'2' if no_eval else '1'}. Run /schliff:auto on {needs_work} low-scoring skills")
+            step += 1
+            lines.append(f"    {step}. Run /schliff:auto on {needs_work} low-scoring skills")
         lines.append("")
 
     # Skill-specific recommendations

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 
 import score_skill as scorer
@@ -245,7 +246,21 @@ def run_doctor(
             "summary": "No skills found. Check skill directories.",
         }
 
-    unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
+    # The digest phase is the only walk that runs OUTSIDE `_score_single_skill`'s
+    # handler, and `skill_payload_digest` reaches `read_skill_safe`, which reads
+    # before it checks size and can therefore raise `MemoryError` — not an
+    # `OSError`, not a `ValueError`, so that function's own guard does not see it.
+    # `_payload_files` justifies leaving `read_skill_safe` outside the bounded
+    # reader on the grounds that "its callers sit inside a handler"; this caller
+    # did not, which made the premise false exactly where the run is hardest to
+    # recover. Falling back to no collapsing reports every copy — an over-count,
+    # which this module has repeatedly recorded as the survivable direction.
+    try:
+        unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
+    except Exception as exc:  # noqa: BLE001 — one bad file must not end the run
+        print(f"Warning: duplicate detection failed ({type(exc).__name__}), "
+              f"reporting every copy separately", file=sys.stderr)
+        unique_skills, duplicate_copies = skills, []
     # path -> the other install locations, so a row carries its own signal. A
     # --json consumer acting on `action` would otherwise have to join against
     # duplicate_copies to learn that the path it was handed is whichever member
@@ -258,6 +273,7 @@ def run_doctor(
     no_eval = 0
     broken_eval = 0
     grouped = 0
+    grouped_broken = 0
     failed = 0
 
     for skill in unique_skills:
@@ -304,7 +320,18 @@ def run_doctor(
             # would put it in the /schliff:init recommendation below — writing
             # into a directory the next plugin update deletes, and contradicting
             # the row three lines above. Same carve-out doctor.md step 5 makes.
+            #
+            # The buckets stay disjoint, so `grouped_broken` is tracked beside them
+            # rather than inside them: a grouped row whose suite is ALSO broken was
+            # otherwise counted nowhere, and the "Recommended next steps" block is
+            # gated on those counts — so the whole block vanished, taking the
+            # "do NOT run /schliff:init on these, it writes over them" line with it.
+            # That line is the strongest warning the report has, and it applies to
+            # a grouped row exactly as much as to a lone one. It names no path, so
+            # printing it cannot point the reader at a copy picked by sort order.
             grouped += 1
+            if score_result.get("eval_suite_error"):
+                grouped_broken += 1
         elif score_result.get("eval_suite_error"):
             # Present but unreadable. Counting it as "missing" would put it in
             # the /schliff:init recommendation below, which writes eval-suite.json
@@ -395,6 +422,7 @@ def run_doctor(
         "no_eval_suite": no_eval,
         "broken_eval_suite": broken_eval,
         "grouped_duplicates": grouped,
+        "grouped_broken_eval_suite": grouped_broken,
         "total_tokens": total_tokens,
         # Physical files on disk, before collapsing copies. `skills_found` is the
         # deduplicated count; without this the difference is only recoverable by
@@ -561,16 +589,21 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
     broken_eval = report.get("broken_eval_suite", 0)
     needs_work = report.get("needs_work", 0)
 
-    if no_eval > 0 or needs_work > 0 or broken_eval > 0:
+    # The repair warning counts grouped-and-broken rows too. They are deliberately
+    # absent from the disjoint buckets, and gating the block on those alone deleted
+    # the only line telling the reader not to run /schliff:init over a file that
+    # failed to load.
+    broken_total = broken_eval + report.get("grouped_broken_eval_suite", 0)
+    if no_eval > 0 or needs_work > 0 or broken_total > 0:
         lines.append("  Recommended next steps:")
         step = 0
         if no_eval > 0:
             step += 1
             lines.append(f"    {step}. Run /schliff:init on {no_eval} skills missing eval suites")
-        if broken_eval > 0:
+        if broken_total > 0:
             step += 1
             lines.append(
-                f"    {step}. Repair {broken_eval} unreadable eval-suite.json — "
+                f"    {step}. Repair {broken_total} unreadable eval-suite.json — "
                 f"do NOT run /schliff:init on these, it writes over them"
             )
         if needs_work > 0:

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -21,13 +21,9 @@ import score_skill as scorer
 import skill_mesh
 from terminal_art import grade_colored, score_to_grade
 
+import shared
 from scoring.formats import detect_format
-from shared import (
-    EXCLUDED_DIRS,
-    estimate_token_cost,
-    eval_suite_error,
-    skill_payload_digest,
-)
+from shared import EXCLUDED_DIRS, estimate_token_cost, skill_payload_digest
 
 # Filenames to match (lowercase) for instruction file discovery
 _INSTRUCTION_FILENAMES = {"claude.md", ".cursorrules", "agents.md"}
@@ -116,10 +112,13 @@ def _score_single_skill(skill_path: str) -> dict:
     # degraded to None so one bad file cannot end the run, but telling the user
     # to run /schliff:init here would write eval-suite.json over the very file
     # that failed to load.
-    suite_error = eval_suite_error.get(str(Path(skill_path).parent / "eval-suite.json"))
+    # `shared.eval_suite_error`, not a bound alias: a later per-run reset in
+    # shared would leave an import-time binding reading a dead dict, and every
+    # row would silently report no suite error.
+    suite_error = shared.eval_suite_error.get(str(Path(skill_path).parent / "eval-suite.json"))
 
     if suite_error:
-        action = f"Fix eval-suite.json first ({suite_error})"
+        action = f"Fix eval-suite.json first: {suite_error}"
     elif not has_eval:
         action = f"/schliff:init {skill_path}"
     elif score < 50:
@@ -285,7 +284,7 @@ def run_doctor(
             # directory the next plugin update deletes.
             reason = result.get("eval_suite_error")
             result["action"] = (
-                f"Resolve the duplicate install first; eval-suite.json is {reason}"
+                f"Resolve the duplicate install first; eval-suite.json: {reason}"
                 if reason else "Resolve the duplicate install first"
             )
         results.append(result)
@@ -444,6 +443,10 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
             "    The counted path is whichever sorted first, which is usually the "
             "plugin cache — act on the copy you control."
         )
+        lines.append(
+            "    Mesh findings below are counted per file, not per install, so "
+            "these copies appear there too."
+        )
         for d in duplicate_copies[:10]:
             lines.append(f"    {d['name']}")
             lines.append(f"      counted: {d['counted']}")
@@ -474,7 +477,9 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         issues = r["issue_count"]
         # The reason is the whole payload of a repair action, so keep it whole
         # rather than truncating to "Fix eval-suite.json first (unreadab".
-        action = r["action"] if r.get("eval_suite_error") else r["action"][:35]
+        # A repair action carries its reason, which is the payload; cap it
+        # wide rather than at 35 so a grouped-and-broken row does not run away.
+        action = r["action"][:70] if r.get("eval_suite_error") else r["action"][:35]
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -229,6 +229,8 @@ def run_doctor(
             "total_tokens": 0,
             "skills_discovered": 0,
             "duplicate_copies": [],
+            "broken_eval_suite": 0,
+            "grouped_duplicates": 0,
             "mesh_health": 100,
             "mesh_issue_count": 0,
             "results": [],
@@ -249,6 +251,7 @@ def run_doctor(
     needs_work = 0
     no_eval = 0
     broken_eval = 0
+    grouped = 0
     failed = 0
 
     for skill in unique_skills:
@@ -287,7 +290,14 @@ def run_doctor(
             )
         results.append(result)
 
-        if score_result.get("eval_suite_error"):
+        if path in copies_by_path:
+            # A grouped row's own action says to resolve the duplicate, and its
+            # path is the plugin cache. Counting it as "missing an eval suite"
+            # would put it in the /schliff:init recommendation below — writing
+            # into a directory the next plugin update deletes, and contradicting
+            # the row three lines above. Same carve-out doctor.md step 5 makes.
+            grouped += 1
+        elif score_result.get("eval_suite_error"):
             # Present but unreadable. Counting it as "missing" would put it in
             # the /schliff:init recommendation below, which writes eval-suite.json
             # over the file that failed to load — contradicting this same row's
@@ -313,7 +323,13 @@ def run_doctor(
     mesh_issues = mesh_result.get("issues", [])
     mesh_health = mesh_result.get("health", {}).get("score", 100)
 
-    summary_parts = [f"{len(results)} skills scanned"]
+    discovered = len(skills)
+    scanned = (
+        f"{len(results)} skills scanned"
+        if discovered == len(results)
+        else f"{len(results)} skills scanned ({discovered} files, duplicates counted once)"
+    )
+    summary_parts = [scanned]
     if healthy:
         summary_parts.append(f"{healthy} healthy")
     if needs_work:
@@ -366,6 +382,7 @@ def run_doctor(
         "needs_work": needs_work,
         "no_eval_suite": no_eval,
         "broken_eval_suite": broken_eval,
+        "grouped_duplicates": grouped,
         "total_tokens": total_tokens,
         # Physical files on disk, before collapsing copies. `skills_found` is the
         # deduplicated count; without this the difference is only recoverable by

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -28,6 +28,13 @@ from shared import EXCLUDED_DIRS, estimate_token_cost, skill_payload_digest
 # Filenames to match (lowercase) for instruction file discovery
 _INSTRUCTION_FILENAMES = {"claude.md", ".cursorrules", "agents.md"}
 
+# Width of the Action column for a row that carries a repair reason. Wide
+# enough for the longest action doctor can compose, which is the grouped-and-
+# broken form plus the longest reason `load_eval_suite` records. Asserted by
+# test_repair_action_fits_its_column rather than trusted: the previous value
+# was picked by eye and silently cut "not a JSON object" to "not a JSON objec".
+REPAIR_ACTION_WIDTH = 80
+
 
 def discover_instruction_files(root_dir: str) -> list[dict]:
     """Discover all project instruction files in a directory tree.
@@ -242,7 +249,7 @@ def run_doctor(
     # path -> the other install locations, so a row carries its own signal. A
     # --json consumer acting on `action` would otherwise have to join against
     # duplicate_copies to learn that the path it was handed is whichever member
-    # sorted first, usually the plugin cache.
+    # sorted first, which is not necessarily the copy worth acting on.
     copies_by_path = {d["counted"]: d["also_installed_at"] for d in duplicate_copies}
 
     results = []
@@ -274,14 +281,16 @@ def run_doctor(
             **score_result,
         }
         # Present only when this row stands for more than one install. `path` and
-        # therefore `action` name whichever member sorted first — usually the
-        # plugin cache, which the next update overwrites.
+        # therefore `action` name whichever member sorted first, which is picked
+        # by sort order and not by merit.
         if path in copies_by_path:
             result["also_installed_at"] = copies_by_path[path]
             # `path` is one member of a group, picked by sort order rather than
-            # by merit, and it is usually the plugin cache. Emitting
-            # `/schliff:auto <that path>` would write .schliff/ history into a
-            # directory the next plugin update deletes.
+            # by merit. Under `--skill-dirs ~/.claude` that is systematically the
+            # plugin cache; under the default dirs, where `.claude/skills` sorts
+            # ahead of the home path, it is the reader's own project copy. Either
+            # way emitting `/schliff:auto <that path>` would name a copy this
+            # command did not choose on merit.
             reason = result.get("eval_suite_error")
             result["action"] = (
                 f"Resolve the duplicate install first; eval-suite.json: {reason}"
@@ -291,7 +300,7 @@ def run_doctor(
 
         if path in copies_by_path:
             # A grouped row's own action says to resolve the duplicate, and its
-            # path is the plugin cache. Counting it as "missing an eval suite"
+            # path was picked by sort order. Counting it as "missing an eval suite"
             # would put it in the /schliff:init recommendation below — writing
             # into a directory the next plugin update deletes, and contradicting
             # the row three lines above. Same carve-out doctor.md step 5 makes.
@@ -440,8 +449,9 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
             f"once ({extra} extra {'copy' if extra == 1 else 'copies'}, counted once):"
         )
         lines.append(
-            "    The counted path is whichever sorted first, which is usually the "
-            "plugin cache — act on the copy you control."
+            "    The counted path is whichever sorted first — an artifact of "
+            "sort order, not a recommendation. Check every path listed "
+            "before acting on any."
         )
         lines.append(
             "    Mesh findings below are counted per file, not per install, so "
@@ -477,9 +487,14 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         issues = r["issue_count"]
         # The reason is the whole payload of a repair action, so keep it whole
         # rather than truncating to "Fix eval-suite.json first (unreadab".
-        # A repair action carries its reason, which is the payload; cap it
-        # wide rather than at 35 so a grouped-and-broken row does not run away.
-        action = r["action"][:70] if r.get("eval_suite_error") else r["action"][:35]
+        # 70 was still too narrow for the composed grouped-and-broken form
+        # ("Resolve the duplicate install first; eval-suite.json: " is 54
+        # characters before the reason even starts), so it truncated the exact
+        # word it was widened to preserve: "not a JSON objec". The width is not
+        # a guess — test_repair_action_fits_its_column derives the longest
+        # composed action from the reasons load_eval_suite can actually produce
+        # and fails if it stops fitting, so a new reason cannot re-open this.
+        action = r["action"][:REPAIR_ACTION_WIDTH] if r.get("eval_suite_error") else r["action"][:35]
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 
@@ -563,8 +578,18 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
             lines.append(f"    {step}. Run /schliff:auto on {needs_work} low-scoring skills")
         lines.append("")
 
-    # Skill-specific recommendations
-    skills_with_recs = [r for r in results if r.get("recommendations")]
+    # Skill-specific recommendations.
+    #
+    # Grouped rows are carved out for the same reason the /schliff:init and
+    # /schliff:auto tallies carve them out, and the same reason doctor.md step 5
+    # does: the row's own `action` says to resolve the duplicate install first,
+    # and its path was picked by sort order rather than by merit. Printing
+    # "extract into references/" beside that is an instruction to edit a file
+    # this command did not choose — and it contradicts the row three lines up.
+    skills_with_recs = [
+        r for r in results
+        if r.get("recommendations") and not r.get("also_installed_at")
+    ]
     if skills_with_recs:
         lines.append("  Skill-specific recommendations:")
         for r in skills_with_recs:

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -36,6 +36,14 @@ _INSTRUCTION_FILENAMES = {"claude.md", ".cursorrules", "agents.md"}
 # was picked by eye and silently cut "not a JSON object" to "not a JSON objec".
 REPAIR_ACTION_WIDTH = 80
 
+# The two path-free action shapes. Named, not inlined, because the width gate has
+# to enumerate exactly the strings that reach the wide column — the previous gate
+# derived only the repair prefix and so did not cover the grouped action, which
+# was 35 characters against a 35-wide cap with zero margin.
+BROKEN_ACTION_PREFIX = "Fix eval-suite.json first: "
+GROUPED_ACTION = "Scored once; other paths are listed above"
+GROUPED_ACTION_PREFIX = "Scored once; eval-suite.json: "
+
 
 def discover_instruction_files(root_dir: str) -> list[dict]:
     """Discover all project instruction files in a directory tree.
@@ -126,7 +134,7 @@ def _score_single_skill(skill_path: str) -> dict:
     suite_error = shared.eval_suite_error.get(str(Path(skill_path).parent / "eval-suite.json"))
 
     if suite_error:
-        action = f"Fix eval-suite.json first: {suite_error}"
+        action = f"{BROKEN_ACTION_PREFIX}{suite_error}"
     elif not has_eval:
         action = f"/schliff:init {skill_path}"
     elif score < 50:
@@ -171,13 +179,16 @@ def _collapse_duplicate_copies(skills: list[dict]) -> tuple[list[dict], list[dic
 
     Nothing is deleted; every path in a group is reported and the caller decides
     (ADR 0019). The counted copy is the first in discovery order, which sorts by
-    path — so for the dominant real case ``plugins/cache/…`` wins over
-    ``plugins/marketplaces/…`` and over ``~/.claude/skills/…``. That is not
-    arbitrary, it is a systematic bias toward the one copy the reader should NOT
-    act on: a plugin cache is overwritten on the next update. The copies are
-    identical in everything measured, so preferring another member would need a
-    path wordlist — the enumeration this whole key exists to avoid. Instead the
-    row for a group carries no runnable ``action``.
+    path. Sort order is not merit, and which member it favours depends on the
+    directories being scanned, so no member may be named by a runnable command:
+    the row for a group carries no ``action`` that acts on a path. Preferring a
+    member on any other basis would need a path wordlist — the enumeration this
+    key exists to avoid.
+
+    What the group asserts is bounded by what the digest reads. Two members can
+    differ in anything outside SKILL.md, ``references/*.md`` and
+    ``eval-suite.json`` — including their version, and including whether both are
+    live installs. The report states the comparison and never concludes from it.
 
     Skills whose digest could not be computed are all kept: an empty digest is
     not an identity, so they must not collapse together.
@@ -238,6 +249,8 @@ def run_doctor(
             "duplicate_copies": [],
             "broken_eval_suite": 0,
             "grouped_duplicates": 0,
+            "grouped_broken_eval_suite": 0,
+            "digest_degraded": False,
             "mesh_health": 100,
             "mesh_issue_count": 0,
             "results": [],
@@ -255,12 +268,14 @@ def run_doctor(
     # did not, which made the premise false exactly where the run is hardest to
     # recover. Falling back to no collapsing reports every copy — an over-count,
     # which this module has repeatedly recorded as the survivable direction.
+    digest_degraded = False
     try:
         unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
     except Exception as exc:  # noqa: BLE001 — one bad file must not end the run
         print(f"Warning: duplicate detection failed ({type(exc).__name__}), "
               f"reporting every copy separately", file=sys.stderr)
         unique_skills, duplicate_copies = skills, []
+        digest_degraded = True
     # path -> the other install locations, so a row carries its own signal. A
     # --json consumer acting on `action` would otherwise have to join against
     # duplicate_copies to learn that the path it was handed is whichever member
@@ -302,15 +317,14 @@ def run_doctor(
         if path in copies_by_path:
             result["also_installed_at"] = copies_by_path[path]
             # `path` is one member of a group, picked by sort order rather than
-            # by merit. Under `--skill-dirs ~/.claude` that is systematically the
-            # plugin cache; under the default dirs, where `.claude/skills` sorts
-            # ahead of the home path, it is the reader's own project copy. Either
-            # way emitting `/schliff:auto <that path>` would name a copy this
-            # command did not choose on merit.
+            # by merit, so no runnable command may name it. The action states
+            # what was measured — one score and one cost — and never what the
+            # reader should do to the filesystem: the digest covers SKILL.md,
+            # `references/*.md` and `eval-suite.json`, so two members can differ
+            # in everything else, including their version.
             reason = result.get("eval_suite_error")
             result["action"] = (
-                f"Resolve the duplicate install first; eval-suite.json: {reason}"
-                if reason else "Resolve the duplicate install first"
+                f"{GROUPED_ACTION_PREFIX}{reason}" if reason else GROUPED_ACTION
             )
         results.append(result)
 
@@ -376,7 +390,7 @@ def run_doctor(
     if grouped:
         # Excluded from every other bucket on purpose, so without this line these
         # rows appear in no tally at all — 20 of 138 on a real installation.
-        summary_parts.append(f"{grouped} duplicate install")
+        summary_parts.append(f"{grouped} counted once")
     if failed:
         summary_parts.append(f"{failed} failed to score")
     if mesh_issues:
@@ -422,6 +436,11 @@ def run_doctor(
         "no_eval_suite": no_eval,
         "broken_eval_suite": broken_eval,
         "grouped_duplicates": grouped,
+        # A consumer that publishes `skills_found` has to be able to see that the
+        # collapse did not run: without this the fallback's output is byte-shape
+        # identical to a clean scan that found no duplicates, so a case study
+        # generated from --json would publish the pre-fix count with no marker.
+        "digest_degraded": digest_degraded,
         "grouped_broken_eval_suite": grouped_broken,
         "total_tokens": total_tokens,
         # Physical files on disk, before collapsing copies. `skills_found` is the
@@ -466,20 +485,31 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         lines.append(f"  Total context cost: ~{total_tokens:,} tokens")
         lines.append("")
 
-    # Same bytes installed twice — counted once, both paths named so the reader
-    # can delete one. Capped like the drift block below.
+    # One scored payload found at several paths — counted once. The block states
+    # what was compared and stops there. It said "installed more than once …
+    # extra copies … so you can delete one", and that is a verdict about the
+    # filesystem this key never measured: on the real install one group is two
+    # ACTIVE plugin versions (0.1.13 and 0.1.15 of the same plugin, both present
+    # in `~/.claude/plugins/installed_plugins.json`, one project-scoped and one
+    # user-scoped) whose directories differ outside the digest domain, and sort
+    # order names the older one as the survivor. Capped like the drift block below.
     duplicate_copies = report.get("duplicate_copies", [])
     if duplicate_copies:
         extra = sum(len(d["also_installed_at"]) for d in duplicate_copies)
         n = len(duplicate_copies)
         lines.append(
-            f"  {n} {'skill is' if n == 1 else 'skills are'} installed more than "
-            f"once ({extra} extra {'copy' if extra == 1 else 'copies'}, counted once):"
+            f"  {n} {'skill has' if n == 1 else 'skills have'} an identical scored "
+            f"payload at {extra + n} paths — each counted once "
+            f"({extra} {'path' if extra == 1 else 'paths'} collapsed):"
         )
         lines.append(
-            "    The counted path is whichever sorted first — an artifact of "
-            "sort order, not a recommendation. Check every path listed "
-            "before acting on any."
+            "    Compared: SKILL.md, references/*.md, eval-suite.json — the files "
+            "the score and the cost come from. The directories themselves were "
+            "NOT compared and may differ, including in version."
+        )
+        lines.append(
+            "    The counted path is whichever sorted first, an artifact of sort "
+            "order rather than a recommendation."
         )
         lines.append(
             "    Mesh findings below are counted per file, not per install, so "
@@ -516,13 +546,19 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         # The reason is the whole payload of a repair action, so keep it whole
         # rather than truncating to "Fix eval-suite.json first (unreadab".
         # 70 was still too narrow for the composed grouped-and-broken form
-        # ("Resolve the duplicate install first; eval-suite.json: " is 54
-        # characters before the reason even starts), so it truncated the exact
-        # word it was widened to preserve: "not a JSON objec". The width is not
+        # (the composed grouped-and-broken prefix runs well past 35 characters
+        # before the reason even starts), so it truncated the exact word it was
+        # widened to preserve: "not a JSON objec". The width is not
         # a guess — test_repair_action_fits_its_column derives the longest
         # composed action from the reasons load_eval_suite can actually produce
         # and fails if it stops fitting, so a new reason cannot re-open this.
-        action = r["action"][:REPAIR_ACTION_WIDTH] if r.get("eval_suite_error") else r["action"][:35]
+        # Path-free actions get the wide column; the narrow one exists for actions
+        # that embed an absolute path (`/schliff:auto <path>`), where widening to
+        # 80 would produce an 80-character clip of a path — neither whole nor
+        # short. Grouped and repair actions are path-free by construction, which
+        # is why the flag is the row's own shape and not a list of prefixes.
+        path_free = r.get("eval_suite_error") or r.get("also_installed_at")
+        action = r["action"][:REPAIR_ACTION_WIDTH] if path_free else r["action"][:35]
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 
@@ -615,8 +651,8 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
     #
     # Grouped rows are carved out for the same reason the /schliff:init and
     # /schliff:auto tallies carve them out, and the same reason doctor.md step 5
-    # does: the row's own `action` says to resolve the duplicate install first,
-    # and its path was picked by sort order rather than by merit. Printing
+    # does: the row's own `action` states that the payload was scored once, and
+    # its path was picked by sort order rather than by merit. Printing
     # "extract into references/" beside that is an instruction to edit a file
     # this command did not choose — and it contradicts the row three lines up.
     skills_with_recs = [

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -22,7 +22,7 @@ import skill_mesh
 from terminal_art import grade_colored, score_to_grade
 
 from scoring.formats import detect_format
-from shared import EXCLUDED_DIRS, estimate_token_cost
+from shared import EXCLUDED_DIRS, estimate_token_cost, skill_payload_digest
 
 # Filenames to match (lowercase) for instruction file discovery
 _INSTRUCTION_FILENAMES = {"claude.md", ".cursorrules", "agents.md"}
@@ -137,6 +137,61 @@ def _score_single_skill(skill_path: str) -> dict:
     }
 
 
+def _collapse_duplicate_copies(skills: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Count one install per distinct payload, and report the copies.
+
+    A plugin that is both cached and vendored appears twice on disk. Measured on
+    a real ``~/.claude``: 159 SKILL.md files, 138 distinct payloads, inflating the
+    headline token cost by 57,331. Counting the same bytes twice is a defect in
+    the report, not a property of the installation.
+
+    Identity is ``skill_payload_digest`` — SKILL.md plus ``references/*.md``,
+    exactly what the token estimate charges for. The reasoning for that key,
+    including the two ways a bare SKILL.md hash gets it wrong, is in that
+    function's docstring; it is not repeated here.
+
+    Path-based exclusion was measured and rejected: adding ``cache`` to
+    ``EXCLUDED_DIRS`` takes 159 to 50, because the cache IS where plugins install.
+    A digest carries no vendor names and does not grow with the next package
+    manager.
+
+    Nothing is deleted. Every path in a group is reported, and the caller decides
+    — the same stance ADR 0019 takes for credential findings. The survivor is the
+    first in discovery order, which is stable because the digest makes every
+    member of a group identical in cost.
+
+    Skills whose digest could not be computed (unreadable, oversized) are all
+    kept: an empty digest is not an identity, so they must not collapse together.
+    """
+    seen: dict[str, dict] = {}
+    groups: dict[str, list[str]] = {}
+    unique: list[dict] = []
+
+    for skill in skills:
+        path = skill.get("path", "")
+        digest = skill_payload_digest(path) if path else ""
+        if not digest:
+            unique.append(skill)
+            continue
+        if digest in seen:
+            groups.setdefault(digest, [seen[digest].get("path", "")]).append(path)
+            continue
+        seen[digest] = skill
+        unique.append(skill)
+
+    duplicates = [
+        {
+            "name": seen[digest].get("name", ""),
+            "payload_digest": digest,
+            "counted": paths[0],
+            "also_installed_at": paths[1:],
+        }
+        for digest, paths in groups.items()
+    ]
+    duplicates.sort(key=lambda d: d["name"])
+    return unique, duplicates
+
+
 def run_doctor(
     skill_dirs: list[str] | None = None,
     verbose: bool = False,
@@ -168,13 +223,15 @@ def run_doctor(
             "summary": "No skills found. Check skill directories.",
         }
 
+    unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
+
     results = []
     healthy = 0
     needs_work = 0
     no_eval = 0
     failed = 0
 
-    for skill in skills:
+    for skill in unique_skills:
         path = skill["path"]
         name = skill["name"]
 
@@ -267,6 +324,7 @@ def run_doctor(
         "needs_work": needs_work,
         "no_eval_suite": no_eval,
         "total_tokens": total_tokens,
+        "duplicate_copies": duplicate_copies,
         "mesh_health": mesh_health,
         "mesh_issue_count": len(mesh_issues),
         "results": results,
@@ -302,6 +360,24 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
     total_tokens = report.get("total_tokens", 0)
     if total_tokens > 0:
         lines.append(f"  Total context cost: ~{total_tokens:,} tokens")
+        lines.append("")
+
+    # Same bytes installed twice — counted once, both paths named so the reader
+    # can delete one. Capped like the drift block below.
+    duplicate_copies = report.get("duplicate_copies", [])
+    if duplicate_copies:
+        extra = sum(len(d["also_installed_at"]) for d in duplicate_copies)
+        lines.append(
+            f"  {len(duplicate_copies)} skills are installed more than once "
+            f"({extra} extra copies, counted once):"
+        )
+        for d in duplicate_copies[:10]:
+            lines.append(f"    {d['name']}")
+            lines.append(f"      counted: {d['counted']}")
+            for other in d["also_installed_at"]:
+                lines.append(f"      also at: {other}")
+        if len(duplicate_copies) > 10:
+            lines.append(f"    ... and {len(duplicate_copies) - 10} more")
         lines.append("")
 
     # Table header

--- a/skills/schliff/scripts/doctor.py
+++ b/skills/schliff/scripts/doctor.py
@@ -240,14 +240,15 @@ def run_doctor(
     unique_skills, duplicate_copies = _collapse_duplicate_copies(skills)
     # path -> the other install locations, so a row carries its own signal. A
     # --json consumer acting on `action` would otherwise have to join against
-    # duplicate_copies to learn that the path it was handed is one arbitrary
-    # choice among several.
+    # duplicate_copies to learn that the path it was handed is whichever member
+    # sorted first, usually the plugin cache.
     copies_by_path = {d["counted"]: d["also_installed_at"] for d in duplicate_copies}
 
     results = []
     healthy = 0
     needs_work = 0
     no_eval = 0
+    broken_eval = 0
     failed = 0
 
     for skill in unique_skills:
@@ -271,8 +272,8 @@ def run_doctor(
             **score_result,
         }
         # Present only when this row stands for more than one install. `path` and
-        # therefore `action` name one arbitrary member of the group; the spec is
-        # explicit that the path is not interchangeable to a reader.
+        # therefore `action` name whichever member sorted first — usually the
+        # plugin cache, which the next update overwrites.
         if path in copies_by_path:
             result["also_installed_at"] = copies_by_path[path]
             # `path` is one member of a group, picked by sort order rather than
@@ -282,7 +283,13 @@ def run_doctor(
             result["action"] = "Resolve the duplicate install first"
         results.append(result)
 
-        if not score_result["has_eval_suite"]:
+        if score_result.get("eval_suite_error"):
+            # Present but unreadable. Counting it as "missing" would put it in
+            # the /schliff:init recommendation below, which writes eval-suite.json
+            # over the file that failed to load — contradicting this same row's
+            # own action three lines above.
+            broken_eval += 1
+        elif not score_result["has_eval_suite"]:
             no_eval += 1
         elif score_result["composite"] >= 80:
             healthy += 1
@@ -309,6 +316,8 @@ def run_doctor(
         summary_parts.append(f"{needs_work} need work")
     if no_eval:
         summary_parts.append(f"{no_eval} missing eval suite")
+    if broken_eval:
+        summary_parts.append(f"{broken_eval} unreadable eval suite")
     if failed:
         summary_parts.append(f"{failed} failed to score")
     if mesh_issues:
@@ -352,6 +361,7 @@ def run_doctor(
         "healthy": healthy,
         "needs_work": needs_work,
         "no_eval_suite": no_eval,
+        "broken_eval_suite": broken_eval,
         "total_tokens": total_tokens,
         # Physical files on disk, before collapsing copies. `skills_found` is the
         # deduplicated count; without this the difference is only recoverable by
@@ -437,7 +447,9 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
         dims = f"{r['measured']}/{r['total_dims']}"
         tokens = r.get("tokens", 0)
         issues = r["issue_count"]
-        action = r["action"][:35]
+        # The reason is the whole payload of a repair action, so keep it whole
+        # rather than truncating to "Fix eval-suite.json first (unreadab".
+        action = r["action"] if r.get("eval_suite_error") else r["action"][:35]
 
         lines.append(f"  {name:<25s} {score:>5.0f} {grade:s} {dims:>6s} {tokens:>7d} {issues:>7d}  {action}")
 
@@ -501,12 +513,18 @@ def format_doctor_report(report: dict, verbose: bool = False) -> str:
 
     # Top-level recommendations
     no_eval = report.get("no_eval_suite", 0)
+    broken_eval = report.get("broken_eval_suite", 0)
     needs_work = report.get("needs_work", 0)
 
-    if no_eval > 0 or needs_work > 0:
+    if no_eval > 0 or needs_work > 0 or broken_eval > 0:
         lines.append("  Recommended next steps:")
         if no_eval > 0:
             lines.append(f"    1. Run /schliff:init on {no_eval} skills missing eval suites")
+        if broken_eval > 0:
+            lines.append(
+                f"    {'2' if no_eval else '1'}. Repair {broken_eval} unreadable "
+                f"eval-suite.json — do NOT run /schliff:init on these, it writes over them"
+            )
         if needs_work > 0:
             lines.append(f"    {'2' if no_eval else '1'}. Run /schliff:auto on {needs_work} low-scoring skills")
         lines.append("")

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -37,6 +37,12 @@ _file_cache: dict[str, str] = {}
 # every failure to None so one bad file cannot end a doctor run — but "absent"
 # and "present and broken" must not look the same in a report: the second earns
 # `/schliff:init`, which would then write over the file that caused it.
+#
+# The value is a path-free REASON, never the formatted exception. It is folded
+# into `skill_payload_digest`, and an OSError message carries the absolute path —
+# which gave two genuine copies of one broken skill different identities, so they
+# stopped collapsing and were billed twice. That is the defect this key exists to
+# remove. Details still reach stderr; only the reason reaches the identity.
 eval_suite_error: dict[str, str] = {}
 
 # Known scoring dimensions for validation
@@ -156,15 +162,32 @@ def _payload_files(skill_path: str) -> list[Path]:
 
     One enumeration, two consumers: ``estimate_token_cost`` charges for these
     files and ``skill_payload_digest`` hashes them. They were hand-mirrored,
-    guard for guard, which is the shape that already produced three defects in
-    this area — a domain re-derived instead of asked for. Sorted for a stable
-    digest; symlinked reference files and a symlinked ``references/`` are skipped,
-    and oversized files are dropped by the caller that reads them.
+    guard for guard, which is the shape that already produced several defects in
+    this area — a domain re-derived instead of asked for.
+
+    **Symlinks are followed**, like ``read_skill_safe`` and ``load_eval_suite``,
+    and for the reason ``read_skill_safe``'s docstring gives: stow, chezmoi,
+    ``claude --worktree`` and shared ``~/.claude/skills`` layouts all produce
+    them. Skipping them was inherited from ``estimate_token_cost`` and measured
+    wrong in both directions — a stow-managed copy reported 12 tokens against
+    1,182 for its byte-identical plain twin, and the two did not collapse. The
+    resolved target must still be a regular file, so a link to a directory or a
+    dangling one is dropped rather than read.
+
+    Sorted for a stable digest; oversized files are dropped by whichever consumer
+    reads them.
     """
     refs_dir = Path(skill_path).parent / "references"
-    if not refs_dir.is_dir() or refs_dir.is_symlink():
+    if not refs_dir.is_dir():
         return []
-    return [f for f in sorted(refs_dir.glob("*.md")) if not f.is_symlink()]
+    out = []
+    for f in sorted(refs_dir.glob("*.md")):
+        try:
+            if f.resolve().is_file():
+                out.append(f)
+        except OSError:
+            continue
+    return out
 
 
 def estimate_token_cost(skill_path: str) -> int:
@@ -297,10 +320,12 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
             print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
             eval_suite_error[str(auto_path)] = "exceeds the size limit"
             return None
-        return json.loads(raw)
+        parsed = json.loads(raw)
+        eval_suite_error.pop(str(auto_path), None)
+        return parsed
     except json.JSONDecodeError as e:
         print(f"Warning: malformed eval-suite.json: {e}", file=sys.stderr)
-        eval_suite_error[str(auto_path)] = f"malformed: {e}"
+        eval_suite_error[str(auto_path)] = "malformed"
     except RecursionError:
         # json.loads recurses per nesting level on CPython below 3.14, and
         # MAX_SKILL_SIZE leaves room for ~200k levels. Not an OSError and not a
@@ -311,7 +336,7 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
         eval_suite_error[str(auto_path)] = "nests too deeply to parse"
     except (OSError, ValueError) as e:
         print(f"Warning: could not read eval-suite.json: {e}", file=sys.stderr)
-        eval_suite_error[str(auto_path)] = f"unreadable: {e}"
+        eval_suite_error[str(auto_path)] = "unreadable"
     return None
 
 

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -145,6 +145,22 @@ def extract_description(content: str) -> str:
     return ""
 
 
+def _payload_files(skill_path: str) -> list[Path]:
+    """The ``references/*.md`` a skill loads alongside its SKILL.md.
+
+    One enumeration, two consumers: ``estimate_token_cost`` charges for these
+    files and ``skill_payload_digest`` hashes them. They were hand-mirrored,
+    guard for guard, which is the shape that already produced three defects in
+    this area — a domain re-derived instead of asked for. Sorted for a stable
+    digest; symlinked reference files and a symlinked ``references/`` are skipped,
+    and oversized files are dropped by the caller that reads them.
+    """
+    refs_dir = Path(skill_path).parent / "references"
+    if not refs_dir.is_dir() or refs_dir.is_symlink():
+        return []
+    return [f for f in sorted(refs_dir.glob("*.md")) if not f.is_symlink()]
+
+
 def estimate_token_cost(skill_path: str) -> int:
     """Estimate token cost when this skill is loaded into context.
 
@@ -161,18 +177,13 @@ def estimate_token_cost(skill_path: str) -> int:
     except (FileNotFoundError, ValueError):
         return 0
 
-    # Check for references/ directory alongside SKILL.md
-    refs_dir = Path(skill_path).parent / "references"
-    if refs_dir.is_dir() and not refs_dir.is_symlink():
-        for ref_file in sorted(refs_dir.glob("*.md")):
-            if ref_file.is_symlink():
-                continue
-            try:
-                ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
-                if len(ref_content) <= MAX_SKILL_SIZE:
-                    total_words += len(ref_content.split())
-            except (OSError, PermissionError):
-                continue
+    for ref_file in _payload_files(skill_path):
+        try:
+            ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
+            if len(ref_content) <= MAX_SKILL_SIZE:
+                total_words += len(ref_content.split())
+        except (OSError, PermissionError):
+            continue
 
     return round(total_words * 1.3)
 
@@ -218,19 +229,13 @@ def skill_payload_digest(skill_path: str) -> str:
     except (OSError, PermissionError, FileNotFoundError, ValueError):
         return ""
 
-    # Same traversal, same guards as estimate_token_cost: sorted for a stable
-    # digest, symlinks skipped, oversized files ignored rather than hashed.
-    refs_dir = path.parent / "references"
-    if refs_dir.is_dir() and not refs_dir.is_symlink():
-        for ref_file in sorted(refs_dir.glob("*.md")):
-            if ref_file.is_symlink():
-                continue
-            try:
-                ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
-            except (OSError, PermissionError):
-                continue
-            if len(ref_content) <= MAX_SKILL_SIZE:
-                _absorb(f"references/{ref_file.name}", ref_content)
+    for ref_file in _payload_files(str(path)):
+        try:
+            ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
+        except (OSError, PermissionError):
+            continue
+        if len(ref_content) <= MAX_SKILL_SIZE:
+            _absorb(f"references/{ref_file.name}", ref_content)
 
     # Ask load_eval_suite itself rather than re-deriving its file discovery. The
     # first attempt copied the symlink guard from estimate_token_cost, but
@@ -247,18 +252,32 @@ def skill_payload_digest(skill_path: str) -> str:
 
 
 def load_eval_suite(skill_path: str) -> Optional[dict]:
-    """Auto-discover and load eval-suite.json from skill directory."""
+    """Auto-discover and load eval-suite.json from skill directory.
+
+    Every failure degrades to ``None``. Only ``JSONDecodeError`` was caught
+    before, so a suite that is a directory, unreadable, or not UTF-8 raised
+    ``IsADirectoryError`` / ``PermissionError`` / ``UnicodeDecodeError``. That was
+    survivable while the only caller sat inside ``_score_single_skill``'s
+    ``except Exception`` — one row went to ``failed``. It stopped being
+    survivable when ``skill_payload_digest`` began calling this before the
+    scoring loop: one malformed suite anywhere under ``~/.claude`` turned the
+    whole run into a traceback. Doctor scans directories that are usually not
+    yours; it reports and never gates (ADR 0014, ADR 0019).
+    """
     skill_dir = Path(skill_path).parent
     auto_path = skill_dir / "eval-suite.json"
-    if auto_path.exists():
-        try:
-            raw = auto_path.read_text(encoding="utf-8")
-            if len(raw) > MAX_SKILL_SIZE:
-                print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
-                return None
-            return json.loads(raw)
-        except json.JSONDecodeError as e:
-            print(f"Warning: malformed eval-suite.json: {e}", file=sys.stderr)
+    try:
+        if not auto_path.exists():
+            return None
+        raw = auto_path.read_text(encoding="utf-8")
+        if len(raw) > MAX_SKILL_SIZE:
+            print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
+            return None
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"Warning: malformed eval-suite.json: {e}", file=sys.stderr)
+    except (OSError, ValueError) as e:
+        print(f"Warning: could not read eval-suite.json: {e}", file=sys.stderr)
     return None
 
 

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -217,7 +217,12 @@ def _read_bounded_with_reason(path: Path) -> tuple[Optional[str], str]:
     """
     fd = None
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        # getattr, not os.O_NONBLOCK: the constant is Unix-only, and on Windows the
+        # attribute lookup raises AttributeError — which `except (OSError, ValueError)`
+        # below does not catch, so every scan path would traceback on its first file.
+        # Falling back to 0 loses the FIFO-open protection on a platform that has no
+        # FIFOs; the fstat check below still rejects anything that is not a regular file.
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             return None, "not a regular file"
@@ -384,9 +389,16 @@ def skill_payload_digest(skill_path: str) -> str:
         # `action`, different `eval_suite_error` — so they must not collapse onto
         # each other. Without this the domain is again smaller than what the row
         # reports, which is the defect this key exists to prevent.
-        failure = eval_suite_error.get(str(path.parent / "eval-suite.json"))
+        suite_path = str(path.parent / "eval-suite.json")
+        failure = eval_suite_error.get(suite_path)
         if failure:
+            # The reason alone is as coarse a key as the "<unserialisable>" literal
+            # was in the branch above: two suites that are both `malformed` for
+            # different reasons, or simply different broken bytes, share one string
+            # and collapse onto each other. The content id is already recorded for
+            # these paths — it is set before `json.loads` runs — so fold it in too.
             _absorb("eval-suite.json:error", failure)
+            _absorb("eval-suite.json:error-id", eval_suite_content_id.get(suite_path) or "")
 
     return digest.hexdigest()
 
@@ -398,9 +410,12 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
     its docstring) and ``_score_single_skill`` asks again in the scoring loop, so
     every suite under the scan root was opened, read and parsed twice and every
     warning about a broken one was printed twice. The cache follows the shape
-    ``_file_cache`` already uses in this module — resolved-path key, bounded by
+    ``_file_cache`` already uses in this module — a path key, bounded by
     ``MAX_CACHE_ENTRIES``, cleared through ``invalidate_cache`` — rather than a
-    second, differently-invalidated one.
+    second, differently-invalidated one. The spelling differs from ``_file_cache``
+    on purpose-by-necessity: this key is the *unresolved* ``eval-suite.json`` path,
+    because that is what ``eval_suite_error`` keys on and the two are read together.
+    ``invalidate_cache`` uses the same spelling, so the pair cannot drift.
 
     The ``eval_suite_error`` entry is replayed on a hit, so a cached failure
     still reaches the report; only the duplicated stderr line is dropped.

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -175,6 +175,16 @@ def _payload_files(skill_path: str) -> list[Path]:
     confines resolved SKILL.md paths to the scan root and ``structure``'s ref
     linter requires refs to resolve back inside their base, for the same reason.
 
+    **The scope of the check, stated exactly:** ``is_symlink()`` tests the last
+    component, which is enough to stop a reference escaping the directory. It
+    does NOT stop a ``references/`` reached *through* a symlinked skill
+    directory — ``is_dir()`` resolves everything above. That is the caller's
+    confinement to make, and ``discover_skills`` makes it (``relative_to`` the
+    scan root), so a default run cannot reach it; ``--skill-dirs <link>`` and an
+    explicit ``score``/``bench`` path can, and there the caller named the link.
+    A ``realpath`` check here would be dead code: the base resolves with the
+    target, so it can never fail. Measured before writing that down.
+
     I briefly reversed this to make a stow layout collapse with its plain twin,
     on the strength of a fixture I had written myself. Measured afterwards over
     the real installation: **0 symlinks across the 41 skills that have a
@@ -316,6 +326,17 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
     try:
         if not auto_path.exists():
             eval_suite_error.pop(str(auto_path), None)
+            return None
+        # Size BEFORE read, like `cli._load_eval_suite_from_args` already does —
+        # the OOM-safe loading the changelog promised, which this loader never
+        # got. Reading first raises MemoryError on a multi-gigabyte target, and
+        # MemoryError is neither OSError nor ValueError nor RecursionError, so
+        # nothing below catches it. This path follows symlinks, and since
+        # `skill_payload_digest` calls it before the scoring loop, one such file
+        # ended the whole run instead of marking one row failed.
+        if auto_path.stat().st_size > MAX_SKILL_SIZE:
+            print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
+            eval_suite_error[str(auto_path)] = "exceeds the size limit"
             return None
         raw = auto_path.read_text(encoding="utf-8")
         if len(raw) > MAX_SKILL_SIZE:

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -182,7 +182,16 @@ def skill_payload_digest(skill_path: str) -> str:
 
     That is SKILL.md, its ``references/*.md``, and ``eval-suite.json`` — the file
     list ``estimate_token_cost`` charges for, plus the one ``load_eval_suite``
-    reads. A digest whose domain is smaller than the quantities it indexes is not
+    reads. The suite is fetched through that loader rather than re-discovered, so
+    the two cannot drift; the references walk mirrors the cost walk, guard for
+    guard.
+
+    Scope, stated exactly: this covers what the SCORE and the COST are derived
+    from. The ``Issues`` column can still differ between two copies with the same
+    digest — ``structure``'s dangling-reference lint resolves declared paths like
+    ``scripts/run.py`` against the skill directory and its plugin/git ancestors,
+    which are outside this domain. Measured over the 20 real duplicate groups: 0
+    divergences today, and the lint does not score. A digest whose domain is smaller than the quantities it indexes is not
     a simpler key, it is a wrong one; that was got wrong once per quantity, and
     both mistakes are recorded with their measurements in docs/specs/2026-08-13-doctor-counts-vendored-skills.md,
     "Amendment 2026-08-26". Not restated here.
@@ -223,16 +232,16 @@ def skill_payload_digest(skill_path: str) -> str:
             if len(ref_content) <= MAX_SKILL_SIZE:
                 _absorb(f"references/{ref_file.name}", ref_content)
 
-    # Same discovery and same size guard as load_eval_suite. Its presence moves a
-    # row from 4-of-7 dimensions to 7-of-7, so it belongs to the identity.
-    suite = path.parent / "eval-suite.json"
-    if suite.is_file() and not suite.is_symlink():
-        try:
-            raw = suite.read_text(encoding="utf-8", errors="replace")
-        except (OSError, PermissionError):
-            raw = ""
-        if raw and len(raw) <= MAX_SKILL_SIZE:
-            _absorb("eval-suite.json", raw)
+    # Ask load_eval_suite itself rather than re-deriving its file discovery. The
+    # first attempt copied the symlink guard from estimate_token_cost, but
+    # load_eval_suite has no such guard — it follows the link. A stow/chezmoi
+    # layout, where eval-suite.json is symlinked, was therefore scored but not
+    # hashed, and the 4-of-7 and 7-of-7 copies collapsed again. Calling the real
+    # loader makes the domains identical by construction, and keeps them
+    # identical if its discovery ever changes.
+    suite = load_eval_suite(str(path))
+    if suite is not None:
+        _absorb("eval-suite.json", json.dumps(suite, sort_keys=True, default=str))
 
     return digest.hexdigest()
 

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -33,6 +33,12 @@ MAX_CACHE_ENTRIES = 500
 # Module-level file cache to avoid redundant reads within a single invocation
 _file_cache: dict[str, str] = {}
 
+# Why an eval suite was not loaded, keyed by its path. `load_eval_suite` degrades
+# every failure to None so one bad file cannot end a doctor run — but "absent"
+# and "present and broken" must not look the same in a report: the second earns
+# `/schliff:init`, which would then write over the file that caused it.
+eval_suite_error: dict[str, str] = {}
+
 # Known scoring dimensions for validation
 VALID_DIMENSIONS = {
     "structure", "triggers", "quality", "edges",
@@ -164,7 +170,9 @@ def _payload_files(skill_path: str) -> list[Path]:
 def estimate_token_cost(skill_path: str) -> int:
     """Estimate token cost when this skill is loaded into context.
 
-    Counts words in SKILL.md + all files in references/ directory.
+    Counts words in SKILL.md plus the ``references/*.md`` that ``_payload_files``
+    enumerates — not every file in that directory. Widening it means widening
+    that helper, which moves the digest with it.
     Uses 1.3 tokens/word approximation (standard for English text with code).
     Returns estimated token count.
     """
@@ -193,9 +201,9 @@ def skill_payload_digest(skill_path: str) -> str:
 
     That is SKILL.md, its ``references/*.md``, and ``eval-suite.json`` — the file
     list ``estimate_token_cost`` charges for, plus the one ``load_eval_suite``
-    reads. The suite is fetched through that loader rather than re-discovered, so
-    the two cannot drift; the references walk mirrors the cost walk, guard for
-    guard.
+    reads. Neither half is re-derived: the references walk and the cost walk
+    share ``_payload_files``, and the suite is fetched through ``load_eval_suite``
+    itself, so no domain can drift from the one it indexes.
 
     Scope, stated exactly: this covers what the SCORE and the COST are derived
     from. The ``Issues`` column can still differ between two copies with the same
@@ -226,7 +234,7 @@ def skill_payload_digest(skill_path: str) -> str:
     # with and without one is one install rather than two.
     try:
         _absorb("SKILL.md", read_skill_safe(str(path)))
-    except (OSError, PermissionError, FileNotFoundError, ValueError):
+    except (OSError, ValueError):
         return ""
 
     for ref_file in _payload_files(str(path)):
@@ -246,7 +254,21 @@ def skill_payload_digest(skill_path: str) -> str:
     # identical if its discovery ever changes.
     suite = load_eval_suite(str(path))
     if suite is not None:
-        _absorb("eval-suite.json", json.dumps(suite, sort_keys=True, default=str))
+        try:
+            _absorb("eval-suite.json", json.dumps(suite, sort_keys=True, default=str))
+        except (RecursionError, TypeError, ValueError):
+            # A suite that parsed but will not serialise still made the row
+            # 7-of-7. Record that fact rather than silently hashing as if there
+            # were no suite at all.
+            _absorb("eval-suite.json", "<unserialisable>")
+    else:
+        # "absent" and "present but broken" produce different rows — different
+        # `action`, different `eval_suite_error` — so they must not collapse onto
+        # each other. Without this the domain is again smaller than what the row
+        # reports, which is the defect this key exists to prevent.
+        failure = eval_suite_error.get(str(path.parent / "eval-suite.json"))
+        if failure:
+            _absorb("eval-suite.json:error", failure)
 
     return digest.hexdigest()
 
@@ -268,16 +290,28 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
     auto_path = skill_dir / "eval-suite.json"
     try:
         if not auto_path.exists():
+            eval_suite_error.pop(str(auto_path), None)
             return None
         raw = auto_path.read_text(encoding="utf-8")
         if len(raw) > MAX_SKILL_SIZE:
             print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
+            eval_suite_error[str(auto_path)] = "exceeds the size limit"
             return None
         return json.loads(raw)
     except json.JSONDecodeError as e:
         print(f"Warning: malformed eval-suite.json: {e}", file=sys.stderr)
+        eval_suite_error[str(auto_path)] = f"malformed: {e}"
+    except RecursionError:
+        # json.loads recurses per nesting level on CPython below 3.14, and
+        # MAX_SKILL_SIZE leaves room for ~200k levels. Not an OSError and not a
+        # ValueError, so the handler below does not see it — and it only raises
+        # on the older interpreters, which means CI's newest leg stays green
+        # while the oldest tracebacks.
+        print("Warning: eval-suite.json nests too deeply to parse, skipping", file=sys.stderr)
+        eval_suite_error[str(auto_path)] = "nests too deeply to parse"
     except (OSError, ValueError) as e:
         print(f"Warning: could not read eval-suite.json: {e}", file=sys.stderr)
+        eval_suite_error[str(auto_path)] = f"unreadable: {e}"
     return None
 
 

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -6,6 +6,7 @@ Single source of truth — imported by all scoring and analysis modules.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sys
@@ -174,6 +175,62 @@ def estimate_token_cost(skill_path: str) -> int:
                 continue
 
     return round(total_words * 1.3)
+
+
+def skill_payload_digest(skill_path: str) -> str:
+    """Identity of an installed skill: SKILL.md plus its ``references/*.md``.
+
+    Two installs are the same install when they would cost the same to load.
+    That is why this hashes exactly the file list ``estimate_token_cost`` above
+    charges for — a digest whose domain is smaller than the measured quantity is
+    not a simpler key, it is a wrong one.
+
+    Hashing SKILL.md alone was tried and is wrong in two ways, both measured over
+    the 159 skills in a real ``~/.claude``:
+
+    * It collapses installs that cost different amounts. Two byte-identical
+      SKILL.md files with different ``references/`` came to 9,013 and 9,591
+      tokens; charging one for the other silently loses 578 tokens.
+    * The published total then depends on iteration order — keep-first gave
+      429,006 and keep-last 429,584 — and keep-first kept a June *backup* while
+      discarding the live ``~/.claude/skills/schliff/SKILL.md``. A rule meant to
+      clean the measurement would have deleted the subject of it from its own
+      report.
+
+    With this key both directions give 138 skills and 438,597 tokens: a swing of
+    zero, and the live skill survives. Regenerating this digest per file is also
+    the frozen corpus list — path plus digest is what lets a third party check a
+    published number against files that are not in this repository.
+
+    Returns an empty string when the file cannot be read, so an unreadable skill
+    never collapses onto another.
+    """
+    path = Path(skill_path)
+    digest = hashlib.sha256()
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError, ValueError):
+        return ""
+    if len(content) > MAX_SKILL_SIZE:
+        return ""
+    digest.update(content.encode("utf-8"))
+
+    # Same traversal, same guards as estimate_token_cost: sorted for a stable
+    # digest, symlinks skipped, oversized files ignored rather than hashed.
+    refs_dir = path.parent / "references"
+    if refs_dir.is_dir() and not refs_dir.is_symlink():
+        for ref_file in sorted(refs_dir.glob("*.md")):
+            if ref_file.is_symlink():
+                continue
+            try:
+                ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
+            except (OSError, PermissionError):
+                continue
+            if len(ref_content) <= MAX_SKILL_SIZE:
+                digest.update(ref_file.name.encode("utf-8"))
+                digest.update(ref_content.encode("utf-8"))
+
+    return digest.hexdigest()
 
 
 def load_eval_suite(skill_path: str) -> Optional[dict]:

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -165,29 +165,31 @@ def _payload_files(skill_path: str) -> list[Path]:
     guard for guard, which is the shape that already produced several defects in
     this area — a domain re-derived instead of asked for.
 
-    **Symlinks are followed**, like ``read_skill_safe`` and ``load_eval_suite``,
-    and for the reason ``read_skill_safe``'s docstring gives: stow, chezmoi,
-    ``claude --worktree`` and shared ``~/.claude/skills`` layouts all produce
-    them. Skipping them was inherited from ``estimate_token_cost`` and measured
-    wrong in both directions — a stow-managed copy reported 12 tokens against
-    1,182 for its byte-identical plain twin, and the two did not collapse. The
-    resolved target must still be a regular file, so a link to a directory or a
-    dangling one is dropped rather than read.
+    **Symlinks are rejected**, unlike ``read_skill_safe`` and ``load_eval_suite``
+    which follow them. The asymmetry is deliberate and it is a shipped security
+    fix: "symlink rejection on ``references/`` directory and files in
+    ``estimate_token_cost``". doctor walks directories that belong to other
+    people, so a plugin can put whatever it likes in ``references/``; following a
+    link there turns a word count into a filesystem oracle, and reading before
+    the size check turns a link to a huge file into an OOM. ``skill_mesh``
+    confines resolved SKILL.md paths to the scan root and ``structure``'s ref
+    linter requires refs to resolve back inside their base, for the same reason.
+
+    I briefly reversed this to make a stow layout collapse with its plain twin,
+    on the strength of a fixture I had written myself. Measured afterwards over
+    the real installation: **0 symlinks across the 41 skills that have a
+    ``references/`` directory**. The cost of the reversal was real and the case
+    it bought was not, so the rejection stands. If a field case ever appears, the
+    fix is confinement plus a ``stat().st_size`` check before the read — not a
+    bare ``resolve()``.
 
     Sorted for a stable digest; oversized files are dropped by whichever consumer
     reads them.
     """
     refs_dir = Path(skill_path).parent / "references"
-    if not refs_dir.is_dir():
+    if not refs_dir.is_dir() or refs_dir.is_symlink():
         return []
-    out = []
-    for f in sorted(refs_dir.glob("*.md")):
-        try:
-            if f.resolve().is_file():
-                out.append(f)
-        except OSError:
-            continue
-    return out
+    return [f for f in sorted(refs_dir.glob("*.md")) if not f.is_symlink()]
 
 
 def estimate_token_cost(skill_path: str) -> int:

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 import sys
 import threading
 import urllib.parse
@@ -32,6 +34,18 @@ MAX_CACHE_ENTRIES = 500
 
 # Module-level file cache to avoid redundant reads within a single invocation
 _file_cache: dict[str, str] = {}
+
+# The same, for parsed eval suites: path -> (stamp, suite, eval_suite_error reason).
+# Keyed by the eval-suite.json path, which is what `eval_suite_error` keys on too.
+#
+# The stamp is (st_mtime_ns, st_size) and it is not decoration: a path-only key
+# made a repaired suite stale — `test_a_repaired_suite_clears_its_recorded_failure`
+# went red on exactly that, a file rewritten from broken to valid still reporting
+# its old failure. Stated exactly, because a cache that lies is worse than the
+# double read it removes: this catches every rewrite that changes the size or
+# lands on a later mtime tick, which is every rewrite a doctor run can observe.
+# It would not catch a same-size rewrite inside one tick by a non-doctor caller.
+_eval_suite_cache: dict[str, tuple[tuple, Optional[dict], Optional[str]]] = {}
 
 # Why an eval suite was not loaded, keyed by its path. `load_eval_suite` degrades
 # every failure to None so one bad file cannot end a doctor run — but "absent"
@@ -98,6 +112,7 @@ def invalidate_cache(skill_path: str) -> None:
     """Invalidate the file cache for a given skill path."""
     key = str(Path(skill_path).resolve())
     _file_cache.pop(key, None)
+    _eval_suite_cache.pop(str(Path(skill_path).parent / "eval-suite.json"), None)
 
 
 def read_skill_safe(skill_path: str) -> str:
@@ -157,7 +172,7 @@ def extract_description(content: str) -> str:
     return ""
 
 
-def _read_bounded(path: Path) -> Optional[str]:
+def _read_bounded_with_reason(path: Path) -> tuple[Optional[str], str]:
     """Read a file only if it is safe to: regular, and within the size limit.
 
     One helper because the same two-line omission produced five defects in this
@@ -174,17 +189,44 @@ def _read_bounded(path: Path) -> Optional[str]:
       ``_score_single_skill``'s handler; it stopped being survivable when the
       digest began reading these files before the scoring loop.
 
-    Returns ``None`` when the file cannot or should not be read. Callers treat
-    that as "no content", never as an error to propagate.
+    Returns ``None`` when the file cannot or should not be read, alongside a
+    short, path-free reason. Callers treat the ``None`` as "no content", never
+    as an error to propagate; the reason exists because collapsing "too large"
+    and "unreadable" into one word told the reader to repair a file whose only
+    problem was its size.
+
+    **The checks run on the descriptor, not on the path.** ``is_file()`` then
+    ``stat()`` then ``read_text()`` leaves two windows in which the path can be
+    swapped for a FIFO after the check and before the open — and anyone who can
+    plant the FIFO can also win that race, so under this function's own threat
+    model the hang it exists to prevent stayed reachable. ``O_NONBLOCK`` makes
+    the open itself return instead of waiting for a writer, and ``fstat`` then
+    describes the exact object that is about to be read. ``read_skill_safe``
+    resolves the same race the other way (read first, size after), which it can
+    afford because it does not need the size before the read; here the size gate
+    is the point, so the descriptor is the only honest thing to measure.
     """
+    fd = None
     try:
-        if not path.is_file():
-            return None
-        if path.stat().st_size > MAX_SKILL_SIZE:
-            return None
-        return path.read_text(encoding="utf-8", errors="replace")
+        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None, "not a regular file"
+        if st.st_size > MAX_SKILL_SIZE:
+            return None, "too large"
+        with os.fdopen(fd, "r", encoding="utf-8", errors="replace") as handle:
+            fd = None  # fdopen owns the descriptor now; closing it twice raises.
+            return handle.read(), ""
     except (OSError, ValueError):
-        return None
+        return None, "unreadable"
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _read_bounded(path: Path) -> Optional[str]:
+    """``_read_bounded_with_reason`` for the callers that only need the text."""
+    return _read_bounded_with_reason(path)[0]
 
 
 def _payload_files(skill_path: str) -> list[Path]:
@@ -333,6 +375,42 @@ def skill_payload_digest(skill_path: str) -> str:
 
 
 def load_eval_suite(skill_path: str) -> Optional[dict]:
+    """Auto-discover and load eval-suite.json, once per path per invocation.
+
+    ``skill_payload_digest`` asks this loader for the suite (deliberately — see
+    its docstring) and ``_score_single_skill`` asks again in the scoring loop, so
+    every suite under the scan root was opened, read and parsed twice and every
+    warning about a broken one was printed twice. The cache follows the shape
+    ``_file_cache`` already uses in this module — resolved-path key, bounded by
+    ``MAX_CACHE_ENTRIES``, cleared through ``invalidate_cache`` — rather than a
+    second, differently-invalidated one.
+
+    The ``eval_suite_error`` entry is replayed on a hit, so a cached failure
+    still reaches the report; only the duplicated stderr line is dropped.
+    """
+    suite_path = Path(skill_path).parent / "eval-suite.json"
+    key = str(suite_path)
+    try:
+        st = suite_path.stat()
+        stamp = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        stamp = ()
+    cached = _eval_suite_cache.get(key)
+    if cached is not None and cached[0] == stamp:
+        _, suite, failure = cached
+        if failure is None:
+            eval_suite_error.pop(key, None)
+        else:
+            eval_suite_error[key] = failure
+        return suite
+    suite = _load_eval_suite_uncached(skill_path)
+    if len(_eval_suite_cache) >= MAX_CACHE_ENTRIES:
+        _eval_suite_cache.pop(next(iter(_eval_suite_cache)))
+    _eval_suite_cache[key] = (stamp, suite, eval_suite_error.get(key))
+    return suite
+
+
+def _load_eval_suite_uncached(skill_path: str) -> Optional[dict]:
     """Auto-discover and load eval-suite.json from skill directory.
 
     Every failure degrades to ``None``. Only ``JSONDecodeError`` was caught
@@ -354,10 +432,15 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
         # One reader for every file this module opens: regular-file check before
         # the size check before the read. See `_read_bounded` for why each half
         # is there and what it cost to learn.
-        raw = _read_bounded(auto_path)
+        raw, why = _read_bounded_with_reason(auto_path)
         if raw is None:
-            print("Warning: eval-suite.json could not be read, skipping", file=sys.stderr)
-            eval_suite_error[str(auto_path)] = "unreadable"
+            # stderr carries the full diagnosis; `eval_suite_error` carries the
+            # short reason, because that one is folded into the identity and
+            # printed inside a repair action whose width is gated by
+            # test_repair_action_fits_its_column.
+            detail = f"exceeds {MAX_SKILL_SIZE:,} bytes" if why == "too large" else why
+            print(f"Warning: eval-suite.json {detail}, skipping", file=sys.stderr)
+            eval_suite_error[str(auto_path)] = why
             return None
         parsed = json.loads(raw)
         # `null` parses to None, which is indistinguishable from "no file" and

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -121,7 +121,12 @@ def invalidate_cache(skill_path: str) -> None:
     """Invalidate the file cache for a given skill path."""
     key = str(Path(skill_path).resolve())
     _file_cache.pop(key, None)
-    _eval_suite_cache.pop(str(Path(skill_path).parent / "eval-suite.json"), None)
+    # Four dicts are keyed on this skill's paths; invalidating two of them left the
+    # other two to outlive the file they describe. One door, all four.
+    suite_key = str(Path(skill_path).parent / "eval-suite.json")
+    _eval_suite_cache.pop(suite_key, None)
+    eval_suite_error.pop(suite_key, None)
+    eval_suite_content_id.pop(suite_key, None)
 
 
 def read_skill_safe(skill_path: str) -> str:
@@ -393,10 +398,20 @@ def skill_payload_digest(skill_path: str) -> str:
         failure = eval_suite_error.get(suite_path)
         if failure:
             # The reason alone is as coarse a key as the "<unserialisable>" literal
-            # was in the branch above: two suites that are both `malformed` for
-            # different reasons, or simply different broken bytes, share one string
-            # and collapse onto each other. The content id is already recorded for
-            # these paths — it is set before `json.loads` runs — so fold it in too.
+            # was in the branch above, so fold in the content id where one exists.
+            #
+            # It exists only for the PARSE-stage failures: a suite that could not be
+            # read has no bytes to hash, and `_load_eval_suite_uncached` drops the id
+            # there. That is not a gap to close. Nothing the row reports derives from
+            # an unread suite's bytes — `estimate_token_cost` never charges
+            # eval-suite.json, `build_scores` gets None, and the only suite-derived
+            # field is the reason word this line already absorbs — so two such rows
+            # are identical in every quantity, which is exactly when the digest is
+            # supposed to collapse them. Making them distinct was measured and it
+            # doubles the install count and the token total for a group whose copies
+            # are byte-identical, i.e. whose read failures are correlated by
+            # construction. `test_two_copies_with_the_same_broken_suite_still_collapse`
+            # is the gate on that.
             _absorb("eval-suite.json:error", failure)
             _absorb("eval-suite.json:error-id", eval_suite_content_id.get(suite_path) or "")
 

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -157,6 +157,36 @@ def extract_description(content: str) -> str:
     return ""
 
 
+def _read_bounded(path: Path) -> Optional[str]:
+    """Read a file only if it is safe to: regular, and within the size limit.
+
+    One helper because the same two-line omission produced five defects in this
+    area. Both halves matter and both were learned the hard way:
+
+    * **Regular file, checked first.** ``read_text`` on a FIFO blocks forever —
+      measured, still hung after six seconds — and on a character device it reads
+      until memory runs out. ``st_size`` is 0 for both, so a size gate alone lets
+      them through. doctor walks directories that belong to other people, so a
+      plugin can put either where a skill file is expected.
+    * **Size before read, not after.** Reading first raises ``MemoryError`` on a
+      multi-gigabyte target, and ``MemoryError`` is not ``OSError`` and not
+      ``ValueError``. That was survivable while every caller sat inside
+      ``_score_single_skill``'s handler; it stopped being survivable when the
+      digest began reading these files before the scoring loop.
+
+    Returns ``None`` when the file cannot or should not be read. Callers treat
+    that as "no content", never as an error to propagate.
+    """
+    try:
+        if not path.is_file():
+            return None
+        if path.stat().st_size > MAX_SKILL_SIZE:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+
 def _payload_files(skill_path: str) -> list[Path]:
     """The ``references/*.md`` a skill loads alongside its SKILL.md.
 
@@ -221,12 +251,9 @@ def estimate_token_cost(skill_path: str) -> int:
         return 0
 
     for ref_file in _payload_files(skill_path):
-        try:
-            ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
-            if len(ref_content) <= MAX_SKILL_SIZE:
-                total_words += len(ref_content.split())
-        except (OSError, PermissionError):
-            continue
+        ref_content = _read_bounded(ref_file)
+        if ref_content is not None:
+            total_words += len(ref_content.split())
 
     return round(total_words * 1.3)
 
@@ -273,11 +300,8 @@ def skill_payload_digest(skill_path: str) -> str:
         return ""
 
     for ref_file in _payload_files(str(path)):
-        try:
-            ref_content = ref_file.read_text(encoding="utf-8", errors="replace")
-        except (OSError, PermissionError):
-            continue
-        if len(ref_content) <= MAX_SKILL_SIZE:
+        ref_content = _read_bounded(ref_file)
+        if ref_content is not None:
             _absorb(f"references/{ref_file.name}", ref_content)
 
     # Ask load_eval_suite itself rather than re-deriving its file discovery. The
@@ -327,23 +351,24 @@ def load_eval_suite(skill_path: str) -> Optional[dict]:
         if not auto_path.exists():
             eval_suite_error.pop(str(auto_path), None)
             return None
-        # Size BEFORE read, like `cli._load_eval_suite_from_args` already does —
-        # the OOM-safe loading the changelog promised, which this loader never
-        # got. Reading first raises MemoryError on a multi-gigabyte target, and
-        # MemoryError is neither OSError nor ValueError nor RecursionError, so
-        # nothing below catches it. This path follows symlinks, and since
-        # `skill_payload_digest` calls it before the scoring loop, one such file
-        # ended the whole run instead of marking one row failed.
-        if auto_path.stat().st_size > MAX_SKILL_SIZE:
-            print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
-            eval_suite_error[str(auto_path)] = "exceeds the size limit"
-            return None
-        raw = auto_path.read_text(encoding="utf-8")
-        if len(raw) > MAX_SKILL_SIZE:
-            print(f"Warning: eval-suite.json exceeds {MAX_SKILL_SIZE} bytes, skipping", file=sys.stderr)
-            eval_suite_error[str(auto_path)] = "exceeds the size limit"
+        # One reader for every file this module opens: regular-file check before
+        # the size check before the read. See `_read_bounded` for why each half
+        # is there and what it cost to learn.
+        raw = _read_bounded(auto_path)
+        if raw is None:
+            print("Warning: eval-suite.json could not be read, skipping", file=sys.stderr)
+            eval_suite_error[str(auto_path)] = "unreadable"
             return None
         parsed = json.loads(raw)
+        # `null` parses to None, which is indistinguishable from "no file" and
+        # routed the row to /schliff:init — the command that overwrites it. And a
+        # list or string parsed fine here while `cli._load_eval_suite_from_args`
+        # rejects the same content outright; the auto-discovery half was the
+        # permissive one. A suite that is not an object is a broken suite.
+        if not isinstance(parsed, dict):
+            print("Warning: eval-suite.json is not a JSON object, skipping", file=sys.stderr)
+            eval_suite_error[str(auto_path)] = "not a JSON object"
+            return None
         eval_suite_error.pop(str(auto_path), None)
         return parsed
     except json.JSONDecodeError as e:

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -59,6 +59,15 @@ _eval_suite_cache: dict[str, tuple[tuple, Optional[dict], Optional[str]]] = {}
 # remove. Details still reach stderr; only the reason reaches the identity.
 eval_suite_error: dict[str, str] = {}
 
+# Content identity of a suite that was read, keyed by its path — a sha256 over the
+# bytes, never the bytes themselves, so this stays 64 characters per entry.
+#
+# `skill_payload_digest` needs a way to tell two suites apart even when it cannot
+# serialise them, and the file belongs to `load_eval_suite`. Deriving it there and
+# reading it here is the alternative to the digest re-opening the path itself,
+# which is the re-derivation that produced five defects in this area already.
+eval_suite_content_id: dict[str, str] = {}
+
 # Known scoring dimensions for validation
 VALID_DIMENSIONS = {
     "structure", "triggers", "quality", "edges",
@@ -360,8 +369,16 @@ def skill_payload_digest(skill_path: str) -> str:
         except (RecursionError, TypeError, ValueError):
             # A suite that parsed but will not serialise still made the row
             # 7-of-7. Record that fact rather than silently hashing as if there
-            # were no suite at all.
-            _absorb("eval-suite.json", "<unserialisable>")
+            # were no suite at all — but record it as something derived from the
+            # file. A fixed marker here gave two skills with DIFFERENT
+            # unserialisable suites one identity, so the second vanished from the
+            # report as a copy of the first: the domain smaller than what the row
+            # reports, which is the failure the `else` branch below names and the
+            # whole reason this key exists. The id comes from `load_eval_suite`,
+            # which read the bytes; re-opening the path here would be the
+            # re-derivation this module keeps paying for.
+            marker = eval_suite_content_id.get(str(path.parent / "eval-suite.json"))
+            _absorb("eval-suite.json:unserialisable", marker or "")
     else:
         # "absent" and "present but broken" produce different rows — different
         # `action`, different `eval_suite_error` — so they must not collapse onto
@@ -428,6 +445,7 @@ def _load_eval_suite_uncached(skill_path: str) -> Optional[dict]:
     try:
         if not auto_path.exists():
             eval_suite_error.pop(str(auto_path), None)
+            eval_suite_content_id.pop(str(auto_path), None)
             return None
         # One reader for every file this module opens: regular-file check before
         # the size check before the read. See `_read_bounded` for why each half
@@ -441,7 +459,10 @@ def _load_eval_suite_uncached(skill_path: str) -> Optional[dict]:
             detail = f"exceeds {MAX_SKILL_SIZE:,} bytes" if why == "too large" else why
             print(f"Warning: eval-suite.json {detail}, skipping", file=sys.stderr)
             eval_suite_error[str(auto_path)] = why
+            eval_suite_content_id.pop(str(auto_path), None)
             return None
+        eval_suite_content_id[str(auto_path)] = hashlib.sha256(
+            raw.encode("utf-8")).hexdigest()
         parsed = json.loads(raw)
         # `null` parses to None, which is indistinguishable from "no file" and
         # routed the row to /schliff:init — the command that overwrites it. And a

--- a/skills/schliff/scripts/shared.py
+++ b/skills/schliff/scripts/shared.py
@@ -178,42 +178,36 @@ def estimate_token_cost(skill_path: str) -> int:
 
 
 def skill_payload_digest(skill_path: str) -> str:
-    """Identity of an installed skill: SKILL.md plus its ``references/*.md``.
+    """Identity of an installed skill: everything a doctor row is derived from.
 
-    Two installs are the same install when they would cost the same to load.
-    That is why this hashes exactly the file list ``estimate_token_cost`` above
-    charges for — a digest whose domain is smaller than the measured quantity is
-    not a simpler key, it is a wrong one.
+    That is SKILL.md, its ``references/*.md``, and ``eval-suite.json`` — the file
+    list ``estimate_token_cost`` charges for, plus the one ``load_eval_suite``
+    reads. A digest whose domain is smaller than the quantities it indexes is not
+    a simpler key, it is a wrong one; that was got wrong once per quantity, and
+    both mistakes are recorded with their measurements in docs/specs/2026-08-13-doctor-counts-vendored-skills.md,
+    "Amendment 2026-08-26". Not restated here.
 
-    Hashing SKILL.md alone was tried and is wrong in two ways, both measured over
-    the 159 skills in a real ``~/.claude``:
-
-    * It collapses installs that cost different amounts. Two byte-identical
-      SKILL.md files with different ``references/`` came to 9,013 and 9,591
-      tokens; charging one for the other silently loses 578 tokens.
-    * The published total then depends on iteration order — keep-first gave
-      429,006 and keep-last 429,584 — and keep-first kept a June *backup* while
-      discarding the live ``~/.claude/skills/schliff/SKILL.md``. A rule meant to
-      clean the measurement would have deleted the subject of it from its own
-      report.
-
-    With this key both directions give 138 skills and 438,597 tokens: a swing of
-    zero, and the live skill survives. Regenerating this digest per file is also
-    the frozen corpus list — path plus digest is what lets a third party check a
-    published number against files that are not in this repository.
-
-    Returns an empty string when the file cannot be read, so an unreadable skill
+    Returns an empty string when SKILL.md cannot be read, so an unreadable skill
     never collapses onto another.
     """
     path = Path(skill_path)
     digest = hashlib.sha256()
+
+    def _absorb(label: str, text: str) -> None:
+        # Length-prefixed: without a separator, a file named `b.md` holding "X"
+        # and a file `a.md` holding "Xb.md" hash the same, so two unrelated
+        # skills would collapse and one would vanish from the report as a copy
+        # of the other.
+        blob = text.encode("utf-8")
+        digest.update(f"{label}:{len(blob)}\0".encode("utf-8"))
+        digest.update(blob)
+
+    # read_skill_safe, not read_text: it strips the BOM, so the same skill saved
+    # with and without one is one install rather than two.
     try:
-        content = path.read_text(encoding="utf-8", errors="replace")
-    except (OSError, PermissionError, ValueError):
+        _absorb("SKILL.md", read_skill_safe(str(path)))
+    except (OSError, PermissionError, FileNotFoundError, ValueError):
         return ""
-    if len(content) > MAX_SKILL_SIZE:
-        return ""
-    digest.update(content.encode("utf-8"))
 
     # Same traversal, same guards as estimate_token_cost: sorted for a stable
     # digest, symlinks skipped, oversized files ignored rather than hashed.
@@ -227,8 +221,18 @@ def skill_payload_digest(skill_path: str) -> str:
             except (OSError, PermissionError):
                 continue
             if len(ref_content) <= MAX_SKILL_SIZE:
-                digest.update(ref_file.name.encode("utf-8"))
-                digest.update(ref_content.encode("utf-8"))
+                _absorb(f"references/{ref_file.name}", ref_content)
+
+    # Same discovery and same size guard as load_eval_suite. Its presence moves a
+    # row from 4-of-7 dimensions to 7-of-7, so it belongs to the identity.
+    suite = path.parent / "eval-suite.json"
+    if suite.is_file() and not suite.is_symlink():
+        try:
+            raw = suite.read_text(encoding="utf-8", errors="replace")
+        except (OSError, PermissionError):
+            raw = ""
+        if raw and len(raw) <= MAX_SKILL_SIZE:
+            _absorb("eval-suite.json", raw)
 
     return digest.hexdigest()
 

--- a/skills/schliff/scripts/skill_mesh.py
+++ b/skills/schliff/scripts/skill_mesh.py
@@ -23,6 +23,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Optional
 
+import shared
+
 # Import scorer functions for tokenization and description extraction
 from nlp import tokenize_meaningful
 from shared import EXCLUDED_DIRS, extract_description
@@ -97,13 +99,14 @@ def discover_skills(skill_dirs: list[str]) -> list[dict]:
                 continue
             seen_paths.add(real_path)
 
-            try:
-                content = resolved.read_text(encoding="utf-8", errors="replace")
-            except (OSError, PermissionError):
-                continue
-
-            # Skip files > 1MB
-            if len(content) > 1_000_000:
+            # The shared reader, not a local read: regular-file check, then size,
+            # then read. Reading first blocks forever on a FIFO named SKILL.md
+            # (measured) and raises MemoryError on a multi-gigabyte one, which
+            # neither handler here catches. This is the first file doctor opens,
+            # so it decides whether the scan can be hung at all — the guard in
+            # `_read_bounded` is downstream of it.
+            content = shared._read_bounded(resolved)
+            if content is None:
                 continue
 
             # Extract metadata

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -8,6 +8,8 @@ Each test here is named after the mutation it has to survive. Two of them exist
 because the first version of this file did not discriminate: they were green
 against the very mutations their docstrings quoted.
 """
+import pathlib
+
 import doctor
 import pytest
 
@@ -350,6 +352,53 @@ def test_an_unreadable_suite_is_not_counted_as_missing(tmp_path):
     assert report["no_eval_suite"] == 0
     assert report["broken_eval_suite"] == 1
     assert "Run /schliff:init on" not in rendered
+
+
+def test_an_oversized_eval_suite_is_never_read(tmp_path, monkeypatch):
+    """Size before read — the OOM-safe loading the changelog promised.
+
+    ``read_text`` on a multi-gigabyte target raises ``MemoryError``, which is
+    neither ``OSError`` nor ``ValueError`` nor ``RecursionError``. The digest
+    calls this before the scoring loop and outside any handler, so one such file
+    ended the whole run. ``cli._load_eval_suite_from_args`` already checked
+    ``stat().st_size`` first; the shared loader never did.
+
+    Remove the ``stat().st_size`` guard and this goes red — the file gets read.
+    """
+    import shared
+
+    skill = _skill(tmp_path, "s", BODY)
+    suite = tmp_path / "s" / "eval-suite.json"
+    suite.write_text("{" + " " * (shared.MAX_SKILL_SIZE + 1000) + "}", encoding="utf-8")
+
+    reads = []
+    real_read = pathlib.Path.read_text
+
+    def _spy(self, *a, **kw):
+        if self.name == "eval-suite.json":
+            reads.append(str(self))
+        return real_read(self, *a, **kw)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", _spy)
+    assert shared.load_eval_suite(skill["path"]) is None
+    assert reads == [], "an oversized suite must not be read into memory at all"
+
+
+def test_a_grouped_row_is_not_counted_as_missing_an_eval_suite(tmp_path):
+    """The footer must not contradict the row, for duplicates either.
+
+    A grouped row's action says to resolve the duplicate and its path is the
+    plugin cache. Counting it as "missing an eval suite" put it in "Run
+    /schliff:init on N skills" — writing into a directory the next plugin update
+    deletes. Field-measured before the fix: all 20 groups landed in that count.
+    """
+    _skill(tmp_path, "cached", BODY)
+    _skill(tmp_path, "vendored", BODY)
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+
+    assert report["grouped_duplicates"] == 1
+    assert report["no_eval_suite"] == 0, "a grouped row must not join the init recommendation"
 
 
 def test_cost_and_digest_read_the_same_files(tmp_path, monkeypatch):

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -770,3 +770,41 @@ def test_grouped_rows_get_no_skill_specific_recommendation(tmp_path, monkeypatch
     assert report["duplicate_copies"], "fixture stopped producing a duplicate group"
     body = rendered.split("Skill-specific recommendations:")
     assert len(body) == 1, f"grouped row still got a recommendation:\n{body[-1][:400]}"
+
+
+def test_unserialisable_suites_do_not_share_one_identity(tmp_path, monkeypatch):
+    """A constant in the digest is not an identity.
+
+    Two skills with the same SKILL.md and DIFFERENT eval-suite.json files that
+    parse but will not serialise both absorbed the literal "<unserialisable>",
+    so their digests matched and the second vanished from the report as a copy
+    of the first — the domain smaller than what the row reports, which is the
+    failure this key exists to prevent and which the branch below it names.
+
+    `json.dumps` is forced to raise rather than reproduced through recursion
+    depth: below Python 3.14 `json.loads` recurses first and the suite never
+    reaches this branch at all, so a nesting fixture would test nothing on the
+    interpreter this suite usually runs on.
+
+    The mutation: put the fixed marker back and this goes red.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    (pathlib.Path(a["path"]).parent / "eval-suite.json").write_text(
+        '{"assertions": ["alpha"]}', encoding="utf-8")
+    (pathlib.Path(b["path"]).parent / "eval-suite.json").write_text(
+        '{"assertions": ["beta"]}', encoding="utf-8")
+    shared._eval_suite_cache.clear()
+
+    def _refuse(*args, **kwargs):
+        raise ValueError("will not serialise")
+
+    monkeypatch.setattr(shared.json, "dumps", _refuse)
+
+    digest_a = shared.skill_payload_digest(a["path"])
+    digest_b = shared.skill_payload_digest(b["path"])
+
+    assert digest_a and digest_b, "an unserialisable suite must not void the identity"
+    assert digest_a != digest_b, (
+        "two different unserialisable suites collapsed onto one identity"
+    )

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -401,6 +401,95 @@ def test_a_grouped_row_is_not_counted_as_missing_an_eval_suite(tmp_path):
     assert report["no_eval_suite"] == 0, "a grouped row must not join the init recommendation"
 
 
+def test_a_fifo_where_a_file_is_expected_does_not_hang(tmp_path):
+    """A plugin can put a FIFO where a skill file goes; doctor must not block.
+
+    ``read_text`` on a FIFO waits for a writer that never comes — measured, still
+    blocked after six seconds — and ``st_size`` is 0, so a size gate alone lets
+    it through. The digest reads these before the scoring loop, so nothing was
+    reported at all. ``_read_bounded`` checks ``is_file()`` first.
+    """
+    import os
+
+    import shared
+
+    skill = _skill(tmp_path, "s", BODY, refs={"placeholder.md": ""})
+    (tmp_path / "s" / "references" / "placeholder.md").unlink()
+    os.mkfifo(tmp_path / "s" / "references" / "pipe.md")
+    os.mkfifo(tmp_path / "s" / "eval-suite.json")
+
+    # Both readers must return rather than block.
+    assert shared.estimate_token_cost(skill["path"]) >= 0
+    assert shared.load_eval_suite(skill["path"]) is None
+    assert shared.skill_payload_digest(skill["path"])
+
+
+def test_an_oversized_reference_is_never_read(tmp_path, monkeypatch):
+    """Size before read on the references side too.
+
+    The loader got this guard first; the reference walk kept reading before
+    checking, under a handler that catches neither ``MemoryError``. Since the
+    digest runs before the scoring loop, one huge file ended the whole run
+    instead of marking a row failed.
+    """
+    import shared
+
+    skill = _skill(tmp_path, "s", BODY, refs={"big.md": "x" * (shared.MAX_SKILL_SIZE + 1000)})
+
+    reads = []
+    real_read = pathlib.Path.read_text
+
+    def _spy(self, *a, **kw):
+        if self.name == "big.md":
+            reads.append(str(self))
+        return real_read(self, *a, **kw)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", _spy)
+    shared.skill_payload_digest(skill["path"])
+    shared.estimate_token_cost(skill["path"])
+    assert reads == [], "an oversized reference must not be read into memory"
+
+
+@pytest.mark.parametrize("content", ["null", "[1, 2, 3]", '"hello"'])
+def test_a_suite_that_is_not_an_object_is_a_broken_suite(tmp_path, content):
+    """`null` was indistinguishable from "no file" and routed to /schliff:init.
+
+    A list or a string parsed fine here while `cli._load_eval_suite_from_args`
+    rejects the same content outright — the auto-discovery half was the
+    permissive one.
+    """
+    import shared
+
+    skill = _skill(tmp_path, "s", BODY)
+    (tmp_path / "s" / "eval-suite.json").write_text(content, encoding="utf-8")
+
+    assert shared.load_eval_suite(skill["path"]) is None
+    assert shared.eval_suite_error.get(str(tmp_path / "s" / "eval-suite.json")) == "not a JSON object"
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    row = report["results"][0]
+    assert "/schliff:init" not in (row["action"] or "")
+
+
+def test_every_scanned_row_lands_in_exactly_one_bucket(tmp_path):
+    """Grouped rows were in no tally at all — 20 of 138 on the real install."""
+    _skill(tmp_path, "cached", BODY)
+    _skill(tmp_path, "vendored", BODY)
+    _skill(tmp_path, "solo", BODY)
+
+    r = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    buckets = (
+        r["healthy"] + r["needs_work"] + r["no_eval_suite"]
+        + r["broken_eval_suite"] + r["grouped_duplicates"] + r["failed"]
+    )
+
+    assert buckets == r["skills_found"]
+    assert r["skills_discovered"] - r["skills_found"] == sum(
+        len(g["also_installed_at"]) for g in r["duplicate_copies"]
+    )
+    assert f"{r['grouped_duplicates']} duplicate install" in doctor.format_doctor_report(r)
+
+
 def test_cost_and_digest_read_the_same_files(tmp_path, monkeypatch):
     """The invariant behind the whole key, gated on BOTH sides.
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -233,14 +233,13 @@ def test_a_broken_suite_row_does_not_send_you_to_overwrite_it(tmp_path):
 
 
 def test_a_grouped_row_carries_no_runnable_action(tmp_path):
-    """The counted path is sort order, not merit — and usually the plugin cache.
+    """The counted path is sort order, not merit.
 
-    ``discover_skills`` sorts by path and the first wins, so
-    ``plugins/cache/…`` beats ``plugins/marketplaces/…`` and ``~/.claude/skills/…``
-    every time. Emitting ``/schliff:auto <that path>`` writes ``.schliff/``
-    history into a directory the next plugin update deletes. Preferring another
-    member would need a path wordlist — the enumeration this key avoids — so the
-    row says what to do instead.
+    ``discover_skills`` sorts by path and the first wins. Which member that
+    favours depends on the directories scanned, so naming it in a runnable
+    command — ``/schliff:auto <that path>`` — would act on a copy this command
+    did not choose. Preferring another member would need a path wordlist, the
+    enumeration this key avoids, so the row states the measurement instead.
     """
     _skill(tmp_path, "cache-copy", BODY)
     _skill(tmp_path, "user-copy", BODY)
@@ -356,43 +355,37 @@ def test_an_unreadable_suite_is_not_counted_as_missing(tmp_path):
     assert "Run /schliff:init on" not in rendered
 
 
-def test_an_oversized_eval_suite_is_never_read(tmp_path, monkeypatch):
+def test_an_oversized_eval_suite_is_not_read_into_memory(tmp_path):
     """Size before read — the OOM-safe loading the changelog promised.
 
-    ``read_text`` on a multi-gigabyte target raises ``MemoryError``, which is
-    neither ``OSError`` nor ``ValueError`` nor ``RecursionError``. The digest
-    calls this before the scoring loop and outside any handler, so one such file
-    ended the whole run. ``cli._load_eval_suite_from_args`` already checked
-    ``stat().st_size`` first; the shared loader never did.
+    This test replaces a spy on ``pathlib.Path.read_text``. The spy was dead:
+    the reader moved to ``os.open``/``os.fdopen``, so it observed nothing and
+    its ``assert reads == []`` was vacuously true — the mutation it named left
+    it green, and only a second, unrelated assertion in the same test carried
+    it. An instrument that a change of read mechanic can silently disarm is not
+    an instrument. Assert the observable outcome instead: the reason recorded,
+    which no read mechanic can fake.
 
-    Remove the ``stat().st_size`` guard and this goes red — the file gets read.
+    Remove the size branch from ``_read_bounded_with_reason`` and this goes red.
     """
     import shared
 
     skill = _skill(tmp_path, "s", BODY)
     suite = tmp_path / "s" / "eval-suite.json"
     suite.write_text("{" + " " * (shared.MAX_SKILL_SIZE + 1000) + "}", encoding="utf-8")
+    shared._eval_suite_cache.clear()
 
-    reads = []
-    real_read = pathlib.Path.read_text
-
-    def _spy(self, *a, **kw):
-        if self.name == "eval-suite.json":
-            reads.append(str(self))
-        return real_read(self, *a, **kw)
-
-    monkeypatch.setattr(pathlib.Path, "read_text", _spy)
     assert shared.load_eval_suite(skill["path"]) is None
-    assert reads == [], "an oversized suite must not be read into memory at all"
+    assert shared.eval_suite_error[str(suite)] == "too large"
 
 
 def test_a_grouped_row_is_not_counted_as_missing_an_eval_suite(tmp_path):
     """The footer must not contradict the row, for duplicates either.
 
-    A grouped row's action says to resolve the duplicate and its path is the
-    plugin cache. Counting it as "missing an eval suite" put it in "Run
-    /schliff:init on N skills" — writing into a directory the next plugin update
-    deletes. Field-measured before the fix: all 20 groups landed in that count.
+    A grouped row's action states that the payload was scored once, and its path
+    was picked by sort order. Counting it as "missing an eval suite" put it in
+    "Run /schliff:init on N skills" — a command against a path this tool did not
+    choose. Field-measured before the fix: all 20 groups landed in that count.
     """
     _skill(tmp_path, "cached", BODY)
     _skill(tmp_path, "vendored", BODY)
@@ -448,30 +441,24 @@ def test_a_fifo_where_a_file_is_expected_does_not_hang(tmp_path):
     assert shared.skill_payload_digest(skill["path"])
 
 
-def test_an_oversized_reference_is_never_read(tmp_path, monkeypatch):
-    """Size before read on the references side too.
+def test_an_oversized_reference_is_not_charged_or_hashed(tmp_path):
+    """The same guard, on the references side, asserted through behaviour.
 
-    The loader got this guard first; the reference walk kept reading before
-    checking, under a handler that catches neither ``MemoryError``. Since the
-    digest runs before the scoring loop, one huge file ended the whole run
-    instead of marking a row failed.
+    The previous version spied on ``pathlib.Path.read_text`` and had ZERO
+    discriminating power after the reader moved to ``os.open``: deleting the
+    size branch entirely left it green, so the guard was unwatched on this path.
+    Cost and identity are what the guard protects, so assert those: an oversized
+    reference must change neither.
     """
     import shared
 
-    skill = _skill(tmp_path, "s", BODY, refs={"big.md": "x" * (shared.MAX_SKILL_SIZE + 1000)})
+    plain = _skill(tmp_path, "plain", BODY)
+    fat = _skill(tmp_path, "fat", BODY, refs={"big.md": "x" * (shared.MAX_SKILL_SIZE + 1000)})
 
-    reads = []
-    real_read = pathlib.Path.read_text
-
-    def _spy(self, *a, **kw):
-        if self.name == "big.md":
-            reads.append(str(self))
-        return real_read(self, *a, **kw)
-
-    monkeypatch.setattr(pathlib.Path, "read_text", _spy)
-    shared.skill_payload_digest(skill["path"])
-    shared.estimate_token_cost(skill["path"])
-    assert reads == [], "an oversized reference must not be read into memory"
+    assert shared.estimate_token_cost(fat["path"]) == shared.estimate_token_cost(plain["path"]), \
+        "an oversized reference was charged — the size guard did not run"
+    assert shared.skill_payload_digest(fat["path"]) == shared.skill_payload_digest(plain["path"]), \
+        "an oversized reference reached the identity — the size guard did not run"
 
 
 @pytest.mark.parametrize("content", ["null", "[1, 2, 3]", '"hello"'])
@@ -496,10 +483,21 @@ def test_a_suite_that_is_not_an_object_is_a_broken_suite(tmp_path, content):
 
 
 def test_every_scanned_row_lands_in_exactly_one_bucket(tmp_path):
-    """Grouped rows were in no tally at all — 20 of 138 on the real install."""
+    """Grouped rows were in no tally at all — 20 of 138 on the real install.
+
+    The fixture matters more than the assertion here. All three skills used to
+    share ``BODY``, so all three collapsed into ONE grouped row and the
+    disjointness was checked over n=1 in the single bucket that cannot collide:
+    double-counting a NON-grouped row left the whole file green. The population
+    now spans a grouped pair, an ungrouped row, and a broken-suite row, so every
+    branch of the classification is represented.
+    """
     _skill(tmp_path, "cached", BODY)
     _skill(tmp_path, "vendored", BODY)
-    _skill(tmp_path, "solo", BODY)
+    _skill(tmp_path, "solo", BODY + "\n## Different\n\nOther bytes entirely.\n")
+    broken = _skill(tmp_path, "broken", BODY + "\n## Third\n\nDifferent again.\n")
+    (pathlib.Path(broken["path"]).parent / "eval-suite.json").write_text("[]", encoding="utf-8")
+    shared._eval_suite_cache.clear()
 
     r = doctor.run_doctor(skill_dirs=[str(tmp_path)])
     buckets = (
@@ -511,7 +509,11 @@ def test_every_scanned_row_lands_in_exactly_one_bucket(tmp_path):
     assert r["skills_discovered"] - r["skills_found"] == sum(
         len(g["also_installed_at"]) for g in r["duplicate_copies"]
     )
-    assert f"{r['grouped_duplicates']} duplicate install" in doctor.format_doctor_report(r)
+    assert f"{r['grouped_duplicates']} counted once" in doctor.format_doctor_report(r)
+    # The population must actually exercise more than the grouped bucket, or the
+    # disjointness above is asserted over a single row and proves nothing.
+    assert r["grouped_duplicates"] >= 1 and r["broken_eval_suite"] >= 1
+    assert r["healthy"] + r["needs_work"] + r["no_eval_suite"] >= 1
 
 
 def test_cost_and_digest_read_the_same_files(tmp_path, monkeypatch):
@@ -634,12 +636,20 @@ def test_repair_action_fits_its_column():
     "not a JSON object" to "not a JSON objec", truncating the exact payload the
     wide cap existed to preserve.
     """
-    prefix = "Resolve the duplicate install first; eval-suite.json: "
-    too_long = {r for r in _eval_suite_reasons()
-                if len(prefix + r) > doctor.REPAIR_ACTION_WIDTH}
+    reasons = _eval_suite_reasons()
+    # Every path-free action doctor can compose, taken from the module's own
+    # constants. The previous version hard-coded ONE prefix, so the bare grouped
+    # action — 35 characters against the 35-wide branch, zero margin — sat
+    # outside the gate that exists for exactly this failure.
+    composed = (
+        [doctor.GROUPED_ACTION]
+        + [doctor.GROUPED_ACTION_PREFIX + r for r in reasons]
+        + [doctor.BROKEN_ACTION_PREFIX + r for r in reasons]
+    )
+    too_long = [a for a in composed if len(a) > doctor.REPAIR_ACTION_WIDTH]
     assert not too_long, (
         f"REPAIR_ACTION_WIDTH={doctor.REPAIR_ACTION_WIDTH} truncates: "
-        + ", ".join(f"{r!r} needs {len(prefix + r)}" for r in sorted(too_long))
+        + ", ".join(f"{a!r} needs {len(a)}" for a in sorted(too_long))
     )
 
 
@@ -910,3 +920,34 @@ def test_a_grouped_and_broken_row_keeps_the_init_warning(tmp_path, monkeypatch):
     disjoint = (report["broken_eval_suite"] + report["no_eval_suite"]
                 + report["healthy"] + report["needs_work"] + report["grouped_duplicates"])
     assert disjoint == len(report["results"]), "buckets stopped partitioning the rows"
+
+
+def test_a_degraded_digest_phase_says_so_in_the_artifact(tmp_path, monkeypatch):
+    """A silent fallback publishes the pre-fix number.
+
+    When the collapse fails the run continues and reports every copy — the
+    survivable direction. But the warning went to stderr only, so the `--json`
+    output was byte-shape identical to a clean scan that genuinely found no
+    duplicates. A case study generated from that output would publish the
+    uncollapsed count with nothing marking it.
+
+    The mutation: drop `digest_degraded` from the report and this goes red.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+
+    clean = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    assert clean["digest_degraded"] is False
+    assert clean["skills_found"] == 1
+
+    monkeypatch.setattr(
+        doctor, "_collapse_duplicate_copies",
+        lambda skills: (_ for _ in ()).throw(MemoryError("digest phase")))
+    degraded = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+
+    assert degraded["skills_found"] == 2, "the fallback must report every copy"
+    assert degraded["digest_degraded"] is True, (
+        "an uncollapsed count that calls itself clean is the pre-fix number, "
+        "published without a marker"
+    )

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -144,6 +144,74 @@ def test_a_symlinked_eval_suite_also_splits_two_installs(tmp_path):
     assert duplicates == []
 
 
+@pytest.mark.parametrize("kind", ["directory", "binary", "unreadable"])
+def test_a_broken_eval_suite_degrades_instead_of_crashing_the_run(tmp_path, kind):
+    """doctor scans other people's directories; it reports, never gates.
+
+    Routing the digest through ``load_eval_suite`` moved that call out of
+    ``_score_single_skill``'s ``except Exception`` and in front of the scoring
+    loop. The loader caught only ``JSONDecodeError``, so one malformed suite
+    anywhere under ``~/.claude`` turned the whole run into a traceback instead of
+    one row marked failed (ADR 0014, ADR 0019).
+    """
+    import os
+
+    _skill(tmp_path, "a", BODY)
+    _skill(tmp_path, "b", BODY)
+    suite = tmp_path / "b" / "eval-suite.json"
+    if kind == "directory":
+        suite.mkdir()
+    elif kind == "binary":
+        suite.write_bytes(b"\xff\xfe\x00\x01")
+    else:
+        suite.write_text("{}", encoding="utf-8")
+        os.chmod(suite, 0)
+
+    try:
+        report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    finally:
+        if kind == "unreadable":
+            os.chmod(suite, 0o644)
+
+    assert report["skills_found"] >= 1, "a broken suite must not empty the report"
+
+
+def test_cost_and_digest_read_the_same_files(tmp_path):
+    """The invariant behind the whole key, asserted directly.
+
+    Three defects in this area were a domain re-derived instead of asked for.
+    Rather than test each guard, this pins the property they exist for: whatever
+    ``estimate_token_cost`` charges for must be what ``skill_payload_digest``
+    hashes. Both now go through ``shared._payload_files``.
+
+    Add a file type to one walk and not the other — the drift is primed, since
+    ``estimate_token_cost``'s docstring says "all files in references/" while the
+    code globs ``*.md`` — and this goes red.
+    """
+    import os
+
+    import shared
+
+    a = _skill(tmp_path, "s", BODY, refs={"keep.md": "counted\n"})
+    refs = tmp_path / "s" / "references"
+    (refs / "ignored.txt").write_text("not markdown\n", encoding="utf-8")
+    (refs / "nested").mkdir()
+    (refs / "nested" / "deep.md").write_text("not walked\n", encoding="utf-8")
+    os.symlink(refs / "keep.md", refs / "linked.md")
+
+    listed = shared._payload_files(a["path"])
+
+    # The enumeration is the contract: exactly the files both sides consume.
+    assert [f.name for f in listed] == ["keep.md"]
+
+    # And it really is the one the cost path uses: removing its only entry must
+    # move the token total.
+    before = shared.estimate_token_cost(a["path"])
+    (refs / "keep.md").unlink()
+    shared.invalidate_cache(a["path"])
+    assert shared.estimate_token_cost(a["path"]) < before
+
+
 def test_mesh_receives_every_physical_copy(tmp_path, monkeypatch):
     """Dedup is for the report, not for discovery.
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -171,7 +171,10 @@ def test_a_broken_eval_suite_degrades_instead_of_crashing_the_run(tmp_path, kind
         report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
     finally:
         if kind == "unreadable":
-            os.chmod(suite, 0o644)
+            # 0o600, not 0o644: this only has to let pytest's tmp_path cleanup
+            # remove the file. Granting world read here is what CodeQL's
+            # py/overly-permissive-file flags, and it is right to.
+            os.chmod(suite, 0o600)
 
     assert report["skills_found"] >= 1, "a broken suite must not empty the report"
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -12,6 +12,7 @@ import pathlib
 
 import doctor
 import pytest
+
 import shared
 
 
@@ -808,3 +809,104 @@ def test_unserialisable_suites_do_not_share_one_identity(tmp_path, monkeypatch):
     assert digest_a != digest_b, (
         "two different unserialisable suites collapsed onto one identity"
     )
+
+
+def test_the_bounded_reader_does_not_need_a_unix_only_constant():
+    """`os.O_NONBLOCK` is Unix-only; on Windows the lookup raises AttributeError.
+
+    That is neither an OSError nor a ValueError, so the reader's own guard would
+    not catch it — and the reader is now on every scan path, so the first file
+    of any `doctor`, `mesh` or `score` run would traceback. The mutation: use
+    `os.O_NONBLOCK` directly and this goes red on a platform without it.
+    """
+    import ast
+    import os as _os
+
+    src = pathlib.Path(shared.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    bare = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Attribute) and n.attr == "O_NONBLOCK"
+        and isinstance(n.value, ast.Name) and n.value.id == "os"
+    ]
+    assert not bare, (
+        "os.O_NONBLOCK referenced directly; use getattr(os, 'O_NONBLOCK', 0) so the "
+        "module imports and runs where the constant does not exist"
+    )
+
+    # And the guard still buys what it is there for where the constant does exist.
+    if hasattr(_os, "O_NONBLOCK"):
+        assert _os.O_RDONLY | getattr(_os, "O_NONBLOCK", 0) != _os.O_RDONLY
+
+
+def test_two_differently_broken_suites_are_two_identities(tmp_path):
+    """The reason string is as coarse a key as the literal it replaced.
+
+    Round 11 fixed this for the unserialisable branch and left its sibling three
+    lines below untouched: two suites that are both `malformed` for different
+    reasons shared one digest and were reported as copies of each other, with a
+    banner telling the reader to "check every path" for two files that differ.
+
+    The mutation: drop the content-id absorb from the error branch, red again.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    (pathlib.Path(a["path"]).parent / "eval-suite.json").write_text(
+        "{{{{ broken", encoding="utf-8")
+    (pathlib.Path(b["path"]).parent / "eval-suite.json").write_text(
+        "[[[[ also broken but different bytes", encoding="utf-8")
+    shared._eval_suite_cache.clear()
+
+    assert shared.skill_payload_digest(a["path"]) != shared.skill_payload_digest(b["path"])
+
+
+def test_a_failing_digest_phase_does_not_end_the_run(tmp_path, monkeypatch):
+    """The one walk that ran outside a handler.
+
+    `skill_payload_digest` reaches `read_skill_safe`, which reads before it
+    checks size and can raise MemoryError — not an OSError, not a ValueError, so
+    its own guard does not see it. The premise `_payload_files` states, that
+    "its callers sit inside a handler", was false for this caller.
+
+    The mutation: unwrap the collapse call and this goes red with a traceback
+    instead of a report.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+    monkeypatch.setattr(
+        doctor, "_collapse_duplicate_copies",
+        lambda skills: (_ for _ in ()).throw(MemoryError("digest phase")))
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+
+    assert report["skills_found"] == 2, "fallback must report every copy, not none"
+    assert report["duplicate_copies"] == []
+
+
+def test_a_grouped_and_broken_row_keeps_the_init_warning(tmp_path, monkeypatch):
+    """The strongest warning in the report must not fall through the buckets.
+
+    `grouped` is checked before `eval_suite_error`, so a duplicated skill with a
+    broken suite incremented neither counter — and the whole "Recommended next
+    steps" block is gated on those, so it vanished, taking
+    "do NOT run /schliff:init on these, it writes over them" with it.
+
+    The mutation: drop `grouped_broken` and this goes red.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    for s in (a, b):
+        (pathlib.Path(s["path"]).parent / "eval-suite.json").write_text("[]", encoding="utf-8")
+    shared._eval_suite_cache.clear()
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    rendered = doctor.format_doctor_report(report)
+
+    assert report["grouped_broken_eval_suite"] == 1
+    assert "do NOT run /schliff:init" in rendered
+    # The disjoint buckets must still partition the rows exactly.
+    disjoint = (report["broken_eval_suite"] + report["no_eval_suite"]
+                + report["healthy"] + report["needs_work"] + report["grouped_duplicates"])
+    assert disjoint == len(report["results"]), "buckets stopped partitioning the rows"

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -12,6 +12,7 @@ import pathlib
 
 import doctor
 import pytest
+import shared
 
 
 def _skill(tmp_path, name, body, refs=None):
@@ -580,3 +581,192 @@ def test_mesh_receives_every_physical_copy(tmp_path, monkeypatch):
     assert seen["n"] == 2, "mesh must see both physical copies, not the collapsed one"
     assert report["skills_found"] == 1, "the report counts one install"
     assert len(report["duplicate_copies"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# The reporting layer around the fix. Every test below is named after the
+# mutation it has to survive; each one was red before the change it guards.
+# ---------------------------------------------------------------------------
+
+
+def _eval_suite_reasons() -> set:
+    """Every reason `load_eval_suite` can put in `eval_suite_error`, from source.
+
+    Enumerated out of the module's AST rather than hand-listed here. A hand list
+    is a snapshot: it agrees with the code on the day it is written and silently
+    stops covering the case someone adds next. The two shapes that produce a
+    reason are an assignment into `eval_suite_error` and a return out of
+    `_read_bounded_with_reason`, whose value flows straight into that dict.
+    """
+    import ast
+
+    src = pathlib.Path(shared.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    reasons = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Subscript) and \
+                        isinstance(target.value, ast.Name) and \
+                        target.value.id == "eval_suite_error":
+                    reasons.add(node.value.value)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_read_bounded_with_reason":
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Return) and isinstance(inner.value, ast.Tuple):
+                    tail = inner.value.elts[-1]
+                    if isinstance(tail, ast.Constant) and isinstance(tail.value, str) and tail.value:
+                        reasons.add(tail.value)
+
+    assert reasons, "found no reasons — the AST walk stopped matching the source"
+    return reasons
+
+
+def test_repair_action_fits_its_column():
+    """The cap must fit the longest action doctor can actually compose.
+
+    The mutation: lower REPAIR_ACTION_WIDTH back to 70 and this goes red naming
+    the reason that no longer fits. That is what 70 did in the field — it cut
+    "not a JSON object" to "not a JSON objec", truncating the exact payload the
+    wide cap existed to preserve.
+    """
+    prefix = "Resolve the duplicate install first; eval-suite.json: "
+    too_long = {r for r in _eval_suite_reasons()
+                if len(prefix + r) > doctor.REPAIR_ACTION_WIDTH}
+    assert not too_long, (
+        f"REPAIR_ACTION_WIDTH={doctor.REPAIR_ACTION_WIDTH} truncates: "
+        + ", ".join(f"{r!r} needs {len(prefix + r)}" for r in sorted(too_long))
+    )
+
+
+def test_a_broken_suite_reason_survives_into_the_rendered_row(tmp_path, monkeypatch):
+    """End to end: the reason reaches the reader whole, not cut mid-word."""
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    for s in (a, b):
+        (pathlib.Path(s["path"]).parent / "eval-suite.json").write_text("[]", encoding="utf-8")
+    shared._eval_suite_cache.clear()
+
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    rendered = doctor.format_doctor_report(report)
+
+    assert "not a JSON object" in rendered, rendered
+    assert "not a JSON objec\n" not in rendered, "reason truncated mid-word"
+
+
+def test_oversize_suite_is_not_reported_as_unreadable(tmp_path, monkeypatch):
+    """A 'repair this file' verdict must not hide that the problem is size.
+
+    The mutation: collapse the size branch of `_read_bounded_with_reason` back
+    into the generic failure and this goes red — the reader is told to fix a
+    file whose only defect is that it is too big.
+    """
+    monkeypatch.setattr(shared, "MAX_SKILL_SIZE", 200)
+    a = _skill(tmp_path, "big", BODY)
+    (pathlib.Path(a["path"]).parent / "eval-suite.json").write_text(
+        '{"cases": [' + ",".join('"x"' for _ in range(200)) + "]}", encoding="utf-8")
+    shared._eval_suite_cache.clear()
+
+    assert shared.load_eval_suite(a["path"]) is None
+    reason = shared.eval_suite_error[str(pathlib.Path(a["path"]).parent / "eval-suite.json")]
+    assert reason == "too large", f"size diagnosis lost, got {reason!r}"
+
+
+def test_the_size_check_runs_on_the_descriptor_that_gets_read(tmp_path):
+    """The TOCTOU window, made deterministic — and measured with a clock.
+
+    A plain FIFO is the WRONG fixture for this: `is_file()` already returns
+    False for one, so the previous stat-then-read shape rejected it too and a
+    FIFO test stays green against the very mutation it quotes. The defect is the
+    window between the check and the open, where the path is swapped for a FIFO
+    after it has already answered "regular file, 10 bytes". `_SwappedPath` is
+    that window with the race taken out: it answers the path-level questions the
+    old shape asked, while the object actually on disk is a FIFO.
+
+    Under the old shape `read_text` then blocks forever. A hang raises nothing,
+    so the instrument is elapsed time — an earlier test in this area passed for
+    the wrong reason by asserting on a TimeoutError the code itself caught.
+    """
+    import os as _os
+    import threading
+
+    fifo = tmp_path / "eval-suite.json"
+    _os.mkfifo(fifo)
+
+    class _SwappedPath:
+        """Answers as a small regular file; opens as the FIFO that is really there."""
+
+        def __fspath__(self):
+            return str(fifo)
+
+        def is_file(self):
+            return True
+
+        def stat(self):
+            return _os.stat_result((0o100644, 0, 0, 1, 0, 0, 10, 0, 0, 0))
+
+        def read_text(self, **kwargs):
+            with open(fifo, encoding="utf-8") as handle:
+                return handle.read()
+
+    out = {}
+
+    def _read():
+        out["result"] = shared._read_bounded_with_reason(_SwappedPath())
+
+    worker = threading.Thread(target=_read, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive(), (
+        "the read blocked: the guard trusted the path's answers instead of the "
+        "descriptor it was about to read"
+    )
+    assert out["result"] == (None, "not a regular file"), out["result"]
+
+
+def test_each_eval_suite_is_read_once_per_run(tmp_path, monkeypatch, capsys):
+    """The digest pass and the scoring pass must not both open the same file.
+
+    The mutation: drop the cache lookup from `load_eval_suite` and this goes red
+    with two warnings for one broken file — which is what the field saw.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    for s in (a, b):
+        (pathlib.Path(s["path"]).parent / "eval-suite.json").write_text("[]", encoding="utf-8")
+    shared._eval_suite_cache.clear()
+    shared.eval_suite_error.clear()
+
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+    capsys.readouterr()
+    doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    warnings = capsys.readouterr().err.count("eval-suite.json is not a JSON object")
+
+    assert warnings == 2, f"expected one warning per distinct suite, got {warnings}"
+
+
+def test_grouped_rows_get_no_skill_specific_recommendation(tmp_path, monkeypatch):
+    """A recommendation to edit a file the command did not choose on merit.
+
+    The row's own action says to resolve the duplicate install first; printing
+    "extract into references/" beside it contradicts that row and points at a
+    path picked by sort order. The mutation: drop the `also_installed_at` filter
+    and this goes red.
+    """
+    long_body = BODY + "\n".join(f"- step {i}" for i in range(400)) + "\n"
+    a = _skill(tmp_path, "cached", long_body)
+    b = _skill(tmp_path, "vendored", long_body)
+    shared._eval_suite_cache.clear()
+
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    rendered = doctor.format_doctor_report(report)
+
+    assert report["duplicate_copies"], "fixture stopped producing a duplicate group"
+    body = rendered.split("Skill-specific recommendations:")
+    assert len(body) == 1, f"grouped row still got a recommendation:\n{body[-1][:400]}"

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -144,7 +144,7 @@ def test_a_symlinked_eval_suite_also_splits_two_installs(tmp_path):
     assert duplicates == []
 
 
-@pytest.mark.parametrize("kind", ["directory", "binary", "unreadable"])
+@pytest.mark.parametrize("kind", ["directory", "binary", "unreadable", "deeply-nested"])
 def test_a_broken_eval_suite_degrades_instead_of_crashing_the_run(tmp_path, kind):
     """doctor scans other people's directories; it reports, never gates.
 
@@ -163,7 +163,17 @@ def test_a_broken_eval_suite_degrades_instead_of_crashing_the_run(tmp_path, kind
         suite.mkdir()
     elif kind == "binary":
         suite.write_bytes(b"\xff\xfe\x00\x01")
+    elif kind == "deeply-nested":
+        # json.loads recurses per level below CPython 3.14, and MAX_SKILL_SIZE
+        # leaves room for ~200k of them. RecursionError is neither OSError nor
+        # ValueError, so the first hardening did not catch it — and it does not
+        # raise on the newest interpreter, so CI's newest leg stayed green while
+        # the oldest tracebacked.
+        depth = 100_000
+        suite.write_text("[" * depth + "]" * depth, encoding="utf-8")
     else:
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("chmod 0 does not deny root; the case would pass vacuously")
         suite.write_text("{}", encoding="utf-8")
         os.chmod(suite, 0)
 
@@ -179,40 +189,105 @@ def test_a_broken_eval_suite_degrades_instead_of_crashing_the_run(tmp_path, kind
     assert report["skills_found"] >= 1, "a broken suite must not empty the report"
 
 
-def test_cost_and_digest_read_the_same_files(tmp_path):
-    """The invariant behind the whole key, asserted directly.
+def test_a_broken_suite_is_not_the_same_install_as_no_suite(tmp_path):
+    """"Absent" and "present but broken" produce different rows.
 
-    Three defects in this area were a domain re-derived instead of asked for.
-    Rather than test each guard, this pins the property they exist for: whatever
-    ``estimate_token_cost`` charges for must be what ``skill_payload_digest``
-    hashes. Both now go through ``shared._payload_files``.
+    Degrading a broken suite to ``None`` stopped the crash, but it also made the
+    two look identical to the digest — so they collapsed, and the row that told
+    the reader to fix the file vanished into ``also_installed_at``. The row now
+    carries ``eval_suite_error`` and a different ``action``, so the failure state
+    belongs to the identity.
 
-    Add a file type to one walk and not the other — the drift is primed, since
-    ``estimate_token_cost``'s docstring says "all files in references/" while the
-    code globs ``*.md`` — and this goes red.
+    Drop the ``eval_suite_error`` branch from ``skill_payload_digest`` and this
+    goes red.
     """
-    import os
+    a = _skill(tmp_path, "no-suite", BODY)
+    b = _skill(tmp_path, "broken-suite", BODY)
+    (tmp_path / "broken-suite" / "eval-suite.json").mkdir()
 
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 2, "a broken suite is not the same install as no suite"
+    assert duplicates == []
+
+
+def test_a_broken_suite_row_does_not_send_you_to_overwrite_it(tmp_path):
+    """The emitted action must be runnable.
+
+    With the suite degraded to ``None`` the row read ``has_eval_suite: False``
+    and the action became ``/schliff:init <path>`` — which writes
+    ``eval-suite.json`` over the very file that failed to load.
+    """
+    _skill(tmp_path, "broken", BODY)
+    (tmp_path / "broken" / "eval-suite.json").mkdir()
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    row = next(r for r in report["results"] if "broken" in r["path"])
+
+    assert row["eval_suite_error"], "the failure must reach the report, not just stderr"
+    assert "/schliff:init" not in (row["action"] or "")
+
+
+def test_a_grouped_row_carries_no_runnable_action(tmp_path):
+    """The counted path is sort order, not merit — and usually the plugin cache.
+
+    ``discover_skills`` sorts by path and the first wins, so
+    ``plugins/cache/…`` beats ``plugins/marketplaces/…`` and ``~/.claude/skills/…``
+    every time. Emitting ``/schliff:auto <that path>`` writes ``.schliff/``
+    history into a directory the next plugin update deletes. Preferring another
+    member would need a path wordlist — the enumeration this key avoids — so the
+    row says what to do instead.
+    """
+    _skill(tmp_path, "cache-copy", BODY)
+    _skill(tmp_path, "user-copy", BODY)
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    grouped = [r for r in report["results"] if "also_installed_at" in r]
+
+    assert len(grouped) == 1
+    assert "/schliff:" not in (grouped[0]["action"] or ""), (
+        "a grouped row must not hand out a command against one arbitrary copy"
+    )
+
+
+def test_cost_and_digest_read_the_same_files(tmp_path, monkeypatch):
+    """The invariant behind the whole key, gated on BOTH sides.
+
+    Four defects in this area were a domain re-derived instead of asked for, so
+    this pins the property they exist for: whatever ``estimate_token_cost``
+    charges for is what ``skill_payload_digest`` hashes.
+
+    The first version asserted only what ``_payload_files`` returns and that the
+    cost path uses it. Verified false negative: giving the digest its own
+    ``glob("*")`` walk left all tests green, so it gated exactly one of the two
+    sides it names. Both are now observed through the same monkeypatch.
+    """
     import shared
 
     a = _skill(tmp_path, "s", BODY, refs={"keep.md": "counted\n"})
     refs = tmp_path / "s" / "references"
-    (refs / "ignored.txt").write_text("not markdown\n", encoding="utf-8")
-    (refs / "nested").mkdir()
-    (refs / "nested" / "deep.md").write_text("not walked\n", encoding="utf-8")
-    os.symlink(refs / "keep.md", refs / "linked.md")
+    (refs / "extra.md").write_text("also counted\n", encoding="utf-8")
 
-    listed = shared._payload_files(a["path"])
+    real = shared._payload_files
+    calls = []
 
-    # The enumeration is the contract: exactly the files both sides consume.
-    assert [f.name for f in listed] == ["keep.md"]
+    def _spy(path):
+        calls.append(path)
+        return real(path)
 
-    # And it really is the one the cost path uses: removing its only entry must
-    # move the token total.
-    before = shared.estimate_token_cost(a["path"])
-    (refs / "keep.md").unlink()
+    monkeypatch.setattr(shared, "_payload_files", _spy)
+
+    cost_before = shared.estimate_token_cost(a["path"])
+    digest_before = shared.skill_payload_digest(a["path"])
+    assert len(calls) == 2, "both consumers must go through the shared enumeration"
+
+    # Narrowing the shared list must move BOTH. A consumer walking the directory
+    # itself would keep its old value and this goes red.
+    monkeypatch.setattr(shared, "_payload_files", lambda p: real(p)[:1])
     shared.invalidate_cache(a["path"])
-    assert shared.estimate_token_cost(a["path"]) < before
+
+    assert shared.estimate_token_cost(a["path"]) < cost_before, "cost side ignored the enumeration"
+    assert shared.skill_payload_digest(a["path"]) != digest_before, "digest side ignored the enumeration"
 
 
 def test_mesh_receives_every_physical_copy(tmp_path, monkeypatch):

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -116,6 +116,34 @@ def test_eval_suite_presence_splits_two_otherwise_identical_installs(tmp_path):
     assert duplicates == []
 
 
+def test_a_symlinked_eval_suite_also_splits_two_installs(tmp_path):
+    """The digest must follow the loader, not a copied guard.
+
+    ``load_eval_suite`` follows a symlink; the first version of the digest
+    copied ``estimate_token_cost``'s symlink skip and therefore did not. A
+    stow/chezmoi layout was scored 7-of-7 and hashed as if it had no suite, so
+    the two copies collapsed and sort order picked the grade again.
+
+    Reinstate a ``not suite.is_symlink()`` guard in ``skill_payload_digest`` and
+    this goes red.
+    """
+    import os
+
+    real = tmp_path / "shared-suite.json"
+    real.write_text(
+        '{"assertions": [{"name": "x", "type": "contains", "value": "Usage"}]}',
+        encoding="utf-8",
+    )
+    a = _skill(tmp_path, "no-suite", BODY)
+    b = _skill(tmp_path, "symlinked", BODY)
+    os.symlink(real, tmp_path / "symlinked" / "eval-suite.json")
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 2, "a symlinked suite still makes this a different install"
+    assert duplicates == []
+
+
 def test_mesh_receives_every_physical_copy(tmp_path, monkeypatch):
     """Dedup is for the report, not for discovery.
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -269,35 +269,48 @@ def test_two_copies_with_the_same_broken_suite_still_collapse(tmp_path):
     assert len(duplicates) == 1
 
 
-def test_a_symlinked_reference_is_read_like_any_other(tmp_path):
-    """stow, chezmoi and worktrees symlink reference files.
+def test_a_symlinked_reference_is_rejected_not_followed(tmp_path):
+    """A shipped security fix, kept deliberately.
 
-    Skipping them was inherited from ``estimate_token_cost`` while
-    ``read_skill_safe`` and ``load_eval_suite`` both follow links. Measured, a
-    stow-managed copy charged 12 tokens against 1,182 for its byte-identical
-    plain twin, and the two did not collapse.
+    doctor walks other people's directories, so a plugin controls what sits in
+    its ``references/``. Following a link there turns a word count into a
+    filesystem oracle, and reading before the size check turns a link to a huge
+    file into an OOM — which is why ``estimate_token_cost`` rejected them and why
+    ``skill_mesh`` confines resolved paths to the scan root.
+
+    I reversed this once, to make a stow layout collapse with its plain twin, on
+    the strength of a fixture I wrote myself. The field says 0 symlinks across
+    the 41 real skills that have a ``references/``. Restore ``resolve()``-and-
+    follow here and this goes red.
     """
     import os
 
-    real = tmp_path / "guide.md"
-    real.write_text("word " * 900, encoding="utf-8")
-    plain = _skill(tmp_path, "plain", BODY, refs={"guide.md": "word " * 900})
-    stow = _skill(tmp_path, "stow", BODY, refs={"placeholder.md": ""})
-    (tmp_path / "stow" / "references" / "placeholder.md").unlink()
-    os.symlink(real, tmp_path / "stow" / "references" / "guide.md")
+    import shared
+
+    outside = tmp_path / "outside.md"
+    outside.write_text("word " * 900, encoding="utf-8")
+    skill = _skill(tmp_path, "s", BODY, refs={"placeholder.md": ""})
+    (tmp_path / "s" / "references" / "placeholder.md").unlink()
+    os.symlink(outside, tmp_path / "s" / "references" / "linked.md")
+
+    assert shared._payload_files(skill["path"]) == [], "a symlinked ref must not be read"
+    # ...and the file outside the skill directory contributes nothing.
+    assert shared.estimate_token_cost(skill["path"]) < 100
+
+
+def test_a_symlinked_references_directory_is_rejected(tmp_path):
+    """Same fix, the directory half of it."""
+    import os
 
     import shared
 
-    assert shared.estimate_token_cost(stow["path"]) == shared.estimate_token_cost(plain["path"])
-    unique, duplicates = doctor._collapse_duplicate_copies([plain, stow])
-    assert len(unique) == 1, "byte-identical payloads, one symlinked, are one install"
+    real_refs = tmp_path / "elsewhere"
+    real_refs.mkdir()
+    (real_refs / "guide.md").write_text("word " * 900, encoding="utf-8")
+    skill = _skill(tmp_path, "s", BODY)
+    os.symlink(real_refs, tmp_path / "s" / "references")
 
-    # A link to a directory, and a dangling one, are still dropped.
-    broken = _skill(tmp_path, "broken", BODY, refs={"placeholder.md": ""})
-    (tmp_path / "broken" / "references" / "placeholder.md").unlink()
-    os.symlink(tmp_path / "plain", tmp_path / "broken" / "references" / "dir.md")
-    os.symlink(tmp_path / "nowhere.md", tmp_path / "broken" / "references" / "dead.md")
-    assert shared._payload_files(broken["path"]) == []
+    assert shared._payload_files(skill["path"]) == []
 
 
 def test_a_repaired_suite_clears_its_recorded_failure(tmp_path):

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -401,6 +401,28 @@ def test_a_grouped_row_is_not_counted_as_missing_an_eval_suite(tmp_path):
     assert report["no_eval_suite"] == 0, "a grouped row must not join the init recommendation"
 
 
+def test_a_fifo_named_skill_md_does_not_hang_discovery(tmp_path):
+    """The first file doctor opens decides whether the scan can be hung at all.
+
+    ``discover_skills`` read SKILL.md directly, so a FIFO there blocked before
+    ``_read_bounded`` was ever reached — the guard was downstream of the hazard.
+    Measured: blocked past eight seconds, nothing discovered, nothing reported.
+    It uses the shared reader now.
+
+    Restore a bare ``read_text`` in ``discover_skills`` and this hangs rather
+    than failing, which is the defect reproduced.
+    """
+    import os
+
+    import skill_mesh
+
+    d = tmp_path / "skills" / "s"
+    d.mkdir(parents=True)
+    os.mkfifo(d / "SKILL.md")
+
+    assert skill_mesh.discover_skills([str(tmp_path)]) == []
+
+
 def test_a_fifo_where_a_file_is_expected_does_not_hang(tmp_path):
     """A plugin can put a FIFO where a skill file goes; doctor must not block.
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -250,6 +250,95 @@ def test_a_grouped_row_carries_no_runnable_action(tmp_path):
     )
 
 
+def test_two_copies_with_the_same_broken_suite_still_collapse(tmp_path):
+    """The failure reason must be path-free.
+
+    Folding the formatted exception into the digest put an absolute path in the
+    identity, so two genuine copies of one broken skill got different digests and
+    were billed twice — the exact double-count this key removes. Only a reason
+    reaches the identity; the detail goes to stderr.
+    """
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    for name in ("cached", "vendored"):
+        (tmp_path / name / "eval-suite.json").mkdir()
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 1, "same skill, same breakage — one install"
+    assert len(duplicates) == 1
+
+
+def test_a_symlinked_reference_is_read_like_any_other(tmp_path):
+    """stow, chezmoi and worktrees symlink reference files.
+
+    Skipping them was inherited from ``estimate_token_cost`` while
+    ``read_skill_safe`` and ``load_eval_suite`` both follow links. Measured, a
+    stow-managed copy charged 12 tokens against 1,182 for its byte-identical
+    plain twin, and the two did not collapse.
+    """
+    import os
+
+    real = tmp_path / "guide.md"
+    real.write_text("word " * 900, encoding="utf-8")
+    plain = _skill(tmp_path, "plain", BODY, refs={"guide.md": "word " * 900})
+    stow = _skill(tmp_path, "stow", BODY, refs={"placeholder.md": ""})
+    (tmp_path / "stow" / "references" / "placeholder.md").unlink()
+    os.symlink(real, tmp_path / "stow" / "references" / "guide.md")
+
+    import shared
+
+    assert shared.estimate_token_cost(stow["path"]) == shared.estimate_token_cost(plain["path"])
+    unique, duplicates = doctor._collapse_duplicate_copies([plain, stow])
+    assert len(unique) == 1, "byte-identical payloads, one symlinked, are one install"
+
+    # A link to a directory, and a dangling one, are still dropped.
+    broken = _skill(tmp_path, "broken", BODY, refs={"placeholder.md": ""})
+    (tmp_path / "broken" / "references" / "placeholder.md").unlink()
+    os.symlink(tmp_path / "plain", tmp_path / "broken" / "references" / "dir.md")
+    os.symlink(tmp_path / "nowhere.md", tmp_path / "broken" / "references" / "dead.md")
+    assert shared._payload_files(broken["path"]) == []
+
+
+def test_a_repaired_suite_clears_its_recorded_failure(tmp_path):
+    """The registry is module state; a stale entry outlives the file.
+
+    Only the "absent" branch cleared it, so a suite that failed once and was
+    then repaired produced a self-contradictory row: 7-of-7 dimensions and an
+    action saying to fix the file.
+    """
+    import shared
+
+    skill = _skill(tmp_path, "s", BODY)
+    suite = tmp_path / "s" / "eval-suite.json"
+
+    suite.write_text("{ broken", encoding="utf-8")
+    assert shared.load_eval_suite(skill["path"]) is None
+    assert shared.eval_suite_error.get(str(suite))
+
+    suite.write_text('{"assertions": []}', encoding="utf-8")
+    assert shared.load_eval_suite(skill["path"]) is not None
+    assert shared.eval_suite_error.get(str(suite)) is None, "a repaired suite must clear its entry"
+
+
+def test_an_unreadable_suite_is_not_counted_as_missing(tmp_path):
+    """The aggregate must not contradict the row.
+
+    Counting it as missing put it in "Run /schliff:init on N skills missing eval
+    suites" — the command that writes over the file the row three lines above
+    says to repair.
+    """
+    _skill(tmp_path, "broken", BODY)
+    (tmp_path / "broken" / "eval-suite.json").mkdir()
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+    rendered = doctor.format_doctor_report(report)
+
+    assert report["no_eval_suite"] == 0
+    assert report["broken_eval_suite"] == 1
+    assert "Run /schliff:init on" not in rendered
+
+
 def test_cost_and_digest_read_the_same_files(tmp_path, monkeypatch):
     """The invariant behind the whole key, gated on BOTH sides.
 

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -1,0 +1,111 @@
+"""doctor counts one install per payload, and names the copies it did not count.
+
+A plugin that is both cached and vendored sits on disk twice. Measured on a real
+``~/.claude``: 159 SKILL.md, 138 distinct payloads, 57,331 tokens of double
+counting in the headline figure.
+
+Each test here is named after the mutation it has to survive. The second one is
+the reason this file exists: it is red against the cheap key (SKILL.md alone),
+which is what a future reader will reach for.
+"""
+import doctor
+import pytest
+
+
+def _skill(tmp_path, name, body, refs=None):
+    d = tmp_path / name
+    (d / "references").mkdir(parents=True) if refs else d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(body, encoding="utf-8")
+    for ref_name, ref_body in (refs or {}).items():
+        (d / "references" / ref_name).write_text(ref_body, encoding="utf-8")
+    return {"name": name, "path": str(d / "SKILL.md")}
+
+
+BODY = "---\nname: thing\ndescription: does a thing\n---\n\n## Usage\n\nRun it.\n"
+
+
+def test_identical_copies_are_counted_once(tmp_path):
+    """The defect itself: same bytes in two places, billed twice."""
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 1
+    assert len(duplicates) == 1
+    # Both paths are named — nothing is deleted, the reader decides (ADR 0019).
+    assert duplicates[0]["counted"] == a["path"]
+    assert duplicates[0]["also_installed_at"] == [b["path"]]
+
+
+def test_same_skill_md_but_different_references_are_two_installs(tmp_path):
+    """THE MUTATION GATE. Red against ``skill["content_hash"]``.
+
+    The token estimate charges for SKILL.md *plus* ``references/*.md``. A key
+    that hashes only SKILL.md has a smaller domain than the quantity it indexes,
+    so it collapses installs that cost different amounts — measured at 9,013
+    against 9,591 tokens on two real skills.
+
+    Replace ``skill_payload_digest`` with a bare SKILL.md hash and this test
+    fails. Nothing else in the suite does.
+    """
+    a = _skill(tmp_path, "slim", BODY, refs={"a.md": "short\n"})
+    b = _skill(tmp_path, "fat", BODY, refs={"a.md": "much longer " * 200})
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 2, "different payloads must not collapse"
+    assert duplicates == []
+
+
+def test_an_unreadable_skill_never_collapses_onto_another(tmp_path):
+    """An empty digest is not an identity.
+
+    Two skills that both fail to hash must stay two, or a permissions error
+    silently deletes a skill from the count.
+    """
+    a = {"name": "gone-a", "path": str(tmp_path / "nope-a" / "SKILL.md")}
+    b = {"name": "gone-b", "path": str(tmp_path / "nope-b" / "SKILL.md")}
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 2
+    assert duplicates == []
+
+
+def test_the_survivor_does_not_depend_on_iteration_order(tmp_path):
+    """The published number must not move when discovery order does.
+
+    The bare-SKILL.md key failed exactly here: keep-first gave 429,006 tokens and
+    keep-last 429,584 over a real installation, and keep-first discarded the live
+    schliff skill in favour of a June backup — the cure authorising the defect.
+    """
+    a = _skill(tmp_path, "first", BODY, refs={"r.md": "same\n"})
+    b = _skill(tmp_path, "second", BODY, refs={"r.md": "same\n"})
+
+    fwd, fwd_dupes = doctor._collapse_duplicate_copies([a, b])
+    rev, rev_dupes = doctor._collapse_duplicate_copies([b, a])
+
+    assert len(fwd) == len(rev) == 1
+    assert len(fwd_dupes) == len(rev_dupes) == 1
+    # The survivor differs by direction — that is fine and unavoidable — but the
+    # GROUP is the same, so the count and the token total cannot move.
+    assert {fwd_dupes[0]["counted"], *fwd_dupes[0]["also_installed_at"]} == \
+           {rev_dupes[0]["counted"], *rev_dupes[0]["also_installed_at"]}
+
+
+def test_mesh_still_sees_every_physical_copy(tmp_path):
+    """Dedup is for the report, not for discovery.
+
+    ``run_mesh_analysis`` is deliberately handed the undeduplicated list: two
+    installs of one skill under the same name is exactly the collision mesh
+    exists to flag. Collapsing first would hide it.
+    """
+    import inspect
+    source = inspect.getsource(doctor.run_doctor)
+    assert "skills=skills" in source, (
+        "mesh must receive the full discovery list, not the deduplicated one"
+    )
+    assert "for skill in unique_skills:" in source, (
+        "scoring must run over the deduplicated list"
+    )

--- a/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
+++ b/skills/schliff/tests/unit/test_doctor_collapses_duplicate_copies.py
@@ -1,12 +1,12 @@
 """doctor counts one install per payload, and names the copies it did not count.
 
-A plugin that is both cached and vendored sits on disk twice. Measured on a real
-``~/.claude``: 159 SKILL.md, 138 distinct payloads, 57,331 tokens of double
-counting in the headline figure.
+A plugin that is both cached and vendored sits on disk twice, so it was billed
+twice. The measurements and the rejected alternatives live in docs/specs/2026-08-13-doctor-counts-vendored-skills.md,
+"Amendment 2026-08-26".
 
-Each test here is named after the mutation it has to survive. The second one is
-the reason this file exists: it is red against the cheap key (SKILL.md alone),
-which is what a future reader will reach for.
+Each test here is named after the mutation it has to survive. Two of them exist
+because the first version of this file did not discriminate: they were green
+against the very mutations their docstrings quoted.
 """
 import doctor
 import pytest
@@ -41,13 +41,11 @@ def test_identical_copies_are_counted_once(tmp_path):
 def test_same_skill_md_but_different_references_are_two_installs(tmp_path):
     """THE MUTATION GATE. Red against ``skill["content_hash"]``.
 
-    The token estimate charges for SKILL.md *plus* ``references/*.md``. A key
-    that hashes only SKILL.md has a smaller domain than the quantity it indexes,
-    so it collapses installs that cost different amounts — measured at 9,013
-    against 9,591 tokens on two real skills.
+    The token estimate charges for SKILL.md *plus* ``references/*.md``, so a key
+    hashing only SKILL.md collapses installs that cost different amounts. The
+    measured pair is in the spec amendment named at the top of this file.
 
-    Replace ``skill_payload_digest`` with a bare SKILL.md hash and this test
-    fails. Nothing else in the suite does.
+    Replace ``skill_payload_digest`` with a bare SKILL.md hash and this goes red.
     """
     a = _skill(tmp_path, "slim", BODY, refs={"a.md": "short\n"})
     b = _skill(tmp_path, "fat", BODY, refs={"a.md": "much longer " * 200})
@@ -73,39 +71,76 @@ def test_an_unreadable_skill_never_collapses_onto_another(tmp_path):
     assert duplicates == []
 
 
-def test_the_survivor_does_not_depend_on_iteration_order(tmp_path):
+def test_the_group_does_not_depend_on_iteration_order(tmp_path):
     """The published number must not move when discovery order does.
 
-    The bare-SKILL.md key failed exactly here: keep-first gave 429,006 tokens and
-    keep-last 429,584 over a real installation, and keep-first discarded the live
-    schliff skill in favour of a June backup — the cure authorising the defect.
+    Fixture note: the two copies get DIFFERENT references on purpose. With
+    identical ones the bare-SKILL.md key groups them too, and this test passes
+    against the very mutation it exists to catch — which is what the first
+    version of it did.
     """
     a = _skill(tmp_path, "first", BODY, refs={"r.md": "same\n"})
     b = _skill(tmp_path, "second", BODY, refs={"r.md": "same\n"})
+    c = _skill(tmp_path, "third", BODY, refs={"r.md": "different\n"})
 
-    fwd, fwd_dupes = doctor._collapse_duplicate_copies([a, b])
-    rev, rev_dupes = doctor._collapse_duplicate_copies([b, a])
+    fwd, fwd_dupes = doctor._collapse_duplicate_copies([a, b, c])
+    rev, rev_dupes = doctor._collapse_duplicate_copies([c, b, a])
 
-    assert len(fwd) == len(rev) == 1
+    # Two distinct payloads either way, and c never joins a group.
+    assert len(fwd) == len(rev) == 2
     assert len(fwd_dupes) == len(rev_dupes) == 1
-    # The survivor differs by direction — that is fine and unavoidable — but the
-    # GROUP is the same, so the count and the token total cannot move.
     assert {fwd_dupes[0]["counted"], *fwd_dupes[0]["also_installed_at"]} == \
-           {rev_dupes[0]["counted"], *rev_dupes[0]["also_installed_at"]}
+           {rev_dupes[0]["counted"], *rev_dupes[0]["also_installed_at"]} == \
+           {a["path"], b["path"]}
 
 
-def test_mesh_still_sees_every_physical_copy(tmp_path):
+def test_eval_suite_presence_splits_two_otherwise_identical_installs(tmp_path):
+    """MUTATION GATE for the score, not the cost.
+
+    ``eval-suite.json`` moves a row from 4-of-7 dimensions to 7-of-7, so ignoring
+    it lets two installs collapse and path sort order decide which grade a reader
+    is shown. The measured pair is in the spec amendment named at the top.
+
+    Drop the eval-suite branch from ``skill_payload_digest`` and this goes red.
+    """
+    a = _skill(tmp_path, "no-suite", BODY)
+    b = _skill(tmp_path, "with-suite", BODY)
+    (tmp_path / "with-suite" / "eval-suite.json").write_text(
+        '{"assertions": [{"name": "x", "type": "contains", "value": "Usage"}]}',
+        encoding="utf-8",
+    )
+
+    unique, duplicates = doctor._collapse_duplicate_copies([a, b])
+
+    assert len(unique) == 2, "a skill with an eval suite is not the same install"
+    assert duplicates == []
+
+
+def test_mesh_receives_every_physical_copy(tmp_path, monkeypatch):
     """Dedup is for the report, not for discovery.
 
-    ``run_mesh_analysis`` is deliberately handed the undeduplicated list: two
-    installs of one skill under the same name is exactly the collision mesh
-    exists to flag. Collapsing first would hide it.
+    Two installs of one skill under the same name is exactly the collision mesh
+    exists to flag, so it must see both. The first version of this test asserted
+    on ``inspect.getsource`` strings and was a verified false negative: handing
+    mesh the deduplicated list left it green.
     """
-    import inspect
-    source = inspect.getsource(doctor.run_doctor)
-    assert "skills=skills" in source, (
-        "mesh must receive the full discovery list, not the deduplicated one"
-    )
-    assert "for skill in unique_skills:" in source, (
-        "scoring must run over the deduplicated list"
-    )
+    import skill_mesh
+
+    a = _skill(tmp_path, "cached", BODY)
+    b = _skill(tmp_path, "vendored", BODY)
+    seen = {}
+
+    monkeypatch.setattr(skill_mesh, "discover_skills", lambda dirs: [a, b])
+    monkeypatch.setattr(doctor.skill_mesh, "discover_skills", lambda dirs: [a, b])
+
+    def _capture(dirs, incremental=True, skills=None):
+        seen["n"] = len(skills or [])
+        return {"issues": [], "health": {"score": 100}}
+
+    monkeypatch.setattr(doctor.skill_mesh, "run_mesh_analysis", _capture)
+
+    report = doctor.run_doctor(skill_dirs=[str(tmp_path)])
+
+    assert seen["n"] == 2, "mesh must see both physical copies, not the collapsed one"
+    assert report["skills_found"] == 1, "the report counts one install"
+    assert len(report["duplicate_copies"]) == 1


### PR DESCRIPTION
`schliff doctor ~/.claude` reported **159 skills, ~495,928 tokens**. Measured: **138 distinct
payloads**. A plugin that is both cached and vendored sits on disk twice, so the count, the grade
distribution and the headline context cost were all inflated.

```
before: 159 skills, 495,928 tokens
after:  159 discovered / 138 counted, 438,597 tokens, 20 duplicate groups named in the report
```

## The path exclusion the plan called for is measured wrong and is not built

Adding `cache` to `EXCLUDED_DIRS` takes **159 → 50**, because the cache *is* where plugins
install — it would delete the majority of real skills from the measurement rather than the
duplicates. That frozenset has already needed three extensions (`site-packages`, `.cache`,
`.vercel`); a digest carries no vendor names and does not grow with the next package manager.

## The key covers everything a row is derived from

`skill_payload_digest` hashes SKILL.md, `references/*.md` and `eval-suite.json` — what a row's
**score** and **cost** come from. Neither half is re-derived: the reference walk and the cost walk
share one enumeration (`shared._payload_files`), and the suite is fetched through
`load_eval_suite` itself, so the domains cannot drift apart.

That took four corrections, each the same shape — a domain re-derived instead of asked for. All
four, with their measurements, live once in
`docs/specs/2026-08-13-doctor-counts-vendored-skills.md`, "Amendment 2026-08-26"; the code points
there rather than restating it. The short version:

| got wrong | consequence |
| --- | --- |
| SKILL.md only | collapses installs that cost different amounts; total became order-dependent, and keep-first kept a June backup over the live skill |
| suite outside the key | `eval-suite.json` moves a row from 4-of-7 to 7-of-7 dimensions; two copies scored 38.3 [E] and 93.0 [A], and sort order picked which the reader saw |
| suite guard copied | `load_eval_suite` follows a symlink, the copied guard did not — a stow/chezmoi layout was scored with a suite and hashed without one |
| loader's error contract | it caught only `JSONDecodeError`; called before the scoring loop, one malformed suite anywhere turned the run into a traceback instead of one failed row |

**Known limit, stated in the spec:** the `Issues` column can still differ within a group —
`structure`'s dangling-reference lint resolves declared paths against plugin/git ancestors,
outside this domain. Measured over the 20 real groups: 0 divergences, and that lint does not
score.

## Placement, and what deliberately does not change

Dedup happens in `run_doctor`, between discovery and the scoring loop. **Mesh still receives the
full list**: two installs of one skill under the same name is exactly the collision mesh exists to
flag. Verified unchanged at 32 `duplicate_name` findings.

Nothing is deleted. Every path in a group is printed and the reader decides (ADR 0019). Which copy
is counted is arbitrary and the report says so — the surviving path is not interchangeable, since
`/schliff:auto` writes `.schliff/` history beside the file and a plugin cache is overwritten on
update. Rows that stand for a group carry `also_installed_at`; `--json` also gains
`skills_discovered`, the physical file count.

```
20 skills are installed more than once (21 extra copies, counted once):
  Which copy is counted is arbitrary — pick the one you control before acting on its path.
  build-review-interface
    counted: ~/.claude/plugins/cache/hamelsmu-evals-skills/…/SKILL.md
    also at: ~/.claude/plugins/marketplaces/hamelsmu-evals-skills/…/SKILL.md
```

## Verification

```
pytest skills/schliff/tests -q          ->  2032 passed (excluding the timing family, which
                                            fails on main too under load)
ruff / markdownlint                     ->  clean
doctor --skill-dirs ~/.claude --json    ->  159 discovered, 138 counted, 438,597 tokens, 20 groups
run_mesh_analysis over the full list    ->  32 duplicate_name (unchanged)
main worktree, same command             ->  159 / 495,928 (the baseline above)
```

Every test is named after the mutation it must survive, and each was verified red against it:
bare SKILL.md key → **5**; drop the suite from the digest → **2**; reinstate the suite's symlink
guard → **1**; remove the loader's `OSError` handler → **3**; mesh given the collapsed list → **1**;
either drift in `_payload_files` → **1**.

## Pre-existing, not touched here

`doctor --json` reports `mesh_issue_count: 0` under `incremental=True` while a fresh analysis
finds 49 (32 `duplicate_name`, 17 `scope_collision`). Identical on `main`, so not a regression of
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcYykJP28nNEShL1QPwa1k
