### PR TITLE
fix(benchmarks): fail the anti-gaming gate on an incomplete corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   travels in the output rather than short-circuiting it, so a consumer can still see why the run
   failed.
 
-  `caught` is lenient — a dimension that was never scored reads as caught, because the `-1`
-  no-eval-suite sentinel is below the penalty threshold — so gating on it can produce a false green
-  but never a false red. That is the safe direction, and it is why this does not wait for the
-  separate fix that makes `caught` honest.
+  A shrinking corpus fails too: `incomplete` only sees a declaration whose file went missing, so
+  retiring a vector on both sides at once — the ordinary edit — left the run reporting a smaller
+  headline and exiting 0. `run.py` now carries a floor on the declared vector count, which is where
+  it has to be, because the contributor guidance says to score a new vector with `run.py --json`
+  before committing.
+
+  What gating on `caught` can and cannot do, stated exactly: it cannot mask a detector that stops
+  firing, but it **can** fire on a scorer improvement. `bloated-preamble.md` is caught purely by the
+  score threshold — its declared filler mechanism emits no issue at all — so raising `efficiency`
+  above 80 reddens every required context while separation is untouched. That red is not false, a
+  declared detection really did stop penalising, but it fires on an improvement and is a real cost.
+  An earlier version of this entry claimed it could never happen; it can, and the vector that
+  carries it is named in the follow-up issue.
 
 - **A broken `eval-suite.json` no longer ends the run.** `schliff score`, `bench`, `eval`, `auto`
   and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   it has to be, because the contributor guidance says to score a new vector with `run.py --json`
   before committing.
 
-  The floor counts distinct vector files, not declarations: counting declarations let a duplicated
-  entry stand in for a removed vector, and a copy-pasted entry with an unchanged `file` key would
-  have published one more detection than there are vectors.
+  A duplicated declaration fails on its own, independently of the floor. Counting declarations let a
+  duplicated entry stand in for a removed vector; tying the check to the floor then still missed the
+  additive case, where a copy-pasted entry with an unchanged `file` key published one more detection
+  than there are vectors at exit 0. The report also says when the headline is inflated, because that
+  number is what a reader quotes.
 
   What gating on `caught` can and cannot do, stated exactly: it cannot mask a detector that stops
   firing **on six of the seven vectors** — not on `keyword-stuffing.md`, whose target dimension is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   it has to be, because the contributor guidance says to score a new vector with `run.py --json`
   before committing.
 
+  The floor counts distinct vector files, not declarations: counting declarations let a duplicated
+  entry stand in for a removed vector, and a copy-pasted entry with an unchanged `file` key would
+  have published one more detection than there are vectors.
+
   What gating on `caught` can and cannot do, stated exactly: it cannot mask a detector that stops
-  firing, but it **can** fire on a scorer improvement. `bloated-preamble.md` is caught purely by the
+  firing **on six of the seven vectors** — not on `keyword-stuffing.md`, whose target dimension is
+  eval-suite-gated and returns the no-suite sentinel, so it reads as caught no matter what the file
+  contains (verified by replacing it with the clean control). And it **can** fire on a scorer
+  improvement. `bloated-preamble.md` is caught purely by the
   score threshold — its declared filler mechanism emits no issue at all — so raising `efficiency`
   above 80 reddens every required context while separation is untouched. That red is not false, a
   declared detection really did stop penalising, but it fires on an improvement and is a real cost.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **The anti-gaming gate reports an incomplete corpus instead of passing quietly.** It could not
+  distinguish "no vector gamed" from "no vector measured": renaming a single skill file under
+  `benchmarks/anti-gaming/skills/` left `run.py` at exit 0 while its headline dropped from 7/7 to
+  6/7, so the vector stopped being tested and the CI job — which asserts only `returncode == 0` —
+  stayed green. Since the gate is enforced in five of the six required status checks, that made
+  every earlier green run unprovable in retrospect. `main()` now lists the unmeasured files, says
+  the separation results are unproven until they are restored, and exits 1; `--json` gains
+  `incomplete`. The corpus state travels in the output rather than short-circuiting it, so a
+  consumer can still see why the run failed.
+
 - **A broken `eval-suite.json` no longer ends the run.** `schliff score`, `bench`, `eval`, `auto`
   and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply
   enough to exhaust the parser's recursion (the last only below Python 3.14, so CI's newest leg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `benchmarks/anti-gaming/skills/` left `run.py` at exit 0 while its headline dropped from 7/7 to
   6/7, so the vector stopped being tested and the CI job — which asserts only `returncode == 0` —
   stayed green. Since the gate is enforced in five of the six required status checks, that made
-  every earlier green run unprovable in retrospect. `main()` now lists the unmeasured files, says
-  the separation results are unproven until they are restored, and exits 1; `--json` gains
-  `incomplete`. The corpus state travels in the output rather than short-circuiting it, so a
-  consumer can still see why the run failed.
+  every earlier green run unprovable in retrospect. The same headline drop is reachable a second
+  way, and the likelier one: a vector that is still measured but is **no longer caught**, i.e. a
+  detector regression. `main()` now names both — the files that produced no measurement, and the
+  vectors whose detector stopped firing — states that the separation results are unproven until
+  they are restored, and exits 1; `--json` gains `incomplete` and `uncaught`. The corpus state
+  travels in the output rather than short-circuiting it, so a consumer can still see why the run
+  failed.
+
+  `caught` is lenient — a dimension that was never scored reads as caught, because the `-1`
+  no-eval-suite sentinel is below the penalty threshold — so gating on it can produce a false green
+  but never a false red. That is the safe direction, and it is why this does not wait for the
+  separate fix that makes `caught` honest.
 
 - **A broken `eval-suite.json` no longer ends the run.** `schliff score`, `bench`, `eval`, `auto`
   and `doctor` all raised on a suite that is a directory, unreadable, not UTF-8, or nested deeply

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -208,6 +208,21 @@ def main():
     clean_path = str(_SKILLS_DIR / CLEAN_CONTROL)
     clean_composite = score_skill(clean_path)["composite"] if Path(clean_path).exists() else None
 
+    # A gate that cannot tell "nothing gamed" from "nothing measured" makes every
+    # green run before it unprovable, retroactively. Measured on f202bc1: renaming
+    # a single skill file leaves this at exit 0 while the headline quietly drops
+    # from 7/7 to 6/7 — so the strongest vector stops being tested, and the CI
+    # wrapper, which asserts only `returncode == 0`, never notices. A rename is
+    # the most ordinary edit there is.
+    #
+    # The corpus state travels in the output rather than short-circuiting it, so
+    # `--json` stays parseable and a consumer can see WHY the run failed. Same
+    # reason `doctor` reports `digest_degraded` instead of warning on stderr: a
+    # degraded result that looks identical to a clean one is the failure.
+    incomplete = [r["file"] for r in results if "error" in r]
+    if clean_composite is None:
+        incomplete.append(CLEAN_CONTROL)
+
     violations = []
     if clean_composite is not None:
         for r in results:
@@ -217,16 +232,22 @@ def main():
     if use_json:
         output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
         print(json.dumps({"clean_composite": clean_composite,
+                          "incomplete": incomplete,
                           "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
         print(f"\nClean control composite: {clean_composite}")
+        if incomplete:
+            print("CORPUS INCOMPLETE — these vectors were not measured at all:")
+            for f in incomplete:
+                print(f"  {f}")
+            print("Every separation result above is unproven until they are restored.")
         if violations:
             print("SEPARATION FAILURES (gamed >= clean):")
             for f, c in violations:
                 print(f"  {f}: {c}")
 
-    sys.exit(1 if violations else 0)
+    sys.exit(1 if violations or incomplete else 0)
 
 
 if __name__ == "__main__":

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -87,6 +87,18 @@ BENCHMARKS = [
 
 CLEAN_CONTROL = "clean-reference.md"
 
+# Floor on the corpus. `incomplete` below only sees a declaration whose file went
+# missing; delete the entry AND the file together — the ordinary "retire a vector"
+# edit — and the corpus shrinks with no signal. Measured: BENCHMARKS = [] prints
+# "0/0 gaming attempts detected" and exits 0.
+#
+# It lives here and not only in the test suite because the spec tells contributors
+# to score a new vector with `run.py --json` before committing, and that check has
+# to be the one that refuses. A floor, not an equality: `== 6` against seven
+# benchmarks is the drift this file has already paid for once. Lowering it is the
+# deliberate act retiring a vector should require.
+MIN_VECTORS = 7
+
 
 def score_skill(skill_path: str) -> dict:
     """Score a single skill across all dimensions."""
@@ -222,6 +234,7 @@ def main():
     incomplete = [r["file"] for r in results if "error" in r]
     if clean_composite is None:
         incomplete.append(CLEAN_CONTROL)
+    shrunk = len(BENCHMARKS) < MIN_VECTORS
 
     # The other half of "a vector stopped being measured": it is still measured,
     # and it is no longer caught. Verified reachable — forcing one benchmark's
@@ -229,10 +242,20 @@ def main():
     # same headline drop a rename produces. A detector regression is the likelier
     # cause of the two, so leaving it out would have closed the smaller half.
     #
-    # `caught` is lenient today (an unmeasured dimension scoring the -1 sentinel
-    # reads as caught, see the follow-up issue), so gating on it can produce a
-    # false GREEN but never a false RED — which is the safe direction to be wrong
-    # in, and why this does not wait for that fix.
+    # What gating on `caught` can and cannot do, stated precisely, because the
+    # first version of this comment claimed "never a false red" and that is wrong.
+    #
+    # It cannot mask a regression: a detector that stops firing turns this red.
+    # It CAN fire on a scorer IMPROVEMENT. `bloated-preamble.md` is caught purely
+    # by the `target_score < 80` threshold — its declared filler mechanism emits
+    # no issue at all (efficiency 63, empty issue list) — so raising efficiency
+    # above 80 reddens every required context while separation is untouched
+    # (composite 26.4 against a clean control of 31.9). Measured. The other
+    # threshold-caught vectors are shielded by an issue keyword; this one is not.
+    #
+    # That red is not false — a declared detection really did stop penalising —
+    # but it fires on an improvement, so it is a real cost and it is named in the
+    # follow-up issue rather than hidden behind a claim that it cannot happen.
     uncaught = [r["file"] for r in results if "error" not in r and not r.get("caught")]
 
     violations = []
@@ -245,6 +268,7 @@ def main():
         output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
         print(json.dumps({"clean_composite": clean_composite,
                           "incomplete": incomplete, "uncaught": uncaught,
+                          "declared_vectors": len(BENCHMARKS), "shrunk": shrunk,
                           "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
@@ -254,6 +278,10 @@ def main():
             for f in incomplete:
                 print(f"  {f}")
             print("Every separation result above is unproven until they are restored.")
+        if shrunk:
+            print(f"CORPUS SHRANK — {len(BENCHMARKS)} vectors declared, "
+                  f"floor is {MIN_VECTORS}. If a vector was retired on purpose, "
+                  f"lower MIN_VECTORS in the same commit and say why.")
         if uncaught:
             print("VECTORS NO LONGER CAUGHT — the detector for these stopped firing:")
             for f in uncaught:
@@ -263,7 +291,7 @@ def main():
             for f, c in violations:
                 print(f"  {f}: {c}")
 
-    sys.exit(1 if violations or incomplete or uncaught else 0)
+    sys.exit(1 if violations or incomplete or uncaught or shrunk else 0)
 
 
 if __name__ == "__main__":

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -234,7 +234,13 @@ def main():
     incomplete = [r["file"] for r in results if "error" in r]
     if clean_composite is None:
         incomplete.append(CLEAN_CONTROL)
-    shrunk = len(BENCHMARKS) < MIN_VECTORS
+    # Distinct FILES, not entries. Counting entries let a duplicated dict restore
+    # the number: one vector removed plus one copy-pasted entry gave 7 declared,
+    # 6 real, "7/7 gaming attempts detected", exit 0 — measured. The likelier
+    # version needs no deletion at all: copy a dict when adding a vector, forget
+    # to change `file`, and the run publishes 8/8 over seven real vectors.
+    vectors = {b["file"] for b in BENCHMARKS}
+    shrunk = len(vectors) < MIN_VECTORS
 
     # The other half of "a vector stopped being measured": it is still measured,
     # and it is no longer caught. Verified reachable — forcing one benchmark's
@@ -245,7 +251,16 @@ def main():
     # What gating on `caught` can and cannot do, stated precisely, because the
     # first version of this comment claimed "never a false red" and that is wrong.
     #
-    # It cannot mask a regression: a detector that stops firing turns this red.
+    # It cannot mask a regression on six of the seven vectors: a detector that
+    # stops firing turns those red. NOT on `keyword-stuffing.md`, whose target
+    # dimension `triggers` is eval-suite-gated and returns the -1 sentinel with
+    # no suite — so `target_score < 80` is satisfied by UNMEASURED rather than by
+    # penalised, and `caught` is permanently True. Measured: replacing that file
+    # with the clean control verbatim, so that it games nothing at all, still
+    # reports caught. Its declared TF-IDF detection is never exercised. Fixing it
+    # means retargeting the vector at a dimension measurable without a suite,
+    # which turns the gate red until it is done, so it is in the follow-up issue
+    # and named here rather than covered by a claim of full coverage.
     # It CAN fire on a scorer IMPROVEMENT. `bloated-preamble.md` is caught purely
     # by the `target_score < 80` threshold — its declared filler mechanism emits
     # no issue at all (efficiency 63, empty issue list) — so raising efficiency
@@ -268,7 +283,8 @@ def main():
         output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
         print(json.dumps({"clean_composite": clean_composite,
                           "incomplete": incomplete, "uncaught": uncaught,
-                          "declared_vectors": len(BENCHMARKS), "shrunk": shrunk,
+                          "declared_vectors": len(vectors),
+                          "declarations": len(BENCHMARKS), "shrunk": shrunk,
                           "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
@@ -279,7 +295,8 @@ def main():
                 print(f"  {f}")
             print("Every separation result above is unproven until they are restored.")
         if shrunk:
-            print(f"CORPUS SHRANK — {len(BENCHMARKS)} vectors declared, "
+            print(f"CORPUS SHRANK — {len(vectors)} distinct vectors "
+                  f"({len(BENCHMARKS)} declarations), "
                   f"floor is {MIN_VECTORS}. If a vector was retired on purpose, "
                   f"lower MIN_VECTORS in the same commit and say why.")
         if uncaught:

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -223,6 +223,18 @@ def main():
     if clean_composite is None:
         incomplete.append(CLEAN_CONTROL)
 
+    # The other half of "a vector stopped being measured": it is still measured,
+    # and it is no longer caught. Verified reachable — forcing one benchmark's
+    # `caught` to False printed "6/7 gaming attempts detected" and exited 0, the
+    # same headline drop a rename produces. A detector regression is the likelier
+    # cause of the two, so leaving it out would have closed the smaller half.
+    #
+    # `caught` is lenient today (an unmeasured dimension scoring the -1 sentinel
+    # reads as caught, see the follow-up issue), so gating on it can produce a
+    # false GREEN but never a false RED — which is the safe direction to be wrong
+    # in, and why this does not wait for that fix.
+    uncaught = [r["file"] for r in results if "error" not in r and not r.get("caught")]
+
     violations = []
     if clean_composite is not None:
         for r in results:
@@ -232,7 +244,7 @@ def main():
     if use_json:
         output = [{k: v for k, v in r.items() if k != "target_details"} for r in results]
         print(json.dumps({"clean_composite": clean_composite,
-                          "incomplete": incomplete,
+                          "incomplete": incomplete, "uncaught": uncaught,
                           "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
@@ -242,12 +254,16 @@ def main():
             for f in incomplete:
                 print(f"  {f}")
             print("Every separation result above is unproven until they are restored.")
+        if uncaught:
+            print("VECTORS NO LONGER CAUGHT — the detector for these stopped firing:")
+            for f in uncaught:
+                print(f"  {f}")
         if violations:
             print("SEPARATION FAILURES (gamed >= clean):")
             for f, c in violations:
                 print(f"  {f}: {c}")
 
-    sys.exit(1 if violations or incomplete else 0)
+    sys.exit(1 if violations or incomplete or uncaught else 0)
 
 
 if __name__ == "__main__":

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -168,7 +168,15 @@ def format_markdown(results: list[dict]) -> str:
 
     caught = sum(1 for r in results if r.get("caught"))
     total = len(results)
+    distinct = len({r["file"] for r in results})
     lines.append(f"**{caught}/{total} gaming attempts detected and penalized.**")
+    if distinct != total:
+        # One row per declaration, so a file declared twice is counted twice. Say
+        # so next to the number rather than under it; the gate reddens on this,
+        # but the headline is what a reader quotes.
+        lines.append("")
+        lines.append(f"**Only {distinct} distinct vectors — the count above is inflated "
+                     f"by duplicate declarations.**")
     lines.append("")
 
     lines.append("| Skill | Target Dim | Gaming Vector | Score | Caught |")
@@ -241,6 +249,14 @@ def main():
     # to change `file`, and the run publishes 8/8 over seven real vectors.
     vectors = {b["file"] for b in BENCHMARKS}
     shrunk = len(vectors) < MIN_VECTORS
+    # A duplicate is its own failure and must not depend on the floor. The
+    # previous version only caught it when the copy ALSO dropped the corpus below
+    # MIN_VECTORS — the removal case. Appending a duplicate without removing
+    # anything, which is what a copy-paste while ADDING a vector produces, left
+    # eight declarations over seven vectors at exit 0 with a headline reading
+    # "8/8". Measured, and it is the case the comment here previously claimed to
+    # cover while the code did not.
+    duplicated = sorted(f for f in vectors if sum(b["file"] == f for b in BENCHMARKS) > 1)
 
     # The other half of "a vector stopped being measured": it is still measured,
     # and it is no longer caught. Verified reachable — forcing one benchmark's
@@ -285,6 +301,7 @@ def main():
                           "incomplete": incomplete, "uncaught": uncaught,
                           "declared_vectors": len(vectors),
                           "declarations": len(BENCHMARKS), "shrunk": shrunk,
+                          "duplicated": duplicated,
                           "violations": violations, "results": output}, indent=2))
     else:
         print(format_markdown(results))
@@ -299,6 +316,10 @@ def main():
                   f"({len(BENCHMARKS)} declarations), "
                   f"floor is {MIN_VECTORS}. If a vector was retired on purpose, "
                   f"lower MIN_VECTORS in the same commit and say why.")
+        if duplicated:
+            print("DECLARED MORE THAN ONCE — the headline counts these twice:")
+            for f in duplicated:
+                print(f"  {f}")
         if uncaught:
             print("VECTORS NO LONGER CAUGHT — the detector for these stopped firing:")
             for f in uncaught:
@@ -308,7 +329,7 @@ def main():
             for f, c in violations:
                 print(f"  {f}: {c}")
 
-    sys.exit(1 if violations or incomplete or uncaught or shrunk else 0)
+    sys.exit(1 if violations or incomplete or uncaught or shrunk or duplicated else 0)
 
 
 if __name__ == "__main__":

--- a/benchmarks/anti-gaming/run.py
+++ b/benchmarks/anti-gaming/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Anti-gaming benchmark — demonstrates Schliff's gaming detection.
 
-Scores 6 synthetic SKILL.md files designed to exploit specific dimensions.
+Scores the synthetic SKILL.md files under skills/, one per gaming vector.
 Each skill targets a different gaming vector. The benchmark verifies that
 Schliff's anti-gaming checks catch and penalize each attempt.
 

--- a/benchmarks/anti-gaming/test_benchmark.py
+++ b/benchmarks/anti-gaming/test_benchmark.py
@@ -96,10 +96,11 @@ class TestScoreSkill:
 # ---------------------------------------------------------------------------
 
 class TestRunBenchmarks:
-    def test_returns_one_result_per_declaration(self):
-        results = bench_run.run_benchmarks()
-        assert isinstance(results, list)
-        assert len(results) == len(bench_run.BENCHMARKS)
+    # `len(results) == len(BENCHMARKS)` used to live here. It was a tautology:
+    # `run_benchmarks` appends exactly one result per entry on both its paths, so
+    # no input can violate it — it asserted Python, not this code. Dropped rather
+    # than reworded; duplicate declarations are caught by
+    # `test_every_benchmark_is_declared_once`, which can actually fail.
 
     def test_each_result_has_caught_field(self):
         results = bench_run.run_benchmarks()

--- a/benchmarks/anti-gaming/test_benchmark.py
+++ b/benchmarks/anti-gaming/test_benchmark.py
@@ -48,8 +48,15 @@ class TestBenchmarkFiles:
 # ---------------------------------------------------------------------------
 
 class TestBenchmarkMetadata:
-    def test_six_benchmarks_defined(self):
-        assert len(bench_run.BENCHMARKS) == 6
+    def test_every_benchmark_is_declared_once(self):
+        # Was `== 6` against seven benchmarks, so this file has been red for as
+        # long as the seventh vector has existed — and it contradicted the floor
+        # in test_composite_unified.py, which is the one CI actually collects.
+        # An equality against a count breaks whenever a vector is ADDED; the
+        # floor that guards against removal lives in run.py, once.
+        assert len(bench_run.BENCHMARKS) >= bench_run.MIN_VECTORS
+        files = [b["file"] for b in bench_run.BENCHMARKS]
+        assert len(files) == len(set(files)), f"duplicate declarations: {files}"
 
     def test_each_has_required_keys(self):
         required = {"file", "target_dimension", "gaming_vector", "detection"}
@@ -89,10 +96,10 @@ class TestScoreSkill:
 # ---------------------------------------------------------------------------
 
 class TestRunBenchmarks:
-    def test_returns_list(self):
+    def test_returns_one_result_per_declaration(self):
         results = bench_run.run_benchmarks()
         assert isinstance(results, list)
-        assert len(results) == 6
+        assert len(results) == len(bench_run.BENCHMARKS)
 
     def test_each_result_has_caught_field(self):
         results = bench_run.run_benchmarks()

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -380,8 +380,11 @@ is harder to catch than a false observation.
 
 What was actually wrong is narrower and was fixed on 2026-08-28: the gate could not tell "no vector
 gamed" from "no vector measured". Renaming one skill file left it at exit 0 while the headline
-dropped from 7/7 to 6/7. `main()` now reports `incomplete` and exits 1, so a vector that stops being
-measured reddens CI instead of vanishing.
+dropped from 7/7 to 6/7 — and so did a vector that is still measured but no longer caught, which is
+the likelier cause of the two. `main()` now reports `incomplete` and `uncaught` and exits 1, so a
+vector that stops being measured OR stops being detected reddens CI instead of vanishing. The
+corpus is additionally pinned against the directory it lives in (not against a count literal, which
+is the `== 6`-against-seven drift), so deleting a `BENCHMARKS` entry fails too.
 
 Still open, and NOT what blocks a new vector: `test_benchmark.py` is red (two assertions expect 6
 benchmarks where `BENCHMARKS` holds 7) and `pyproject.toml`'s `testpaths` excludes the directory, so

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -392,9 +392,10 @@ retiring a vector should require. It lives in `run.py` as `MIN_VECTORS`, with ex
 in the gate itself and not only in a test, because the guidance above tells contributors to check a
 new vector with `run.py --json`, and that invocation has to be the one that refuses.
 
-Still open, and NOT what blocks a new vector: `test_benchmark.py` is red (two assertions expect 6
-benchmarks where `BENCHMARKS` holds 7) and `pyproject.toml`'s `testpaths` excludes the directory, so
-no default run collects that file. What actually blocks adding a vector is the opposite of what this
+Still open, and NOT what blocks a new vector: `pyproject.toml`'s `testpaths` excludes
+`benchmarks/`, so no default run collects `test_benchmark.py`. (Its two `== 6` assertions against
+seven benchmarks were fixed on 2026-08-29 and the file passes — an earlier version of this
+paragraph still called it red, which was a false claim about the commit correcting it.) What actually blocks adding a vector is the opposite of what this
 paragraph assumed — it is not that nobody would run it, it is that everybody does: a vector whose
 composite reaches the clean control makes `violations` non-empty and reddens five required contexts,
 with `enforce_admins: true` and no override. Score every new vector locally with `run.py --json`

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -388,7 +388,9 @@ whose `.md` file survives fails too. That comparison alone cannot see a vector d
 sides at once — the two sets shrink together — so a floor on the vector count sits beside it.
 The floor is a literal, deliberately: an equality against a count is the `== 6`-against-seven drift,
 whereas a floor does not break when a vector is added, and lowering it is the deliberate act that
-retiring a vector should require.
+retiring a vector should require. It lives in `run.py` as `MIN_VECTORS`, with exactly one home —
+in the gate itself and not only in a test, because the guidance above tells contributors to check a
+new vector with `run.py --json`, and that invocation has to be the one that refuses.
 
 Still open, and NOT what blocks a new vector: `test_benchmark.py` is red (two assertions expect 6
 benchmarks where `BENCHMARKS` holds 7) and `pyproject.toml`'s `testpaths` excludes the directory, so

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -369,12 +369,28 @@ skill, because `tests/fixtures/self-skill-baseline/SKILL.md` is scanned. A SKILL
 under `playground/.venv/lib/python3.12/site-packages/`; in a user's repo that would be
 `node_modules` and `.venv`. Next after this.
 
-`benchmarks/anti-gaming/` runs in no CI job — `grep -rn 'anti-gaming\|benchmarks' .github/workflows/
-Makefile` returns nothing (the wider `.github/` does hit one line, an option label in
-`ISSUE_TEMPLATE/feature_request.yml`, which runs nothing) — and its own `test_benchmark.py` is red: two assertions expect 6 benchmarks where
-`BENCHMARKS` holds 7, and `pyproject.toml`'s `testpaths` excludes the directory, so no default run
-collects it. Until both are fixed, adding a gaming vector there buys a line nobody runs. The vector
-for the SSH-address limit (Amendment 2026-08-25) is blocked on exactly this.
+~~`benchmarks/anti-gaming/` runs in no CI job~~ — **CORRECTED 2026-08-28, and the correction is the
+lesson.** The grep this claim rested on is accurate: `grep -rn 'anti-gaming\|benchmarks'
+.github/workflows/ Makefile` returns nothing. The conclusion drawn from it was not.
+`skills/schliff/tests/unit/test_composite_unified.py:187` runs `run.py` as a subprocess and asserts
+`returncode == 0`, and `test.yml` invokes `pytest tests/unit/` with an explicit path, which
+overrides `testpaths`. The gate has therefore been **enforced in five of the six required contexts**
+(`test 3.10`–`3.13`, `test-macos`) the whole time. A true observation with a false conclusion, which
+is harder to catch than a false observation.
+
+What was actually wrong is narrower and was fixed on 2026-08-28: the gate could not tell "no vector
+gamed" from "no vector measured". Renaming one skill file left it at exit 0 while the headline
+dropped from 7/7 to 6/7. `main()` now reports `incomplete` and exits 1, so a vector that stops being
+measured reddens CI instead of vanishing.
+
+Still open, and NOT what blocks a new vector: `test_benchmark.py` is red (two assertions expect 6
+benchmarks where `BENCHMARKS` holds 7) and `pyproject.toml`'s `testpaths` excludes the directory, so
+no default run collects that file. What actually blocks adding a vector is the opposite of what this
+paragraph assumed — it is not that nobody would run it, it is that everybody does: a vector whose
+composite reaches the clean control makes `violations` non-empty and reddens five required contexts,
+with `enforce_admins: true` and no override. Score every new vector locally with `run.py --json`
+before committing it. The SSH-address vector (Amendment 2026-08-25) is gated on that, not on CI
+coverage.
 
 Two smaller items, unowned: `commands/schliff/analyze.md` step 7 documents
 `run-eval.sh <skill> --eval-suite <suite>`, which exits `Error: unknown option --eval-suite` — the

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -372,7 +372,8 @@ under `playground/.venv/lib/python3.12/site-packages/`; in a user's repo that wo
 ~~`benchmarks/anti-gaming/` runs in no CI job~~ — **CORRECTED 2026-08-28, and the correction is the
 lesson.** The grep this claim rested on is accurate: `grep -rn 'anti-gaming\|benchmarks'
 .github/workflows/ Makefile` returns nothing. The conclusion drawn from it was not.
-`skills/schliff/tests/unit/test_composite_unified.py:187` runs `run.py` as a subprocess and asserts
+`test_anti_gaming_benchmark_gate` in `skills/schliff/tests/unit/test_composite_unified.py` runs
+`run.py` as a subprocess and asserts
 `returncode == 0`, and `test.yml` invokes `pytest tests/unit/` with an explicit path, which
 overrides `testpaths`. The gate has therefore been **enforced in five of the six required contexts**
 (`test 3.10`–`3.13`, `test-macos`) the whole time. A true observation with a false conclusion, which

--- a/docs/specs/2026-08-13-structural-signal-detection.md
+++ b/docs/specs/2026-08-13-structural-signal-detection.md
@@ -383,8 +383,12 @@ gamed" from "no vector measured". Renaming one skill file left it at exit 0 whil
 dropped from 7/7 to 6/7 — and so did a vector that is still measured but no longer caught, which is
 the likelier cause of the two. `main()` now reports `incomplete` and `uncaught` and exits 1, so a
 vector that stops being measured OR stops being detected reddens CI instead of vanishing. The
-corpus is additionally pinned against the directory it lives in (not against a count literal, which
-is the `== 6`-against-seven drift), so deleting a `BENCHMARKS` entry fails too.
+corpus is additionally pinned against the directory it lives in, so deleting a `BENCHMARKS` entry
+whose `.md` file survives fails too. That comparison alone cannot see a vector deleted on **both**
+sides at once — the two sets shrink together — so a floor on the vector count sits beside it.
+The floor is a literal, deliberately: an equality against a count is the `== 6`-against-seven drift,
+whereas a floor does not break when a vector is added, and lowering it is the deliberate act that
+retiring a vector should require.
 
 Still open, and NOT what blocks a new vector: `test_benchmark.py` is red (two assertions expect 6
 benchmarks where `BENCHMARKS` holds 7) and `pyproject.toml`'s `testpaths` excludes the directory, so

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -359,3 +359,27 @@ def test_the_anti_gaming_gate_fails_when_the_corpus_shrinks(bench_module, monkey
 
     assert exc.value.code == 1, "a corpus below the floor must not pass"
     assert "CORPUS SHRANK" in capsys.readouterr().out
+
+
+def test_a_duplicated_declaration_does_not_refill_the_floor(bench_module, monkeypatch, capsys):
+    """The floor counts vectors, not entries.
+
+    Counting entries let a duplicated dict restore the number: one vector removed
+    plus one copy-pasted entry gave seven declared against six real, the headline
+    read "7/7 gaming attempts detected", and the gate exited 0 — measured. The
+    likelier version needs no removal at all, only a copy-paste when adding a
+    vector with the `file` key left unchanged.
+
+    The mutation: count `len(BENCHMARKS)` instead of the distinct files, and this
+    goes green again.
+    """
+    shortened = [b for b in bench_module.BENCHMARKS[:-1]]
+    monkeypatch.setattr(bench_module, "BENCHMARKS", shortened + [dict(shortened[0])])
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+
+    with pytest.raises(SystemExit) as exc:
+        bench_module.main()
+
+    assert exc.value.code == 1, "a duplicate declaration must not stand in for a vector"
+    out = capsys.readouterr().out
+    assert "CORPUS SHRANK" in out and "distinct vectors" in out, out[-300:]

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -189,7 +189,10 @@ def test_anti_gaming_benchmark_gate():
     repo = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
     proc = subprocess.run(["/usr/bin/python3", "benchmarks/anti-gaming/run.py"],
                           cwd=str(repo), capture_output=True, text=True)
-    assert proc.returncode == 0, f"anti-gaming separation failed:\n{proc.stdout}"
+    # Neutral wording: the gate now exits 1 for three distinct reasons (separation
+    # broken, corpus incomplete, a vector no longer caught) and stdout says which.
+    # Naming one of them here put the wrong why in the CI headline for the others.
+    assert proc.returncode == 0, f"anti-gaming gate failed:\n{proc.stdout}"
 
 
 def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys):
@@ -206,9 +209,10 @@ def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys)
     import pytest
 
     repo = Path(__file__).resolve().parents[4]
-    bench_dir = str(repo / "benchmarks" / "anti-gaming")
-    if bench_dir not in sys.path:
-        sys.path.insert(0, bench_dir)
+    # syspath_prepend, not sys.path.insert: the module is named `run`, about as
+    # generic as a top-level name gets, and a bare insert leaves that directory
+    # ahead of scripts/ for every later test in the process.
+    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
     import run as bench
 
     monkeypatch.setattr(sys, "argv", ["run.py"])
@@ -223,6 +227,32 @@ def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys)
     out = capsys.readouterr().out
     assert "CORPUS INCOMPLETE" in out, out[-400:]
     assert "renamed-away.md" in out, "the report must name what it did not measure"
+
+
+def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
+    """A vector can also stop being measured by losing its declaration.
+
+    `incomplete` catches a file that vanished while its BENCHMARKS entry stayed.
+    Drop the entry as well — an ordinary edit — and the headline reads 6/6 with
+    an empty `incomplete` and exit 0: verified. The only assertion pinning the
+    count lives in benchmarks/anti-gaming/test_benchmark.py, which is red and
+    which `testpaths` excludes from every run, so no enforced check saw it.
+
+    Pinned against the directory rather than a literal count: `== 6` against
+    seven benchmarks is the drift this file must not repeat. Both directions
+    fail — a skill file with no entry, and an entry with no file.
+    """
+    repo = Path(__file__).resolve().parents[4]
+    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
+    import run as bench
+
+    on_disk = {p.name for p in (repo / "benchmarks" / "anti-gaming" / "skills").glob("*.md")}
+    declared = {b["file"] for b in bench.BENCHMARKS} | {bench.CLEAN_CONTROL}
+
+    assert on_disk == declared, (
+        f"undeclared skill files: {sorted(on_disk - declared)}; "
+        f"declared but absent: {sorted(declared - on_disk)}"
+    )
 
 
 def test_evolve_score_file_matches_cli(tmp_path):

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -209,10 +209,15 @@ def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys)
     import pytest
 
     repo = Path(__file__).resolve().parents[4]
-    # syspath_prepend, not sys.path.insert: the module is named `run`, about as
-    # generic as a top-level name gets, and a bare insert leaves that directory
-    # ahead of scripts/ for every later test in the process.
+    # Two leaks, not one. `syspath_prepend` reverts the path entry — which matters
+    # because while it is live, `benchmarks/anti-gaming/skills/` sits ahead of the
+    # repo root as a `skills` namespace package. The `delitem` reverts the OTHER
+    # half: `sys.modules["run"]` outlives monkeypatch on its own, under about the
+    # most generic top-level name there is, and stays bound to the benchmark
+    # runner for the rest of the process. Recording the key as absent BEFORE the
+    # import is what makes undo remove it.
     monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
+    monkeypatch.delitem(sys.modules, "run", raising=False)
     import run as bench
 
     monkeypatch.setattr(sys, "argv", ["run.py"])
@@ -244,6 +249,7 @@ def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
     """
     repo = Path(__file__).resolve().parents[4]
     monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
+    monkeypatch.delitem(sys.modules, "run", raising=False)
     import run as bench
 
     on_disk = {p.name for p in (repo / "benchmarks" / "anti-gaming" / "skills").glob("*.md")}
@@ -252,6 +258,20 @@ def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
     assert on_disk == declared, (
         f"undeclared skill files: {sorted(on_disk - declared)}; "
         f"declared but absent: {sorted(declared - on_disk)}"
+    )
+
+    # Set equality compares two things that move together, so it cannot see a
+    # vector being deleted on BOTH sides at once — measured: `git rm no-scope.md`
+    # plus its dict entry gives 6/6, empty `incomplete`, exit 0, and this very
+    # assertion still passes. A floor is the only thing that catches a corpus
+    # shrinking, and unlike the `== 6`-against-seven equality that this file
+    # exists to not repeat, a floor does not break when a vector is ADDED.
+    #
+    # Lowering this number is the deliberate act. If a vector is genuinely
+    # retired, lower it in the same commit and say why there.
+    assert len(bench.BENCHMARKS) >= 7, (
+        f"the corpus shrank to {len(bench.BENCHMARKS)} vectors; if that was "
+        f"deliberate, lower this floor in the same commit and say why"
     )
 
 
@@ -276,3 +296,37 @@ def test_default_run_reports_seven_of_seven():
             ["structure", "triggers", "quality", "edges", "efficiency", "composability", "clarity"]}
     r = compute_composite(full)
     assert r["measured_dimensions"] == 7 and r["total_dimensions"] == 7
+
+
+def test_the_anti_gaming_gate_fails_when_a_vector_is_no_longer_caught(monkeypatch, capsys):
+    """A detector regression is the likelier half, and it shipped untested.
+
+    The gate exits 1 on `uncaught`, and nothing asserted it: removing that term
+    from the exit expression left all fourteen tests in this file green, so a
+    revert would have shipped. The behaviour was checked by hand in a shell and
+    never written down, which is the same thing as not checking it.
+
+    The vector is still measured here — no `error` key — so `incomplete` cannot
+    carry this; only `caught` can.
+    """
+    import pytest
+
+    repo = Path(__file__).resolve().parents[4]
+    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
+    monkeypatch.delitem(sys.modules, "run", raising=False)
+    import run as bench
+
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+    monkeypatch.setattr(bench, "run_benchmarks", lambda: [{
+        "file": "detector-regressed.md", "target_dimension": "efficiency",
+        "gaming_vector": "x", "detection": "y", "target_score": 91,
+        "target_issues": [], "composite": 1.0, "all_scores": {}, "caught": False,
+    }])
+
+    with pytest.raises(SystemExit) as exc:
+        bench.main()
+
+    assert exc.value.code == 1, "a vector that stopped being detected must not pass"
+    out = capsys.readouterr().out
+    assert "VECTORS NO LONGER CAUGHT" in out, out[-400:]
+    assert "detector-regressed.md" in out, "the report must name the vector that stopped firing"

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -10,6 +10,8 @@ Pins three invariants permanently:
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
@@ -184,6 +186,37 @@ def test_clean_body_not_stuffing_penalized(tmp_path):
         f"legitimate domain skill scored too low: {result['score']}"
 
 
+@pytest.fixture
+def bench_module(monkeypatch, request):
+    """The anti-gaming runner, imported without leaving it behind.
+
+    Two leaks, and only one of them monkeypatch handles. `syspath_prepend` does
+    revert the path entry, which matters because while it is live
+    `benchmarks/anti-gaming/skills/` sits ahead of the repo root as a `skills`
+    namespace package. The other is `sys.modules["run"]`, squatting about the
+    most generic top-level name there is for the rest of the process.
+
+    `monkeypatch.delitem(..., raising=False)` does NOT clean that up. Read the
+    source: when the key is absent it either raises or does nothing, and records
+    no undo entry either way — so an earlier version of this file carried a
+    comment asserting a pytest behaviour pytest does not have. An explicit
+    finalizer is the honest form.
+    """
+    repo = Path(__file__).resolve().parents[4]
+    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
+    preexisting = sys.modules.get("run")
+    import run as bench
+
+    def _restore():
+        if preexisting is None:
+            sys.modules.pop("run", None)
+        else:
+            sys.modules["run"] = preexisting
+
+    request.addfinalizer(_restore)
+    return bench
+
+
 def test_anti_gaming_benchmark_gate():
     import subprocess
     repo = Path(__file__).resolve().parents[4]  # unit→tests→schliff→skills→repo root
@@ -195,7 +228,7 @@ def test_anti_gaming_benchmark_gate():
     assert proc.returncode == 0, f"anti-gaming gate failed:\n{proc.stdout}"
 
 
-def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys):
+def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(bench_module, monkeypatch, capsys):
     """"No vector gamed" and "no vector measured" must not both be exit 0.
 
     The gate above asserts only ``returncode == 0``. Measured on f202bc1, before
@@ -206,19 +239,7 @@ def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys)
 
     This is the unit half; the subprocess test above covers the real corpus.
     """
-    import pytest
-
-    repo = Path(__file__).resolve().parents[4]
-    # Two leaks, not one. `syspath_prepend` reverts the path entry — which matters
-    # because while it is live, `benchmarks/anti-gaming/skills/` sits ahead of the
-    # repo root as a `skills` namespace package. The `delitem` reverts the OTHER
-    # half: `sys.modules["run"]` outlives monkeypatch on its own, under about the
-    # most generic top-level name there is, and stays bound to the benchmark
-    # runner for the rest of the process. Recording the key as absent BEFORE the
-    # import is what makes undo remove it.
-    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
-    monkeypatch.delitem(sys.modules, "run", raising=False)
-    import run as bench
+    bench = bench_module
 
     monkeypatch.setattr(sys, "argv", ["run.py"])
     monkeypatch.setattr(
@@ -234,7 +255,7 @@ def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys)
     assert "renamed-away.md" in out, "the report must name what it did not measure"
 
 
-def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
+def test_the_benchmark_corpus_and_its_declarations_agree(bench_module):
     """A vector can also stop being measured by losing its declaration.
 
     `incomplete` catches a file that vanished while its BENCHMARKS entry stayed.
@@ -247,10 +268,8 @@ def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
     seven benchmarks is the drift this file must not repeat. Both directions
     fail — a skill file with no entry, and an entry with no file.
     """
+    bench = bench_module
     repo = Path(__file__).resolve().parents[4]
-    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
-    monkeypatch.delitem(sys.modules, "run", raising=False)
-    import run as bench
 
     on_disk = {p.name for p in (repo / "benchmarks" / "anti-gaming" / "skills").glob("*.md")}
     declared = {b["file"] for b in bench.BENCHMARKS} | {bench.CLEAN_CONTROL}
@@ -261,18 +280,12 @@ def test_the_benchmark_corpus_and_its_declarations_agree(monkeypatch):
     )
 
     # Set equality compares two things that move together, so it cannot see a
-    # vector being deleted on BOTH sides at once — measured: `git rm no-scope.md`
-    # plus its dict entry gives 6/6, empty `incomplete`, exit 0, and this very
-    # assertion still passes. A floor is the only thing that catches a corpus
-    # shrinking, and unlike the `== 6`-against-seven equality that this file
-    # exists to not repeat, a floor does not break when a vector is ADDED.
-    #
-    # Lowering this number is the deliberate act. If a vector is genuinely
-    # retired, lower it in the same commit and say why there.
-    assert len(bench.BENCHMARKS) >= 7, (
-        f"the corpus shrank to {len(bench.BENCHMARKS)} vectors; if that was "
-        f"deliberate, lower this floor in the same commit and say why"
-    )
+    # vector deleted on BOTH sides at once — measured: removing a file plus its
+    # dict entry gives 6/6, empty `incomplete`, exit 0, and this very assertion
+    # still passes. `run.py` carries the floor for that, and the number lives
+    # there alone; asserting it again here would be a second home for it. What
+    # this checks is that the floor is actually WIRED to the exit code.
+    assert len(bench.BENCHMARKS) >= bench.MIN_VECTORS
 
 
 def test_evolve_score_file_matches_cli(tmp_path):
@@ -298,7 +311,7 @@ def test_default_run_reports_seven_of_seven():
     assert r["measured_dimensions"] == 7 and r["total_dimensions"] == 7
 
 
-def test_the_anti_gaming_gate_fails_when_a_vector_is_no_longer_caught(monkeypatch, capsys):
+def test_the_anti_gaming_gate_fails_when_a_vector_is_no_longer_caught(bench_module, monkeypatch, capsys):
     """A detector regression is the likelier half, and it shipped untested.
 
     The gate exits 1 on `uncaught`, and nothing asserted it: removing that term
@@ -309,12 +322,7 @@ def test_the_anti_gaming_gate_fails_when_a_vector_is_no_longer_caught(monkeypatc
     The vector is still measured here — no `error` key — so `incomplete` cannot
     carry this; only `caught` can.
     """
-    import pytest
-
-    repo = Path(__file__).resolve().parents[4]
-    monkeypatch.syspath_prepend(str(repo / "benchmarks" / "anti-gaming"))
-    monkeypatch.delitem(sys.modules, "run", raising=False)
-    import run as bench
+    bench = bench_module
 
     monkeypatch.setattr(sys, "argv", ["run.py"])
     monkeypatch.setattr(bench, "run_benchmarks", lambda: [{
@@ -330,3 +338,24 @@ def test_the_anti_gaming_gate_fails_when_a_vector_is_no_longer_caught(monkeypatc
     out = capsys.readouterr().out
     assert "VECTORS NO LONGER CAUGHT" in out, out[-400:]
     assert "detector-regressed.md" in out, "the report must name the vector that stopped firing"
+
+
+def test_the_anti_gaming_gate_fails_when_the_corpus_shrinks(bench_module, monkeypatch, capsys):
+    """Retiring a vector on both sides is the edit `incomplete` cannot see.
+
+    `incomplete` needs a declaration whose file went missing. Delete the entry
+    and the file together — the ordinary way to retire a vector — and the run
+    reports a smaller headline and exits 0: measured, `BENCHMARKS = []` printed
+    "0/0 gaming attempts detected" and exited 0.
+
+    Asserted through the exit code rather than by repeating the floor's value,
+    which lives in `run.py` and should have exactly one home.
+    """
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+    monkeypatch.setattr(bench_module, "BENCHMARKS", bench_module.BENCHMARKS[:-1])
+
+    with pytest.raises(SystemExit) as exc:
+        bench_module.main()
+
+    assert exc.value.code == 1, "a corpus below the floor must not pass"
+    assert "CORPUS SHRANK" in capsys.readouterr().out

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -192,6 +192,39 @@ def test_anti_gaming_benchmark_gate():
     assert proc.returncode == 0, f"anti-gaming separation failed:\n{proc.stdout}"
 
 
+def test_the_anti_gaming_gate_fails_on_an_incomplete_corpus(monkeypatch, capsys):
+    """"No vector gamed" and "no vector measured" must not both be exit 0.
+
+    The gate above asserts only ``returncode == 0``. Measured on f202bc1, before
+    this: renaming ONE skill file left the run at exit 0 while the headline
+    quietly dropped from 7/7 to 6/7 — the strongest vector stopped being tested
+    and CI stayed green. A rename is the most ordinary edit there is, and a gate
+    that can silently stop measuring makes every earlier green unprovable.
+
+    This is the unit half; the subprocess test above covers the real corpus.
+    """
+    import pytest
+
+    repo = Path(__file__).resolve().parents[4]
+    bench_dir = str(repo / "benchmarks" / "anti-gaming")
+    if bench_dir not in sys.path:
+        sys.path.insert(0, bench_dir)
+    import run as bench
+
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+    monkeypatch.setattr(
+        bench, "run_benchmarks",
+        lambda: [{"file": "renamed-away.md", "error": "File not found: renamed-away.md"}])
+
+    with pytest.raises(SystemExit) as exc:
+        bench.main()
+
+    assert exc.value.code == 1, "an unmeasured vector must not pass as a clean run"
+    out = capsys.readouterr().out
+    assert "CORPUS INCOMPLETE" in out, out[-400:]
+    assert "renamed-away.md" in out, "the report must name what it did not measure"
+
+
 def test_evolve_score_file_matches_cli(tmp_path):
     """evolve._score_file must return the same headline composite as the CLI path."""
     import importlib

--- a/skills/schliff/tests/unit/test_composite_unified.py
+++ b/skills/schliff/tests/unit/test_composite_unified.py
@@ -383,3 +383,30 @@ def test_a_duplicated_declaration_does_not_refill_the_floor(bench_module, monkey
     assert exc.value.code == 1, "a duplicate declaration must not stand in for a vector"
     out = capsys.readouterr().out
     assert "CORPUS SHRANK" in out and "distinct vectors" in out, out[-300:]
+
+
+def test_a_duplicate_declaration_fails_even_without_a_removal(bench_module, monkeypatch, capsys):
+    """The additive case — a copy-paste while ADDING a vector.
+
+    The first version of the duplicate guard only fired when the copy also
+    dropped the corpus below the floor, i.e. the removal case the test above
+    exercises. Appending a duplicate without removing anything left eight
+    declarations over seven vectors at exit 0, with the headline reading "8/8":
+    measured, and it is the case the code comment claimed to cover.
+
+    This assertion lives here and not in `benchmarks/anti-gaming/test_benchmark.py`,
+    which holds the other duplicate check: `testpaths` excludes that directory and
+    CI runs `pytest tests/unit/`, so nothing collects it. A guard enforced nowhere
+    is a guard that exists only in the repository.
+    """
+    monkeypatch.setattr(bench_module, "BENCHMARKS",
+                        bench_module.BENCHMARKS + [dict(bench_module.BENCHMARKS[0])])
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+
+    with pytest.raises(SystemExit) as exc:
+        bench_module.main()
+
+    assert exc.value.code == 1, "a duplicated declaration must redden the gate on its own"
+    out = capsys.readouterr().out
+    assert "DECLARED MORE THAN ONCE" in out, out[-300:]
+    assert "inflated by duplicate declarations" in out, "the headline must not overstate coverage"


### PR DESCRIPTION
The anti-gaming gate could not tell **"no vector gamed"** from **"no vector measured"**.

Measured on `f202bc1` — rename one file under `benchmarks/anti-gaming/skills/`:

```
Report:      "6/7 gaming attempts detected and penalized."
returncode:  0   →  the CI wrapper asserts == 0  →  green
```

A rename is the most ordinary edit there is, and the strongest vector stopped being tested without
anything failing.

### Why this is not cosmetic

The gate is not unwatched. `skills/schliff/tests/unit/test_composite_unified.py:187` starts `run.py`
as a subprocess and asserts `returncode == 0`, and `test.yml` invokes `pytest tests/unit/` with an
explicit path that overrides `testpaths` — so the gate is **enforced in five of the six required
status checks**. A gate that can silently stop measuring makes every earlier green run unprovable in
retrospect.

### The change

`main()` collects the files that produced no measurement, names them, states that the separation
results are unproven until they are restored, and exits 1. `--json` gains an `incomplete` list.

The corpus state travels *in the output* rather than short-circuiting it, so `--json` stays
parseable and a consumer can see why the run failed — the same reasoning as `doctor` reporting
`digest_degraded` instead of warning on stderr.

**It buys no new red.** The corpus is complete, so today's exit code is unchanged. It closes the
path by which the gate turns itself off.

### Mutation-checked, both directions

| mutation | result |
|---|---|
| one fixture renamed | `exit 1`, names `sophisticated-gamer.md` |
| clean control removed | `exit 1`, names `clean-reference.md` |
| guard dropped from the exit code | the new test goes red |
| unchanged repo | `exit 0`, `incomplete: []` |

### Spec correction

The claim that `benchmarks/anti-gaming/` runs in no CI job is corrected in place, and the correction
is the lesson: the `grep` it rested on was accurate, the conclusion drawn from it was not.

Recorded there too: adding a gaming vector is blocked by the **opposite** of what that paragraph
assumed. Not that nobody runs it — that everybody does. A vector whose composite reaches the clean
control (31.9) makes `violations` non-empty and reddens five required contexts, with
`enforce_admins: true` and no override. Score every new vector locally with `run.py --json` first.

Still open, deliberately not in this PR: `test_benchmark.py` is red (`== 6` against 7 benchmarks) and
`caught` credits `keyword-stuffing.md` on the `-1` no-eval-suite sentinel. Both are reporting
honesty, neither touches the exit code, and they belong in one separate change.